### PR TITLE
Speed up UPRN ingest by parallelising emit, and improving filtering.

### DIFF
--- a/src/diagonal.works/b6/api/functions/functions.go
+++ b/src/diagonal.works/b6/api/functions/functions.go
@@ -37,6 +37,7 @@ var functions = api.FunctionSymbols{
 	"find-relations":   FindRelationFeatures,
 	"containing-areas": findAreasContainingPoints,
 	"intersecting":     intersecting,
+	"intersecting-cap": intersectingCap,
 	"tagged":           tagged,
 	"keyed":            keyed,
 	"and":              and,
@@ -192,6 +193,15 @@ var wrappers = []interface{}{
 				return result.(b6.Geometry), err
 			} else {
 				return nil, err
+			}
+		}
+	},
+	func(c api.Callable) func(b6.Geometry, *api.Context) (bool, error) {
+		return func(g b6.Geometry, context *api.Context) (bool, error) {
+			if result, err := api.Call1(g, c, context); result != nil {
+				return result.(bool), err
+			} else {
+				return false, err
 			}
 		}
 	},

--- a/src/diagonal.works/b6/api/functions/search.go
+++ b/src/diagonal.works/b6/api/functions/search.go
@@ -91,6 +91,10 @@ func intersecting(g b6.Geometry, context *api.Context) (b6.Query, error) {
 	return b6.Empty{}, nil
 }
 
