### PR TITLE
Use semver versions for the compact index.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ proto:
 	protoc -I=proto --go_out=src proto/tiles.proto
 	protoc -I=proto --go_out=src proto/geometry.proto
 	protoc -I=proto --go_out=src proto/features.proto
+	protoc -I=proto --go_out=src proto/compact.proto
 	protoc -I=proto --go_out=src --go-grpc_out=src proto/api.proto
 	protoc -I=src/diagonal.works/b6/osm/proto --go_out=src src/diagonal.works/b6/osm/proto/pbf.proto
 

--- a/proto/compact.proto
+++ b/proto/compact.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package compact;
+
+option go_package = "diagonal.works/b6/proto";
+
+message CompactHeaderProto {
+    repeated string namespaces = 1;
+    string Builder = 2;
+}


### PR DESCRIPTION
Use semver versions for the compact index, to match the approach for the API, and to track changes that don't break backward compatability. Use a protobuf to encode the header data, to allow flexibility where memory isn't at a premium.
Invalidates all previous indices by changing the header magic.