### PR TITLE
Move to a memory mapped hashtable for tokens.

### DIFF
--- a/src/diagonal.works/b6/ingest/testing.go
+++ b/src/diagonal.works/b6/ingest/testing.go
@@ -1330,6 +1330,7 @@ func ValidateTagsAreSearchable(buildWorld BuildOSMWorld, t *testing.T) {
 	points := b6.AllPoints(b6.FindPoints(b6.IntersectsCap{cap}, w))
 	if len(points) != 1 {
 		t.Errorf("Expected to find 1 point, found %d", len(points))
+		return
 	}
 	if amenity := points[0].Get("#amenity"); !amenity.IsValid() {
 		t.Errorf("Expected amenity tag to be searchable")


### PR DESCRIPTION
Take advantage of the index magic change requiring an index rebuild to move to a memory mapped hashtable for the token -> index lookup, as reading all tokens at startup time is expensive for large indices.