### PR TITLE
Parallelise ingest of multiple gdal files.

### DIFF
--- a/etc/b6build-nightly-notifier.yaml
+++ b/etc/b6build-nightly-notifier.yaml
@@ -1,0 +1,25 @@
+# Deployed with:
+# gcloud run deploy b6build-nightly-notifier \
+#   --region=europe-west1 \
+#   --image=us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/slack:latest \
+#   --no-allow-unauthenticated \
+#   --update-env-vars=CONFIG_PATH=gs://diagonal.works/etc/b6build-nightly-notifier.yaml,PROJECT_ID=diagonal-platform
+apiVersion: cloud-build-notifiers/v1
+kind: SlackNotifier
+metadata:
+  name: b6build-nightly-notifier
+spec:
+  notification:
+    filter: build.status == Build.Status.SUCCESS
+    params:
+      buildStatus: $(build.status)
+    delivery:
+      webhookUrl:
+        secretRef: webhook-url
+    template:
+      type: golang
+      uri: gs://diagonal.works/etc/b6build-nightly-template.json
+  secrets:
+  - name: webhook-url
+    value: projects/854624783986/secrets/slack-b6build-webhook/versions/1
+

--- a/etc/b6build-nightly-template.json
+++ b/etc/b6build-nightly-template.json
@@ -1,0 +1,29 @@
+[
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Cloud Build {{.Build.ProjectId}} {{.Build.Id}} {{.Params.buildStatus}}"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "View Build Logs"
+      },
+      "accessory": {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Logs"
+        },
+        "value": "clicked",
+        "url": "{{.Build.LogUrl}}",
+        "action_id": "button-action"
+      }
+    }
+  ]

