### PR TITLE
Fix a sightline panic, and allow features to be passed back in Python.

### DIFF
--- a/python/diagonal_b6/b6_test.py
+++ b/python/diagonal_b6/b6_test.py
@@ -65,6 +65,10 @@ class B6Test(unittest.TestCase):
     def test_uk_ons_boundary_id(self):
         self.assertEqual(b6.uk_ons_boundary_id("E01000953").value, 76343044687353)
 
+    def test_area_str(self):
+        area = self.connection(b6.find_area(b6.osm_way_area_id(COAL_DROPS_YARD_WEST_BUILDING_ID)))
+        self.assertEqual("<Area /area/openstreetmap.org/way/222021572>", str(area))
+
     def test_relation_members(self):
         greenway = self.connection(b6.find_relation(b6.osm_relation_id(JUBILEE_GREENWAY_ID)))
         paths = ([str(m) for m in greenway.members() if m.is_path()])
@@ -81,6 +85,11 @@ class B6Test(unittest.TestCase):
         for d in degrees:
             self.assertGreaterEqual(d, 0)
             self.assertLess(d, 10)
+
+    def test_send_evaluated_feature_back_to_server(self):
+        point = self.connection(b6.find_point(b6.osm_node_id(STABLE_STREET_BRIDGE_NORTH_END_ID)))
+        degree = self.connection(b6.degree(point))
+        self.assertEqual(degree, self.connection(b6.find_point(b6.osm_node_id(STABLE_STREET_BRIDGE_NORTH_END_ID)).degree()))
 
     def test_path_lengths(self):
         lengths = [length for (id, length) in self.connection(b6.find_paths(b6.keyed("#highway")).length())]

--- a/python/diagonal_b6/features.py
+++ b/python/diagonal_b6/features.py
@@ -42,7 +42,7 @@ class FeatureID(expression.Literal):
 
     def __str__(self):
         type = features_pb2.FeatureType.Name(self.type).replace("FeatureType", "").lower()
-        return "%s/%s/%d" % (type, self.namespace, self.value)
+        return "/%s/%s/%d" % (type, self.namespace, self.value)
 
     def __repr__(self):
         return str(self)
@@ -58,7 +58,7 @@ class FeatureID(expression.Literal):
         query.spatial.area.id.namespace = self.namespace
         query.spatial.area.id.value = self.value
 
-class Feature:
+class Feature(expression.Node):
 
     def is_point(self):
         return self.id.is_point()
@@ -105,10 +105,15 @@ class Feature:
     def all_tags(self):
         return [(tag.key, tag.value) for tag in self._pb.tags]
 
+    def to_node_proto(self):
+        node = api_pb2.NodeProto()
+        node.call.function.symbol = "find-feature"
+        node.call.args.add().CopyFrom(self.id.to_node_proto())
+        return node
+
     def __str__(self):
         type = features_pb2.FeatureType.Name(self.id.type).replace("FeatureType", "").title()
-        namespace = features_pb2.FeatureIDProto.Namespace.Name(self.id.namespace).replace("Namespace", "").lower()
-        return "<%s %s:%d>" % (type, namespace, self.id.value)
+        return "<%s %s>" % (type, self.id)
 
     def _fill_query(self, query):
         return self.id._fill_query(query)


### PR DESCRIPTION
Fix a sightline panic that occured when an edge ended exactly on the reference line between the point and the North pole. As it was part of the same bug report, also allow features to be passed back to the b6 server by encoding them as a call to find-feature with their ID. In passing, correct a bug that prevented str() from working on features given we now use string namespaces, not integers.

gh-42: str() on features, and sending features to the backend
gh-43: sightline crash