### PR TITLE
Include boundaries and URPNs on map tiles.

### DIFF
--- a/src/diagonal.works/b6/api/vm.go
+++ b/src/diagonal.works/b6/api/vm.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 
 	"diagonal.works/b6"
@@ -199,7 +198,6 @@ func newVM(node *pb.NodeProto, w b6.World, fs FunctionSymbols, cs FunctionConver
 			}
 		}
 		if err := compile(c.Targets[i].Node, &c); err != nil {
-			log.Printf("Failed: %+v, err: %s", node, err)
 			return nil, err
 		}
 		c.Append(Instruction{Op: OpReturn})

--- a/src/diagonal.works/b6/cmd/b6/b6.go
+++ b/src/diagonal.works/b6/cmd/b6/b6.go
@@ -19,6 +19,9 @@ import (
 	"diagonal.works/b6/renderer"
 
 	"google.golang.org/grpc"
+
+	_ "github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/gcs"
+	_ "github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/local"
 )
 
 func main() {

--- a/src/diagonal.works/b6/cmd/b6/shell.go
+++ b/src/diagonal.works/b6/cmd/b6/shell.go
@@ -112,7 +112,7 @@ func fillSpans(v interface{}, spans []SpanJSON) []SpanJSON {
 		spans = fillSpansFromTag(v, spans)
 	case b6.Point:
 		ll := s2.LatLngFromPoint(v.Point())
-		spans = append(spans, SpanJSON{Text: fmt.Sprintf("%f, %f", ll.Lat.Degrees(), ll.Lng.Degrees())})
+		spans = append(spans, SpanJSON{Text: fmt.Sprintf("%f, %f", ll.Lat.Degrees(), ll.Lng.Degrees()), Class: "literal"})
 	case geojson.GeoJSON:
 		spans = fillSpansFromGeoJSON(v, spans)
 	default:

--- a/src/diagonal.works/b6/renderer/renderer.go
+++ b/src/diagonal.works/b6/renderer/renderer.go
@@ -36,16 +36,17 @@ func layerNumber(f b6.Feature) int {
 type BasemapLayer int
 
 const (
-	BasemapLayerWater BasemapLayer = iota
+	BasemapLayerBoundary BasemapLayer = iota
+	BasemapLayerContour
+	BasemapLayerWater
 	BasemapLayerRoad
 	BasemapLayerLandUse
-	BasemapLayerContour
 	BasemapLayerBuilding
-	BasemapLayerRoute
+	BasemapLayerPoint
 	BasemapLayerLabel
 	BasemapLayerInvalid
 
-	BasemapLayerBegin = BasemapLayerWater
+	BasemapLayerBegin = BasemapLayerBoundary
 	BasemapLayerEnd   = BasemapLayerInvalid
 )
 
@@ -53,12 +54,13 @@ type BasemapLayers [BasemapLayerEnd]*Layer
 
 func NewLayers() *BasemapLayers {
 	var l BasemapLayers
+	l[BasemapLayerBoundary] = NewLayer("boundary")
+	l[BasemapLayerContour] = NewLayer("contour")
 	l[BasemapLayerWater] = NewLayer("water")
 	l[BasemapLayerRoad] = NewLayer("road")
 	l[BasemapLayerLandUse] = NewLayer("landuse")
-	l[BasemapLayerContour] = NewLayer("contour")
 	l[BasemapLayerBuilding] = NewLayer("building")
-	l[BasemapLayerRoute] = NewLayer("route")
+	l[BasemapLayerPoint] = NewLayer("point")
 	l[BasemapLayerLabel] = NewLayer("label")
 	return &l
 }
@@ -105,6 +107,8 @@ func (b *BasemapRenderer) findFeatures(tile b6.Tile) []b6.Feature {
 			b6.Tagged{Key: "#leisure", Value: "pitch"},
 			b6.Tagged{Key: "#natural", Value: "heath"},
 			b6.Tagged{Key: "#outline", Value: "contour"},
+			b6.Tagged{Key: "#boundary", Value: "lsoa"},
+			b6.Tagged{Key: "#place", Value: "uprn"},
 			b6.Keyed{Key: "#building"},
 			b6.Keyed{Key: "#water"},
 			b6.Keyed{Key: "#waterway"},
@@ -129,6 +133,8 @@ func (b *BasemapRenderer) findFeatures(tile b6.Tile) []b6.Feature {
 			b6.Tagged{Key: "#leisure", Value: "pitch"},
 			b6.Tagged{Key: "#natural", Value: "heath"},
 			b6.Tagged{Key: "#outline", Value: "contour"},
+			b6.Tagged{Key: "#boundary", Value: "lsoa"},
+			b6.Tagged{Key: "#place", Value: "uprn"},
 			b6.Keyed{Key: "#building"},
 			b6.Keyed{Key: "#water"},
 			b6.Keyed{Key: "#waterway"},
@@ -138,6 +144,7 @@ func (b *BasemapRenderer) findFeatures(tile b6.Tile) []b6.Feature {
 			b6.Tagged{Key: "#highway", Value: "trunk"},
 			b6.Tagged{Key: "#highway", Value: "primary"},
 			b6.Tagged{Key: "#highway", Value: "motorway"},
+			b6.Tagged{Key: "#boundary", Value: "lsoa"},
 			b6.Keyed{Key: "#water"},
 		}
 	} else {
@@ -172,6 +179,8 @@ var renderRules = []struct {
 	{Tag: b6.Tag{Key: "#natural"}, Attribute: "natural", Layer: BasemapLayerLandUse},
 	{Tag: b6.Tag{Key: "#leisure"}, Attribute: "leisure", Layer: BasemapLayerLandUse},
 	{Tag: b6.Tag{Key: "#place", Value: "city"}, Attribute: "leisure", Layer: BasemapLayerLabel},
+	{Tag: b6.Tag{Key: "#place", Value: "uprn"}, Attribute: "place", Layer: BasemapLayerPoint},
+	{Tag: b6.Tag{Key: "#boundary"}, Attribute: "place", Layer: BasemapLayerBoundary},
 	{Tag: b6.Tag{Key: "#outline", Value: "contour"}, Attribute: "outline", Layer: BasemapLayerContour},
 }
 


### PR DESCRIPTION
Include boundaries and UPRNs on map tiles, but only render them if they've been explictly coloured.