+func intersectingCap(center b6.Point, radius float64, context *api.Context) (b6.Query, error) {
+	return &b6.IntersectsCap{Cap: s2.CapFromCenterAngle(center.Point(), b6.MetersToAngle(radius))}, nil
+}
+
 func typePoint(context *api.Context) (*pb.QueryProto, error) {
 	return &pb.QueryProto{
 		Query: &pb.QueryProto_Typed{
@@ -141,7 +145,7 @@ func within(a b6.Area, context *api.Context) (b6.Query, error) {
 }
 
 func withinCap(p b6.Point, radius float64, context *api.Context) (b6.Query, error) {
-	return b6.IntersectsCap{Cap: s2.CapFromCenterAngle(p.Point(), b6.MetersToAngle(radius))}, nil
+	return &b6.IntersectsCap{Cap: s2.CapFromCenterAngle(p.Point(), b6.MetersToAngle(radius))}, nil
 }
 
 func tagged(key string, value string, context *api.Context) (b6.Query, error) {

--- a/src/diagonal.works/b6/api/functions/sightline.go
+++ b/src/diagonal.works/b6/api/functions/sightline.go
@@ -97,7 +97,7 @@ func SightlineUsingPolarCoordinates(center s2.Point, radius s1.Angle, w b6.World
 	containsPoint := s2.NewContainsPointQuery(index, s2.VertexModelOpen)
 	tolerance := b6.MetersToAngle(0.01)
 	cap := s2.CapFromCenterAngle(center, radius)
-	features := b6.FindAreas(b6.Intersection{b6.IntersectsCap{Cap: cap}, b6.Keyed{Key: "#building"}}, w)
+	features := b6.FindAreas(b6.Intersection{&b6.IntersectsCap{Cap: cap}, b6.Keyed{Key: "#building"}}, w)
 	edges := make([][2]s2.Point, 0, 8)
 	occlusions := make([]*s2.Loop, 0, 2)
 	for features.Next() {

--- a/src/diagonal.works/b6/api/vm.go
+++ b/src/diagonal.works/b6/api/vm.go
@@ -25,6 +25,22 @@ type Context struct {
 	VM *VM
 }
 
+func (c *Context) Fork(n int) []*Context {
+	var vms []VM
+	if c.VM != nil {
+		vms = c.VM.Fork(n)
+	}
+	ctxs := make([]*Context, n)
+	for i := range ctxs {
+		copy := *c
+		ctxs[i] = &copy
+		if vms != nil {
+			ctxs[i].VM = &vms[i]
+		}
+	}
+	return ctxs
+}
+
 type Op uint8
 
 const (

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
@@ -1,136 +1,24 @@
 package main
 
 import (
-	"compress/gzip"
 	"context"
-	"encoding/csv"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
-	"strconv"
+	"runtime"
 	"strings"
 
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/api/functions"
-	"diagonal.works/b6/geojson"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/ingest/compact"
-
-	"github.com/golang/geo/s2"
+	"diagonal.works/b6/ingest/gb/uprn"
 
 	_ "github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/gcs"
 	_ "github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/local"
 )
-
-type UPRNSource struct {
-	Filename string
-	Filter   func(p b6.PointFeature, c *api.Context) (bool, error)
-	JoinTags ingest.JoinTags
-}
-
-type PointWrapper struct {
-	*ingest.PointFeature
-}
-
-func (p PointWrapper) PointID() b6.PointID {
-	return p.PointFeature.PointID
-}
-
-func (p PointWrapper) Covering(coverer s2.RegionCoverer) s2.CellUnion {
-	return s2.CellUnion([]s2.CellID{p.CellID().Parent(coverer.MaxLevel)})
-}
-
-func (p PointWrapper) ToGeoJSON() geojson.GeoJSON {
-	return b6.PointFeatureToGeoJSON(p)
-}
-
-func (s *UPRNSource) Read(options ingest.ReadOptions, emit ingest.Emit, ctx context.Context) error {
-	f, err := os.OpenFile(s.Filename, os.O_RDONLY, 0)
-	defer f.Close()
-	if err != nil {
-		return err
-	}
-
-	if options.SkipPoints {
-		return nil
-	}
-
-	d, err := gzip.NewReader(f)
-	if err != nil {
-		return err
-	}
-	r := csv.NewReader(d)
-	header, err := r.Read()
-	if err != nil {
-		return err
-	}
-	fields := []string{"UPRN", "LATITUDE", "LONGITUDE"}
-	indicies := make([]int, len(fields))
-	for i, f := range fields {
-		indicies[i] = -1
-		for j, column := range header {
-			if f == strings.Trim(column, "\ufeff") { // Remove byte order mark
-				indicies[i] = j
-				break
-			}
-		}
-		if indicies[i] < 0 {
-			return fmt.Errorf("Failed to find field %q", f)
-		}
-	}
-
-	point := ingest.PointFeature{
-		PointID: b6.PointID{
-			Namespace: b6.NamespaceGBUPRN,
-		},
-		Tags: []b6.Tag{{Key: "#place", Value: "uprn"}},
-	}
-	uprns := 0
-	emits := 0
-	joins := 0
-
-	context := functions.NewContext(b6.EmptyWorld{})
-	for {
-		row, err := r.Read()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
-		uprns++
-		point.PointID.Value, err = strconv.ParseUint(row[indicies[0]], 10, 64)
-		if err != nil {
-			return fmt.Errorf("Parsing id for %q: %s", row, err)
-		}
-		lat, err := strconv.ParseFloat(row[indicies[1]], 64)
-		if err != nil {
-			return fmt.Errorf("Parsing latitude for %q: %s", row, err)
-		}
-		lng, err := strconv.ParseFloat(row[indicies[2]], 64)
-		if err != nil {
-			return fmt.Errorf("Parsing longitude for %q: %s", row, err)
-		}
-		point.Location = s2.LatLngFromDegrees(lat, lng)
-		point.Tags = point.Tags[0:1] // Keep #place=uprn
-		s.JoinTags.AddTags(row[indicies[0]], &point)
-		if len(point.Tags) > 1 {
-			joins++
-		}
-		if ok, err := s.Filter(PointWrapper{PointFeature: &point}, context); ok {
-			emits++
-			if err := emit(&point, 0); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
-	}
-	log.Printf("uprns: %d emits: %d joined: %d", uprns, emits, joins)
-	return nil
-}
 
 func main() {
 	inputFlag := flag.String("input", "", "Input open UPRN CSV, gzipped")
@@ -138,6 +26,7 @@ func main() {
 	boundingBoxFlag := flag.String("bounding-box", "", "lat,lng,lat,lng bounding box to crop points outside")
 	filterFlag := flag.String("filter", "", "A b6 shell expression for a function taking a point feature and returning a boolean")
 	joinFlag := flag.String("join", "", "Join tag values from a CSV")
+	cores := flag.Int("cores", runtime.NumCPU(), "Available cores")
 	flag.Parse()
 
 	crop, err := ingest.ParseBoundingBox(*boundingBoxFlag)
@@ -145,25 +34,30 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var filter func(b6.PointFeature, *api.Context) (bool, error)
+	var filter func(g b6.Feature, c *api.Context) (bool, error)
+	apiContext := functions.NewContext(b6.EmptyWorld{})
 	if *filterFlag != "" {
 		expression, err := api.ParseExpression(*filterFlag)
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = api.EvaluateAndFill(expression, functions.NewContext(b6.EmptyWorld{}), &filter)
+		err = api.EvaluateAndFill(expression, apiContext, &filter)
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		filter = func(p b6.PointFeature, c *api.Context) (bool, error) {
-			return crop.ContainsPoint(p.Point()), nil
+		filter = func(f b6.Feature, c *api.Context) (bool, error) {
+			if p, ok := f.(b6.PointFeature); ok {
+				return crop.ContainsPoint(p.Point()), nil
+			}
+			return true, nil
 		}
 	}
 
-	source := &UPRNSource{
+	source := &uprn.Source{
 		Filename: *inputFlag,
 		Filter:   filter,
+		Context:  apiContext,
 	}
 
 	if *joinFlag != "" {
@@ -178,7 +72,7 @@ func main() {
 
 	config := compact.Options{
 		OutputFilename:       *outputFlag,
-		Cores:                1,
+		Cores:                *cores,
 		WorkDirectory:        "",
 		PointsWorkOutputType: compact.OutputTypeMemory,
 	}

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -129,7 +129,7 @@ func mustBuildCamdenForBenchmarks() b6.World {
 
 var benchmarkSearchQuery = b6.Intersection{
 	b6.Keyed{Key: "#building"},
-	b6.IntersectsCap{Cap: s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.5305, -0.1232)), b6.MetersToAngle(1000.0))},
+	&b6.IntersectsCap{Cap: s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.5305, -0.1232)), b6.MetersToAngle(1000.0))},
 }
 
 func BenchmarkSearchWorld(b *testing.B) {

--- a/src/diagonal.works/b6/ingest/features.go
+++ b/src/diagonal.works/b6/ingest/features.go
@@ -1046,12 +1046,6 @@ type ReadOptions struct {
 	Cores         int
 }
 
-type Emit func(f Feature, goroutine int) error
-
-type FeatureSource interface {
-	Read(options ReadOptions, emit Emit, ctx context.Context) error
-}
-
 type WorldFeatureSource struct {
 	World b6.World
 }

--- a/src/diagonal.works/b6/ingest/gb/uprn/source.go
+++ b/src/diagonal.works/b6/ingest/gb/uprn/source.go
@@ -1,0 +1,166 @@
+package uprn
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+
+	"diagonal.works/b6"
+	"diagonal.works/b6/api"
+	"diagonal.works/b6/geojson"
+	"diagonal.works/b6/ingest"
+	"github.com/golang/geo/s2"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/io/filesystem"
+)
+
+type Filter func(f b6.Feature, c *api.Context) (bool, error)
+
+type Source struct {
+	Filename string
+	Filter   func(f b6.Feature, c *api.Context) (bool, error)
+	Context  *api.Context
+	JoinTags ingest.JoinTags
+}
+
+func (s *Source) Read(options ingest.ReadOptions, emit ingest.Emit, ctx context.Context) error {
+	fs, err := filesystem.New(ctx, s.Filename)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	f, err := fs.OpenRead(ctx, s.Filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if options.SkipPoints {
+		return nil
+	}
+
+	d, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	r := csv.NewReader(d)
+	header, err := r.Read()
+	if err != nil {
+		return err
+	}
+	fields := []string{"UPRN", "LATITUDE", "LONGITUDE"}
+	columns := make([]int, len(fields))
+	for i, f := range fields {
+		columns[i] = -1
+		for j, column := range header {
+			if f == strings.Trim(column, "\ufeff") { // Remove byte order mark
+				columns[i] = j
+				break
+			}
+		}
+		if columns[i] < 0 {
+			return fmt.Errorf("Failed to find field %q", f)
+		}
+	}
+
+	goroutines := options.Cores
+	if goroutines < 1 {
+		goroutines = 1
+	}
+	filtered := filter(s.Filter, emit, options, s.Context)
+	p, wait := ingest.ParalleliseEmit(filtered, goroutines, ctx)
+	err = s.read(r, p, columns, goroutines)
+	return wait()
+}
+
+func (s *Source) read(r *csv.Reader, emit ingest.Emit, columns []int, goroutines int) error {
+	ps := make([]ingest.PointFeature, goroutines*2)
+	for i := range ps {
+		ps[i] = ingest.PointFeature{
+			PointID: b6.PointID{
+				Namespace: b6.NamespaceGBUPRN,
+			},
+			Tags: []b6.Tag{{Key: "#place", Value: "uprn"}},
+		}
+	}
+
+	uprns := 0
+	joins := 0
+	var err error
+	for {
+		var row []string
+		row, err = r.Read()
+		if err == io.EOF {
+			log.Printf("uprns: %d joined: %d", uprns, joins)
+			return nil
+		} else if err != nil {
+			return err
+		}
+		slot := uprns % len(ps)
+		uprns++
+		ps[slot].PointID.Value, err = strconv.ParseUint(row[columns[0]], 10, 64)
+		if err != nil {
+			return fmt.Errorf("Parsing id for %q: %s", row, err)
+		}
+		lat, err := strconv.ParseFloat(row[columns[1]], 64)
+		if err != nil {
+			return fmt.Errorf("Parsing latitude for %q: %s", row, err)
+		}
+		lng, err := strconv.ParseFloat(row[columns[2]], 64)
+		if err != nil {
+			return fmt.Errorf("Parsing longitude for %q: %s", row, err)
+		}
+		ps[slot].Location = s2.LatLngFromDegrees(lat, lng)
+		ps[slot].Tags = ps[slot].Tags[0:1] // Keep #place=uprn
+		s.JoinTags.AddTags(row[columns[0]], &ps[slot])
+		if len(ps[slot].Tags) > 1 {
+			joins++
+		}
+		if err := emit(&ps[slot], slot%goroutines); err != nil {
+			return err
+		}
+	}
+}
+
+type point struct {
+	*ingest.PointFeature
+}
+
+func (p point) PointID() b6.PointID {
+	return p.PointFeature.PointID
+}
+
+func (p point) Covering(coverer s2.RegionCoverer) s2.CellUnion {
+	return s2.CellUnion([]s2.CellID{p.CellID().Parent(coverer.MaxLevel)})
+}
+
+func (p point) ToGeoJSON() geojson.GeoJSON {
+	return b6.PointFeatureToGeoJSON(p)
+}
+
+func filter(filter Filter, emit ingest.Emit, options ingest.ReadOptions, ctx *api.Context) ingest.Emit {
+	goroutines := options.Cores
+	if goroutines < 1 {
+		goroutines = 1
+	}
+	ctxs := ctx.Fork(goroutines)
+	return func(f ingest.Feature, goroutine int) error {
+		var err error
+		keep := true
+		if p, ok := f.(*ingest.PointFeature); ok {
+			if keep, err = filter(point{p}, ctxs[goroutine]); err != nil {
+				return err
+			}
+		}
+		if keep {
+			return emit(f, goroutine)
+		}
+		return nil
+	}
+}

--- a/src/diagonal.works/b6/ingest/mutable_test.go
+++ b/src/diagonal.works/b6/ingest/mutable_test.go
@@ -461,7 +461,7 @@ func ValidateUpdatingPathUpdatesS2CellIndex(w MutableWorld, t *testing.T) {
 		return
 	}
 
-	areas = b6.AllAreas(b6.FindAreas(b6.IntersectsCap{cap}, w))
+	areas = b6.AllAreas(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, w))
 	if len(areas) != 1 || areas[0].AreaID() != area.AreaID {
 		t.Errorf("Expected to find 1 matching area within the region (found %d)", len(areas))
 	}
@@ -493,7 +493,7 @@ func ValidateUpdatingPointLocationsUpdatesS2CellIndex(w MutableWorld, t *testing
 
 	// A cap covering only part of the Eastern Shed
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.5370349, -0.1232719)), b6.MetersToAngle(10))
-	areas := b6.AllAreas(b6.FindAreas(b6.IntersectsCap{cap}, w))
+	areas := b6.AllAreas(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, w))
 	if len(areas) != 0 {
 		t.Errorf("Didn't expect to find an area %s", areas[0].FeatureID())
 	}
@@ -507,7 +507,7 @@ func ValidateUpdatingPointLocationsUpdatesS2CellIndex(w MutableWorld, t *testing
 		return
 	}
 
-	areas = b6.AllAreas(b6.FindAreas(b6.IntersectsCap{cap}, w))
+	areas = b6.AllAreas(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, w))
 	if len(areas) != 1 || areas[0].AreaID() != area.AreaID {
 		t.Errorf("Expected to find an area within the region")
 	}
@@ -826,7 +826,7 @@ func TestModifyPathInExistingWorld(t *testing.T) {
 
 	// A cap covering only part of the Eastern Shed
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.5370349, -0.1232719)), b6.MetersToAngle(10))
-	areas := b6.AllAreas(b6.FindAreas(b6.IntersectsCap{Cap: cap}, overlay))
+	areas := b6.AllAreas(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, overlay))
 	if len(areas) != 0 {
 		t.Errorf("Didn't expect to find an area %s", areas[0].FeatureID())
 	}
@@ -839,7 +839,7 @@ func TestModifyPathInExistingWorld(t *testing.T) {
 		return
 	}
 
-	areas = b6.AllAreas(b6.FindAreas(b6.IntersectsCap{Cap: cap}, overlay))
+	areas = b6.AllAreas(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, overlay))
 	if len(areas) != 1 || areas[0].AreaID() != area.AreaID {
 		t.Errorf("Expected to area within the region (found %d areas)", len(areas))
 	}
@@ -866,7 +866,7 @@ func TestModifyPointsOnPathInExistingWorld(t *testing.T) {
 
 	overlay := NewMutableOverlayWorld(base)
 	granarySquareCap := s2.CapFromCenterAngle(s2.Interpolate(0.5, a.Point(), b.Point()), b6.MetersToAngle(10))
-	paths := b6.AllPaths(b6.FindPaths(b6.IntersectsCap{granarySquareCap}, overlay))
+	paths := b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: granarySquareCap}, overlay))
 	if len(paths) != 1 {
 		t.Errorf("Expected to find 1 path around Granary Square, found %d", len(paths))
 	}
