### PR TITLE
Make it possible to import 2022 census boundaries.

### DIFF
--- a/src/diagonal.works/b6/api/shell.go
+++ b/src/diagonal.works/b6/api/shell.go
@@ -129,7 +129,7 @@ func idFromUKONS(a *NamespaceAlias, token string) (b6.FeatureID, error) {
 	if len(parts) == 2 {
 		year, err := strconv.Atoi(parts[0])
 		if err == nil {
-			id = b6.FeatureIDFromGBONSCode(parts[1], year, a.Type)
+			id = b6.FeatureIDFromUKONSCode(parts[1], year, a.Type)
 		}
 	}
 	var err error
@@ -140,7 +140,7 @@ func idFromUKONS(a *NamespaceAlias, token string) (b6.FeatureID, error) {
 }
 
 func idToUKONS(a *NamespaceAlias, id b6.FeatureID) string {
-	code, year, ok := b6.GBONSCodeFromFeatureID(id)
+	code, year, ok := b6.UKONSCodeFromFeatureID(id)
 	if ok {
 		return fmt.Sprintf("%s%d/%s", a.Prefix, year, code)
 	}

--- a/src/diagonal.works/b6/api/shell_test.go
+++ b/src/diagonal.works/b6/api/shell_test.go
@@ -823,8 +823,7 @@ func TestToFeatureIDExpression(t *testing.T) {
 		{camden.StableStreetBridgeID.FeatureID(), "/w/140633010"},
 		{camden.LightermanID.FeatureID(), "/a/427900370"},
 		{b6.MakePointID(b6.NamespaceGBUPRN, 116000008).FeatureID(), "/gb/uprn/116000008"},
-		{b6.FeatureIDFromGBONSCode("E01000953", 2011, b6.FeatureTypeArea).FeatureID(), "/uk/ons/2011/E01000953"},
-		{b6.PointIDFromGBPostcode("N1C 4AD").FeatureID(), "/gb/codepoint/n1c4ad"},
+		{b6.FeatureIDFromUKONSCode("E01000953", 2011, b6.FeatureTypeArea).FeatureID(), "/uk/ons/2011/E01000953"},
 	}
 	for _, test := range tests {
 		if token := UnparseFeatureID(test.ID, true); token != test.Token {

--- a/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
@@ -27,7 +27,8 @@ var idStrategies = map[string]gdal.IDStrategy{
 	"":            gdal.IndexIDStrategy,
 	"strip":       gdal.StripNonDigitsIDStrategy,
 	"hash":        gdal.HashIDStrategy,
-	"gb-ons-2011": gdal.GBONS2011IDStrategy,
+	"uk-ons-2011": gdal.UKONS2011IDStrategy,
+	"uk-ons-2022": gdal.UKONS2022IDStrategy,
 }
 
 type input interface {

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -808,6 +808,17 @@ function renderShellBlock(block, root, response, blocks) {
     input.select("input").on("focusout", e => {
         block.select("ul").classed("focussed", false);
     });
+    input.on("keydown", e => {
+        switch (e.key) {
+            case "Tab":
+                const node = input.select("input").node();
+                if (state.highlighted >= 0 && state.filtered[state.highlighted].length > node.value.length) {
+                    node.value = state.filtered[state.highlighted] + " ";
+                }
+                e.preventDefault();
+                break;
+        }
+    });
     input.on("keyup", e => {
         switch (e.key) {
             case "ArrowUp":

--- a/src/diagonal.works/b6/ids.go
+++ b/src/diagonal.works/b6/ids.go
@@ -68,7 +68,7 @@ const (
 	ukONSNumberMask = 0xffffffff
 )
 
-func FeatureIDFromGBONSCode(code string, year int, t FeatureType) FeatureID {
+func FeatureIDFromUKONSCode(code string, year int, t FeatureType) FeatureID {
 	// ONS codes are a letter followed by 8 digits
 	if len(code) != 9 {
 		return FeatureIDInvalid
@@ -82,7 +82,7 @@ func FeatureIDFromGBONSCode(code string, year int, t FeatureType) FeatureID {
 	return FeatureID{Type: t, Namespace: NamespaceUKONSBoundaries, Value: codeBits | yearBits | uint64(n)}
 }
 
-func GBONSCodeFromFeatureID(id FeatureID) (string, int, bool) {
+func UKONSCodeFromFeatureID(id FeatureID) (string, int, bool) {
 	if id.Namespace != NamespaceUKONSBoundaries {
 		return "", 0, false
 	}

--- a/src/diagonal.works/b6/ids_test.go
+++ b/src/diagonal.works/b6/ids_test.go
@@ -61,8 +61,8 @@ func TestFeatureIDFromGBONSCode(t *testing.T) {
 
 	year := 2011
 	for _, code := range codes {
-		id := FeatureIDFromGBONSCode(code, year, FeatureTypeArea)
-		if c, y, ok := GBONSCodeFromFeatureID(id); !ok || c != code || y != year {
+		id := FeatureIDFromUKONSCode(code, year, FeatureTypeArea)
+		if c, y, ok := UKONSCodeFromFeatureID(id); !ok || c != code || y != year {
 			t.Errorf("Expected %s, year %d, found %s, year %d", code, year, c, y)
 		}
 	}

--- a/src/diagonal.works/b6/ingest/compact/build.go
+++ b/src/diagonal.works/b6/ingest/compact/build.go
@@ -125,7 +125,7 @@ func (o *Options) PointsWorkOutput() Output {
 }
 
 const (
-	maxEncodedFeatureSize = 1 << 19 // Measured empirically
+	maxEncodedFeatureSize = 64 * 1024 * 1204 // Measured empirically
 
 	// Tags used for the first pass
 	PointTag         encoding.Tag = 0

--- a/src/diagonal.works/b6/ingest/gdal/source.go
+++ b/src/diagonal.works/b6/ingest/gdal/source.go
@@ -39,8 +39,12 @@ var (
 		return b6.FeatureID{Type: t, Namespace: ns, Value: h.Sum64()}, nil
 	}
 
-	GBONS2011IDStrategy IDStrategy = func(value string, i int, t b6.FeatureType, ns b6.Namespace) (b6.FeatureID, error) {
-		return b6.FeatureIDFromGBONSCode(value, 2011, t), nil
+	UKONS2011IDStrategy IDStrategy = func(value string, i int, t b6.FeatureType, ns b6.Namespace) (b6.FeatureID, error) {
+		return b6.FeatureIDFromUKONSCode(value, 2011, t), nil
+	}
+
+	UKONS2022IDStrategy IDStrategy = func(value string, i int, t b6.FeatureType, ns b6.Namespace) (b6.FeatureID, error) {
+		return b6.FeatureIDFromUKONSCode(value, 2022, t), nil
 	}
 )
 

--- a/src/diagonal.works/b6/ingest/gdal/source_test.go
+++ b/src/diagonal.works/b6/ingest/gdal/source_test.go
@@ -16,13 +16,13 @@ func TestReadFeaturesFromLSOABoundaries(t *testing.T) {
 		CopyTags:   []CopyTag{{Field: "LSOA11CD", Key: "code"}, {Field: "LSOA11NM", Key: "name"}, {Field: "POPULATION", Key: "population"}},
 		AddTags:    []b6.Tag{{Key: "#boundary", Value: "lsoa"}},
 		IDField:    "LSOA11CD",
-		IDStrategy: GBONS2011IDStrategy,
+		IDStrategy: UKONS2011IDStrategy,
 		Bounds:     s2.FullRect(),
 	}
 
 	var found ingest.Feature
 	emit := func(f ingest.Feature, goroutine int) error {
-		if f.FeatureID() == b6.FeatureIDFromGBONSCode("E01000858", 2011, b6.FeatureTypeArea) {
+		if f.FeatureID() == b6.FeatureIDFromUKONSCode("E01000858", 2011, b6.FeatureTypeArea) {
 			found = f
 		}
 		return nil
@@ -52,13 +52,13 @@ func TestReadFeaturesFromLSOABoundariesCopyingAllFields(t *testing.T) {
 		CopyTags:      []CopyTag{{Field: "LSOA11CD", Key: "code"}},
 		AddTags:       []b6.Tag{{Key: "#boundary", Value: "lsoa"}},
 		IDField:       "LSOA11CD",
-		IDStrategy:    GBONS2011IDStrategy,
+		IDStrategy:    UKONS2011IDStrategy,
 		Bounds:        s2.FullRect(),
 	}
 
 	var found ingest.Feature
 	emit := func(f ingest.Feature, goroutine int) error {
-		if f.FeatureID() == b6.FeatureIDFromGBONSCode("E01000858", 2011, b6.FeatureTypeArea) {
+		if f.FeatureID() == b6.FeatureIDFromUKONSCode("E01000858", 2011, b6.FeatureTypeArea) {
 			found = f
 		}
 		return nil

--- a/src/diagonal.works/b6/ui/blocks.go
+++ b/src/diagonal.works/b6/ui/blocks.go
@@ -351,6 +351,17 @@ func featureID(f b6.Feature) string {
 		return code.Value
 	} else if ref := f.Get("ref"); ref.IsValid() {
 		return ref.Value
+	} else {
+		switch f.FeatureID().Namespace {
+		case b6.NamespaceGBCodePoint:
+			if postcode, ok := b6.PostcodeFromPointID(f.FeatureID().ToPointID()); ok {
+				return postcode
+			}
+		case b6.NamespaceUKONSBoundaries:
+			if code, _, ok := b6.UKONSCodeFromFeatureID(f.FeatureID()); ok {
+				return code
+			}
+		}
 	}
 	return fmt.Sprintf("%d", f.FeatureID().Value)
 }


### PR DESCRIPTION
Make it possible to import 2022 census boundaries by increasing the buffer size for encoding features, and adding a command line flag to use the 2022 ID namespace. In passing, make tab copy a suggestion with sending it in the b6 UX.