### PR TITLE
Use mmap to allocate memory for worlds read from cloud storage.

### DIFF
--- a/src/diagonal.works/b6/go.mod
+++ b/src/diagonal.works/b6/go.mod
@@ -7,11 +7,12 @@ go 1.20
 replace github.com/lukeroth/gdal v0.0.0-20220614134811-3c605a05e283 => github.com/diagonalworks/gdal v0.0.0-20230425060405-b7726afc0d73
 
 require (
-	github.com/apache/beam v2.19.0+incompatible
+	github.com/apache/beam v2.32.0+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/lukeroth/gdal v0.0.0-20220614134811-3c605a05e283
 	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
+	golang.org/x/mod v0.10.0
 	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
@@ -31,7 +32,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/src/diagonal.works/b6/go.sum
+++ b/src/diagonal.works/b6/go.sum
@@ -14,6 +14,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/beam v2.19.0+incompatible h1:Dm4cSxkGeH8l9OG2jkOodp2Dg6uZjorV0XU8vDy/fa4=
 github.com/apache/beam v2.19.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
+github.com/apache/beam v2.32.0+incompatible h1:8MOeoZwBgORfaJjrZxpkqJWEIzwupRGLqUqG0/mvEtQ=
+github.com/apache/beam v2.32.0+incompatible/go.mod h1:/8NX3Qi8vGstDLLaeaU7+lzVEu/ACaQhYjeefzQ0y1o=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/src/diagonal.works/b6/ingest/compact/world.go
+++ b/src/diagonal.works/b6/ingest/compact/world.go
@@ -1020,7 +1020,7 @@ func (w *World) Merge(data []byte) error {
 	var header Header
 	header.Unmarshal(data)
 	if header.Magic != HeaderMagic {
-		return fmt.Errorf("Bad header magic")
+		return fmt.Errorf("Bad header magic: expected %x, found %x", uint64(HeaderMagic), header.Magic)
 	}
 	if err := verifyVersion(&header, data); err != nil {
 		return err


### PR DESCRIPTION
Use mmap to allocate memory for worlds read from cloud storage, to bypass the go garbage collector. Also parallelise reads.