@@ -879,12 +879,12 @@ func TestModifyPointsOnPathInExistingWorld(t *testing.T) {
 	}
 
 	bankCap := s2.CapFromCenterAngle(s2.Interpolate(0.5, aPrime.Point(), bPrime.Point()), b6.MetersToAngle(10))
-	paths = b6.AllPaths(b6.FindPaths(b6.IntersectsCap{Cap: bankCap}, overlay))
+	paths = b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: bankCap}, overlay))
 	if len(paths) != 1 {
 		t.Errorf("Expected to find 1 path around Bank, found %d", len(paths))
 	}
 
-	paths = b6.AllPaths(b6.FindPaths(b6.IntersectsCap{Cap: granarySquareCap}, overlay))
+	paths = b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: granarySquareCap}, overlay))
 	if len(paths) != 0 {
 		t.Errorf("Expected to find no paths around Granary Square, found %d", len(paths))
 	}
@@ -912,7 +912,7 @@ func TestModifyPointsOnClosedPathInExistingWorld(t *testing.T) {
 
 	overlay := NewMutableOverlayWorld(base)
 	granarySquareCap := s2.CapFromCenterAngle(s2.Interpolate(0.5, a.Point(), b.Point()), b6.MetersToAngle(10))
-	paths := b6.AllPaths(b6.FindPaths(b6.IntersectsCap{granarySquareCap}, overlay))
+	paths := b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: granarySquareCap}, overlay))
 	if len(paths) != 1 {
 		t.Errorf("Expected to find 1 path around Granary Square, found %d", len(paths))
 	}