--- a/src/diagonal.works/b6/api/functions/export.go
+++ b/src/diagonal.works/b6/api/functions/export.go
@@ -11,7 +11,7 @@ func exportWorld(filename string, c *api.Context) (int, error) {
 	source := ingest.WorldFeatureSource{World: c.World}
 	options := compact.Options{
 		OutputFilename:       filename,
-		Cores:                c.Cores,
+		Goroutines:           c.Cores,
 		WorkDirectory:        "",
 		PointsWorkOutputType: compact.OutputTypeMemory,
 	}

--- a/src/diagonal.works/b6/cmd/b6-connect/b6-connect.go
+++ b/src/diagonal.works/b6/cmd/b6-connect/b6-connect.go
@@ -129,7 +129,7 @@ func main() {
 	}
 	options := compact.Options{
 		OutputFilename:       *output,
-		Cores:                *cores,
+		Goroutines:           *cores,
 		WorkDirectory:        *scratch,
 		PointsWorkOutputType: t,
 	}

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-codepoint/b6-ingest-gb-codepoint.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-codepoint/b6-ingest-gb-codepoint.go
@@ -174,7 +174,7 @@ func main() {
 		if postcodes, err = readCodepointOpen(*inputFlag); err == nil {
 			config := compact.Options{
 				OutputFilename:       *outputFlag,
-				Cores:                *coresFlag,
+				Goroutines:           *coresFlag,
 				WorkDirectory:        "",
 				PointsWorkOutputType: compact.OutputTypeMemory,
 			}

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
@@ -72,7 +72,7 @@ func main() {
 
 	config := compact.Options{
 		OutputFilename:       *outputFlag,
-		Cores:                *cores,
+		Goroutines:           *cores,
 		WorkDirectory:        "",
 		PointsWorkOutputType: compact.OutputTypeMemory,
 	}

--- a/src/diagonal.works/b6/cmd/b6-ingest-osm/b6-ingest-osm.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-osm/b6-ingest-osm.go
@@ -32,7 +32,7 @@ func main() {
 		}
 		options := compact.Options{
 			OutputFilename:       *output,
-			Cores:                *cores,
+			Goroutines:           *cores,
 			WorkDirectory:        *scratch,
 			PointsWorkOutputType: t,
 		}

--- a/src/diagonal.works/b6/graph/connectivity.go
+++ b/src/diagonal.works/b6/graph/connectivity.go
@@ -416,7 +416,7 @@ func (m *modifyWorldSource) Read(options ingest.ReadOptions, emit ingest.Emit, c
 		SkipPaths:     options.SkipPaths,
 		SkipAreas:     options.SkipAreas,
 		SkipRelations: options.SkipRelations,
-		Cores:         options.Cores,
+		Goroutines:    options.Goroutines,
 	}
 	each := func(f b6.Feature, goroutine int) error {
 		switch f := f.(type) {

--- a/src/diagonal.works/b6/ingest/basic.go
+++ b/src/diagonal.works/b6/ingest/basic.go
@@ -664,7 +664,7 @@ func NewWorldFromSource(source FeatureSource, o *BuildOptions) (b6.World, error)
 		lock.Unlock()
 		return nil
 	}
-	options := ReadOptions{Cores: o.Cores}
+	options := ReadOptions{Goroutines: o.Cores}
 	if err := source.Read(options, f, context.Background()); err != nil {
 		return nil, err
 	}

--- a/src/diagonal.works/b6/ingest/compact/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/compact/overlay_test.go
@@ -20,7 +20,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 	osmSource := ingest.MemoryOSMSource{Nodes: nodes, Ways: ways, Relations: relations}
 	o := ingest.BuildOptions{Cores: 2}
 	source, err := ingest.NewFeatureSourceFromPBF(&osmSource, &o, context.Background())
-	options := Options{Cores: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
 	index, err := BuildInMemory(source, &options)
 	if err != nil {
 		t.Errorf("Failed to build base index: %s", err)

--- a/src/diagonal.works/b6/ingest/compact/world.go
+++ b/src/diagonal.works/b6/ingest/compact/world.go
@@ -552,9 +552,9 @@ func (f *FeaturesByID) newRelationFromBuffer(fb *featureBlock, id uint64, b []by
 }
 
 func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error, options *b6.EachFeatureOptions) error {
-	cores := options.Cores
-	if cores < 1 {
-		cores = 1
+	goroutines := options.Goroutines
+	if goroutines < 1 {
+		goroutines = 1
 	}
 
 	if !options.SkipPoints {
@@ -565,7 +565,7 @@ func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error,
 				}
 				return nil
 			}
-			if err := fb.Map.EachItem(emit, cores); err != nil {
+			if err := fb.Map.EachItem(emit, goroutines); err != nil {
 				return err
 			}
 		}
@@ -576,7 +576,7 @@ func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error,
 			emit := func(id uint64, tagged []encoding.Tagged, g int) error {
 				return each(f.newPathFromBuffer(fb, id, tagged[0].Data), g)
 			}
-			if err := fb.Map.EachItem(emit, cores); err != nil {
+			if err := fb.Map.EachItem(emit, goroutines); err != nil {
 				return err
 			}
 		}
@@ -587,7 +587,7 @@ func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error,
 			emit := func(id uint64, tagged []encoding.Tagged, g int) error {
 				return each(f.newAreaFromBuffer(fb, id, tagged[0].Data), g)
 			}
-			if err := fb.Map.EachItem(emit, cores); err != nil {
+			if err := fb.Map.EachItem(emit, goroutines); err != nil {
 				return err
 			}
 		}
@@ -598,7 +598,7 @@ func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error,
 			emit := func(id uint64, tagged []encoding.Tagged, g int) error {
 				return each(f.newRelationFromBuffer(fb, id, tagged[0].Data), g)
 			}
-			if err := fb.Map.EachItem(emit, cores); err != nil {
+			if err := fb.Map.EachItem(emit, goroutines); err != nil {
 				return err
 			}
 		}

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -19,7 +19,7 @@ func mergeOSM(nodes []osm.Node, ways []osm.Way, relations []osm.Relation, base b
 	if err != nil {
 		return err
 	}
-	options := Options{Cores: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
 	var index []byte
 	if base == nil {
 		if index, err = BuildInMemory(source, &options); err != nil {
@@ -114,7 +114,7 @@ func mustBuildCamdenForBenchmarks() b6.World {
 		panic(err)
 	}
 
-	options := Options{Cores: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
 	var index []byte
 	if index, err = BuildInMemory(source, &options); err != nil {
 		panic(err)

--- a/src/diagonal.works/b6/ingest/features.go
+++ b/src/diagonal.works/b6/ingest/features.go
@@ -795,7 +795,7 @@ func (f *FeaturesByID) FindLocationByID(id b6.PointID) (s2.LatLng, bool) {
 }
 
 func (f *FeaturesByID) EachFeature(each func(f b6.Feature, goroutine int) error, options *b6.EachFeatureOptions) error {
-	cores := options.Cores
+	cores := options.Goroutines
 	if cores < 1 {
 		cores = 1
 	}
@@ -1043,7 +1043,7 @@ type ReadOptions struct {
 	SkipAreas     bool
 	SkipRelations bool
 	SkipTags      bool
-	Cores         int
+	Goroutines    int
 }
 
 type WorldFeatureSource struct {
@@ -1056,7 +1056,7 @@ func (w WorldFeatureSource) Read(options ReadOptions, emit Emit, ctx context.Con
 		SkipPaths:     options.SkipPaths,
 		SkipAreas:     options.SkipAreas,
 		SkipRelations: options.SkipRelations,
-		Cores:         options.Cores,
+		Goroutines:    options.Goroutines,
 	}
 	f := func(f b6.Feature, goroutine int) error {
 		return emit(NewFeatureFromWorld(f), goroutine)
@@ -1067,7 +1067,7 @@ func (w WorldFeatureSource) Read(options ReadOptions, emit Emit, ctx context.Con
 type MemoryFeatureSource []Feature
 
 func (m MemoryFeatureSource) Read(options ReadOptions, emit Emit, ctx context.Context) error {
-	cores := options.Cores
+	cores := options.Goroutines
 	if cores < 1 {
 		cores = 1
 	}

--- a/src/diagonal.works/b6/ingest/gb/uprn/source.go
+++ b/src/diagonal.works/b6/ingest/gb/uprn/source.go
@@ -69,7 +69,7 @@ func (s *Source) Read(options ingest.ReadOptions, emit ingest.Emit, ctx context.
 		}
 	}
 
-	goroutines := options.Cores
+	goroutines := options.Goroutines
 	if goroutines < 1 {
 		goroutines = 1
 	}
@@ -145,7 +145,7 @@ func (p point) ToGeoJSON() geojson.GeoJSON {
 }
 
 func filter(filter Filter, emit ingest.Emit, options ingest.ReadOptions, ctx *api.Context) ingest.Emit {
-	goroutines := options.Cores
+	goroutines := options.Goroutines
 	if goroutines < 1 {
 		goroutines = 1
 	}

--- a/src/diagonal.works/b6/ingest/mutable.go
+++ b/src/diagonal.works/b6/ingest/mutable.go
@@ -343,7 +343,7 @@ func NewMutableWorldFromSource(source FeatureSource, cores int) (b6.World, error
 		lock.Unlock()
 		return nil
 	}
-	options := ReadOptions{Cores: cores}
+	options := ReadOptions{Goroutines: cores}
 	err := source.Read(options, f, context.Background())
 	return w, err
 }

--- a/src/diagonal.works/b6/ingest/osm.go
+++ b/src/diagonal.works/b6/ingest/osm.go
@@ -320,7 +320,7 @@ func reassembleMultiPolygon(relation *osm.Relation, areaWays *IDSet, ways map[os
 }
 
 func (s *pbfSource) Read(options ReadOptions, emit Emit, ctx context.Context) error {
-	cores := options.Cores
+	cores := options.Goroutines
 	if cores < 1 {
 		cores = 1
 	}

--- a/src/diagonal.works/b6/ingest/testing.go
+++ b/src/diagonal.works/b6/ingest/testing.go
@@ -1535,7 +1535,7 @@ func ValidateEachFeature(buildWorld BuildOSMWorld, t *testing.T) {
 		SkipPaths:     true,
 		SkipAreas:     false,
 		SkipRelations: true,
-		Cores:         2,
+		Goroutines:    2,
 	}
 	if err := w.EachFeature(each, &options); err != nil {
 		t.Errorf("Expected no error from EachFeature, found: %s", err)

--- a/src/diagonal.works/b6/ingest/world_test.go
+++ b/src/diagonal.works/b6/ingest/world_test.go
@@ -68,7 +68,7 @@ func buildMutableOverlayWorldOnBasic(nodes []osm.Node, ways []osm.Way, relations
 		}
 		return nil
 	}
-	options := ReadOptions{Cores: 2}
+	options := ReadOptions{Goroutines: 2}
 	if err := source.Read(options, emit, context.Background()); err != nil {
 		return nil, err
 	}

--- a/src/diagonal.works/b6/world.go
+++ b/src/diagonal.works/b6/world.go
@@ -745,7 +745,7 @@ type EachFeatureOptions struct {
 	SkipPaths     bool
 	SkipAreas     bool
 	SkipRelations bool
-	Cores         int
+	Goroutines    int
 }
 
 type World interface {


### PR DESCRIPTION
Parallelise ingest of multiple gdal files. Rename the Cores option to Goroutines to clarify the semantics, as the code increasingly relies the semantics of numbered goroutines emitting one feature at a time. In passing, add build notifier configuration.