### PR TITLE
Add a nightly build that pushes a new docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ TARGETOS ?= $(shell uname -s | tr A-Z a-z)
 # Sets TARGETPLATFORM to something like linux/x86_64 or darwin/arm64
 export TARGETPLATFORM ?= ${TARGETOS}/${TARGETARCH}
 
-
-all: .git/hooks/pre-commit b6 b6-ingest-osm b6-ingest-gdal b6-ingest-terrain b6-ingest-gb-uprn b6-ingest-gb-codepoint b6-connect b6-api python docker
+all: .git/hooks/pre-commit b6 b6-ingest-osm b6-ingest-gdal b6-ingest-terrain b6-ingest-gb-uprn b6-ingest-gb-codepoint b6-connect b6-api python
 
 .git/hooks/pre-commit: etc/pre-commit
 	cp $< $@

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ bin/linux/x86_64/b6 --world=data/camden.index
 You can run the entire build inside a docker container with:
 ```
 make docker/Dockerfile.b6
-docker build --build-arg=TARGETOS=linux --build-arg=TARGETARCH=amd64 -f docker/Dockerfile.b6
+docker build --build-arg=TARGETOS=linux --build-arg=TARGETARCH=amd64 -f docker/Dockerfile.b6 .
 ```
 ## Ingesting data
 

--- a/etc/cloudbuild.nightly.yaml
+++ b/etc/cloudbuild.nightly.yaml
@@ -1,0 +1,13 @@
+options:
+  pool:
+    name: projects/diagonal-platform/locations/europe-west1/workerPools/ci
+steps:
+- name: "gcr.io/cloud-builders/git"
+  args: ["fetch", "--unshallow"]
+  allowFailure: true
+- name: "gcc"
+  args: ["make", "docker/Dockerfile.b6"]
+- name: "docker"
+  args: ["docker", "build", "--build-arg", "TARGETOS=linux", "--build-arg", "TARGETARCH=amd64", "-f", "docker/Dockerfile.b6", "-t", "europe-docker.pkg.dev/diagonal-public/b6/b6:nightly", "."]
+images:
+- "europe-docker.pkg.dev/diagonal-public/b6/b6:nightly"

--- a/src/diagonal.works/b6/ingest/compact/encoding.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"sort"
 	"sync"
@@ -1642,9 +1641,6 @@ func NewTokenMapEncoder() *TokenMapEncoder {
 
 func (t *TokenMapEncoder) Add(token string, index int) {
 	if (float64(t.n+1) / float64(len(t.tokens))) > TokenMapMaxLoadFactor {
-		{
-			log.Printf("add token: double to %d", len(t.tokens)*2)
-		}
 		tokens := t.tokens
 		indices := t.indices
 		t.tokens = make([][]string, len(t.tokens)*2)


### PR DESCRIPTION
Add a nightly build that pushes a new docker image, including fixing the documentation. Remove 'docker' from the all Makefile target, since we don't copy the docker configuration into the image during build. In passing, remove unnecessary logging from the index build.