@@ -927,12 +927,12 @@ func TestModifyPointsOnClosedPathInExistingWorld(t *testing.T) {
 	}
 
 	bankCap := s2.CapFromCenterAngle(s2.Interpolate(0.5, aPrime.Point(), bPrime.Point()), b6.MetersToAngle(10))
-	paths = b6.AllPaths(b6.FindPaths(b6.IntersectsCap{Cap: bankCap}, overlay))
+	paths = b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: bankCap}, overlay))
 	if len(paths) != 1 {
 		t.Errorf("Expected to find 1 path around Bank, found %d", len(paths))
 	}
 
-	paths = b6.AllPaths(b6.FindPaths(b6.IntersectsCap{Cap: granarySquareCap}, overlay))
+	paths = b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: granarySquareCap}, overlay))
 	if len(paths) != 0 {
 		t.Errorf("Expected to find no paths around Granary Square, found %d", len(paths))
 	}

--- a/src/diagonal.works/b6/ingest/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/overlay_test.go
@@ -44,7 +44,7 @@ func TestOverlayWorldReturnsPathsFromAllIndices(t *testing.T) {
 	overlay := NewOverlayWorld(worlds[0], worlds[1])
 
 	cap := s2.CapFromCenterAngle(nodes[0].Location.ToS2Point(), b6.MetersToAngle(500))
-	found := b6.AllPaths(b6.FindPaths(b6.IntersectsCap{cap}, overlay))
+	found := b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: cap}, overlay))
 
 	expected := []osm.WayID{140633010, 557698825, 642639444, 807925586}
 	if len(found) != len(expected) {

--- a/src/diagonal.works/b6/ingest/source.go
+++ b/src/diagonal.works/b6/ingest/source.go
@@ -1,0 +1,71 @@
+package ingest
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type Emit func(f Feature, goroutine int) error
+
+type FeatureSource interface {
+	Read(options ReadOptions, emit Emit, ctx context.Context) error
+}
+
+type Wait func() error
+
+// ParalleliseEmit passes features concurrently to the given emit function,
+// using the specified number of goroutines. Wait() blocks until all
+// goroutines have finished emitting. This is useful to adapt a source
+// that inherently uses a single goroutine (likely due to the input data
+// format) to a sink that can make use of parallelism.
+// The gorotuine specified in each emit call is used for that feature. If that
+// goroutine is still emitting the previous feature, the emit call blocks. This
+// behaviour allows a caller to use a buffer of 2*goroutines features to avoid
+// dynamic allocation.
+func ParalleliseEmit(emit Emit, goroutines int, ctx context.Context) (Emit, Wait) {
+	if goroutines < 1 {
+		goroutines = 1
+	}
+	c := make([]chan Feature, goroutines)
+	for i := range c {
+		c[i] = make(chan Feature, 0)
+	}
+
+	g, gc := errgroup.WithContext(ctx)
+	for i := 0; i < goroutines; i++ {
+		goroutine := i
+		g.Go(func() error {
+			for f := range c[goroutine] {
+				if err := emit(f, goroutine); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	running := true
+	wait := func() error {
+		if running {
+			for i := 0; i < goroutines; i++ {
+				close(c[i])
+			}
+			running = false
+		}
+		return g.Wait()
+	}
+	parallelised := func(f Feature, goroutine int) error {
+		if running {
+			select {
+			case <-gc.Done():
+				return wait()
+			case c[goroutine] <- f:
+				return nil
+			}
+		} else {
+			return wait()
+		}
+	}
+	return parallelised, wait
+}

--- a/src/diagonal.works/b6/ingest/source_test.go
+++ b/src/diagonal.works/b6/ingest/source_test.go
@@ -1,0 +1,79 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"diagonal.works/b6"
+)
+
+func TestParalliseEmit(t *testing.T) {
+	const cores = 8
+	const nIDs = 1024
+	const ns = b6.Namespace("diagonal.works/ns/test")
+
+	emitted := make([][]b6.FeatureID, cores)
+	emit := func(f Feature, goroutine int) error {
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		emitted[goroutine] = append(emitted[goroutine], f.FeatureID())
+		return nil
+	}
+
+	ps := make([]PointFeature, cores*2)
+	parallelised, wait := ParalleliseEmit(emit, cores, context.Background())
+	for i := 0; i < nIDs; i++ {
+		slot := i % len(ps)
+		ps[slot].PointID = b6.MakePointID(ns, uint64(i))
+		if err := parallelised(&ps[slot], i%cores); err != nil {
+			break
+		}
+	}
+	if err := wait(); err != nil {
+		t.Errorf("Expected no error, found %s", err)
+		return
+	}
+
+	expected := make(map[b6.FeatureID]struct{})
+	for i := 0; i < nIDs; i++ {
+		expected[b6.MakePointID(ns, uint64(i)).FeatureID()] = struct{}{}
+	}
+	for _, ids := range emitted {
+		for _, id := range ids {
+			delete(expected, id)
+		}
+	}
+	if len(expected) != 0 {
+		t.Errorf("Expected all ids to be emitted")
+	}
+}
+
+func TestParalliseEmitWithError(t *testing.T) {
+	const cores = 8
+	const nIDs = 1024
+	const ns = b6.Namespace("diagonal.works/ns/test")
+
+	broken := errors.New("Broken")
+	emit := func(f Feature, goroutine int) error {
+		if f.FeatureID().Value == 42 {
+			return broken
+		}
+		return nil
+	}
+
+	ps := make([]PointFeature, cores*2)
+	parallelised, wait := ParalleliseEmit(emit, cores, context.Background())
+	for i := 0; i < nIDs; i++ {
+		slot := i % len(ps)
+		ps[slot].PointID = b6.MakePointID(ns, uint64(i))
+		if err := parallelised(&ps[slot], i%cores); err != nil {
+			break
+		}
+	}
+	if err := wait(); err != broken {
+		t.Errorf("Expected %s, found %s", broken, err)
+		return
+	}
+}

--- a/src/diagonal.works/b6/ingest/spatial_test.go
+++ b/src/diagonal.works/b6/ingest/spatial_test.go
@@ -37,7 +37,7 @@ func TestIntersectsWithCap(t *testing.T) {
 
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53617, -0.12582)), b6.MetersToAngle(100))
 	roughAreas := makeAreaMap(b6.FindAreas(b6.MightIntersect{cap}, w))
-	exactAreas := makeAreaMap(b6.FindAreas(b6.IntersectsCap{cap}, w))
+	exactAreas := makeAreaMap(b6.FindAreas(&b6.IntersectsCap{Cap: cap}, w))
 
 	if len(roughAreas) <= len(exactAreas) || len(exactAreas) == 0 {
 		t.Errorf("Expected there to be less areas by exact match than rough match")

--- a/src/diagonal.works/b6/ingest/testing.go
+++ b/src/diagonal.works/b6/ingest/testing.go
@@ -224,7 +224,7 @@ func ValidateWaysWithMissingNodesArentIndexed(buildWorld BuildOSMWorld, t *testi
 		return
 	}
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53534, -0.12447)), b6.MetersToAngle(100))
-	paths := b6.AllPaths(b6.FindPaths(b6.IntersectsCap{cap}, w))
+	paths := b6.AllPaths(b6.FindPaths(&b6.IntersectsCap{Cap: cap}, w))
 
 	expected := 1
 	if len(paths) != expected {
@@ -248,7 +248,7 @@ func ValidatePointsWithoutTagsArentIndexed(buildWorld BuildOSMWorld, t *testing.
 		return
 	}
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53534, -0.12447)), b6.MetersToAngle(100))
-	points := b6.AllPoints(b6.FindPoints(b6.IntersectsCap{cap}, w))
+	points := b6.AllPoints(b6.FindPoints(&b6.IntersectsCap{Cap: cap}, w))
 
 	if len(points) == 1 {
 		if points[0].FeatureID().Value != uint64(nodes[0].ID) {
@@ -413,7 +413,7 @@ func ValidateRelationsAsAreas(buildWorld BuildOSMWorld, t *testing.T) {
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53534, -0.12447)), b6.MetersToAngle(500))
 
 	expectedAreas := 1
-	q := b6.Intersection{b6.IntersectsCap{cap}, b6.Tagged{Key: "#building", Value: "yes"}}
+	q := b6.Intersection{&b6.IntersectsCap{Cap: cap}, b6.Tagged{Key: "#building", Value: "yes"}}
 	if areas := b6.AllAreas(b6.FindAreas(q, w)); len(areas) != expectedAreas {
 		t.Errorf("Expected %d area, found %d", expectedAreas, len(areas))
 	} else {
@@ -1117,7 +1117,7 @@ func ValidateSpatialQueriesOnAnEmptyIndexReturnNothing(buildWorld BuildOSMWorld,
 	}
 
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53534, -0.12447)), b6.MetersToAngle(500))
-	query := b6.IntersectsCap{cap}
+	query := &b6.IntersectsCap{Cap: cap}
 	if paths := b6.AllPaths(b6.FindPaths(query, w)); len(paths) != 0 {
 		// The most likely failure mode is a panic()/nil pointer, rather than
 		// imaginary ways, but both are covered.
@@ -1327,7 +1327,7 @@ func ValidateTagsAreSearchable(buildWorld BuildOSMWorld, t *testing.T) {
 	}
 
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.5357237, -0.1253052)), b6.MetersToAngle(100))
-	points := b6.AllPoints(b6.FindPoints(b6.IntersectsCap{cap}, w))
+	points := b6.AllPoints(b6.FindPoints(&b6.IntersectsCap{Cap: cap}, w))
 	if len(points) != 1 {
 		t.Errorf("Expected to find 1 point, found %d", len(points))
 		return


### PR DESCRIPTION
Reworks IntersectsCap{} to cache the polygon used to approximate the cap, and parallises the output of uprn ingest while avoiding dynamic allocation of points.