### PR TITLE
Batch transformations to support the ingestion of large shapefiles.

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -260,8 +260,9 @@ function setupMap(state, styles) {
             if (feature.get("layer") == "road") {
                 const width = roadWidth(feature, resolution);
                 if (width > 0) {
+                    const id = idKeyFromFeature(feature);
                     if (state.featureColours) {
-                        const colour = state.featureColours[idKeyFromFeature(feature)];
+                        const colour = state.featureColours[id];
                         if (colour) {
                             return new Style({
                                 stroke: new Stroke({
@@ -271,12 +272,21 @@ function setupMap(state, styles) {
                             });
                         }
                     }
-                    return new Style({
-                        stroke: new Stroke({
-                            color: "#e1e1ee",
-                            width: width
-                        })
-                    });
+                    if (state.highlighted[id]) {
+                        return new Style({
+                            stroke: new Stroke({
+                                color: styles["highlighted-road-fill"]["stroke"],
+                                width: width
+                            })
+                        });
+                    } else {
+                        return new Style({
+                            stroke: new Stroke({
+                                color: styles["road-fill"]["stroke"],
+                                width: width
+                            })
+                        });
+                    }
                 }
             }
         },
@@ -1190,6 +1200,8 @@ function newQueryStyle(state, styles) {
 }
 
 const Styles = [
+    "road-fill",
+    "highlighted-road-fill",
     "highlighted-point",
     "highlighted-path",
     "highlighted-area",

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -470,6 +470,14 @@ li div.collection-feature {
     display: none;
 }
 
+.palette > .road-fill {
+    stroke: #e1e1ee;
+}
+
+.palette > .highlighted-road-fill {
+    stroke: #37589f;
+}
+
 .palette > .highlighted-point {
     stroke: #37589f;
     fill: #5f8ef7;

--- a/src/diagonal.works/b6/graph/connectivity.go
+++ b/src/diagonal.works/b6/graph/connectivity.go
@@ -46,15 +46,23 @@ func BuildStreetNetwork(paths b6.PathFeatures, threshold s1.Angle, weights Weigh
 		}
 		stack = stack[0:0]
 		seen := make(map[b6.SegmentKey]struct{})
-		segments := w.Traverse(path.Feature(0).PointID())
+		first := path.Feature(0)
+		if first == nil {
+			continue
+		}
+		segments := w.Traverse(first.PointID())
 		var origin s2.Point
 		for segments.Next() {
 			segment := segments.Segment()
 			if segment.Feature.FeatureID() == path.FeatureID() {
 				seen[segment.ToKey()] = struct{}{}
-				origin = segment.FirstFeature().Point()
-				stack = append(stack, segment.LastFeature())
-				break
+				if first := segment.FirstFeature(); first != nil {
+					origin = first.Point()
+					if last := segment.LastFeature(); last != nil {
+						stack = append(stack, last)
+						break
+					}
+				}
 			}
 		}
 
@@ -76,7 +84,9 @@ func BuildStreetNetwork(paths b6.PathFeatures, threshold s1.Angle, weights Weigh
 							connected = true
 							break
 						} else {
-							stack = append(stack, segment.LastFeature())
+							if last := segment.LastFeature(); last != nil {
+								stack = append(stack, segment.LastFeature())
+							}
 							seen[segment.ToKey()] = struct{}{}
 						}
 					}

--- a/src/diagonal.works/b6/ingest/compact/encoding.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding.go
@@ -693,9 +693,9 @@ func MarshalGeometryEncodingAndLength(e GeometryEncoding, l int, buffer []byte) 
 	case GeometryEncodingReferences:
 		v = uint64(l) << 1
 	case GeometryEncodingLatLngs:
-		v = uint64(l)<<2 | 1
+		v = (uint64(l) << 2) | 1
 	case GeometryEncodingMixed:
-		v = uint64(l)<<2 | 3
+		v = (uint64(l) << 2) | 3
 	default:
 		panic("Unexpected GeometryEncoding")
 	}
@@ -845,7 +845,7 @@ func (g *PathGeometryMixed) LatLng(i int) (LatLng, bool) {
 }
 
 func (g *PathGeometryMixed) Marshal(primary Namespace, buffer []byte) int {
-	i := MarshalGeometryEncodingAndLength(GeometryEncodingLatLngs, len(g.Points), buffer)
+	i := MarshalGeometryEncodingAndLength(GeometryEncodingMixed, len(g.Points), buffer)
 	references := make(Bits, len(g.Points))
 	for j, r := range g.Points {
 		references[j] = r.Reference != ReferenceInvald

--- a/src/diagonal.works/b6/ingest/compact/encoding_test.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding_test.go
@@ -382,21 +382,26 @@ func TestGeometryMixedEncoding(t *testing.T) {
 
 	var buffer [128]byte
 	n := g.Marshal(nt.Encode(b6.NamespaceOSMNode), buffer[0:])
-	var gg PathGeometryMixed
-	nn := gg.Unmarshal(nt.Encode(b6.NamespaceOSMNode), buffer[0:n])
-	if len(g.Points) != len(g.Points) {
-		t.Errorf("Expected length %d, found %d", len(g.Points), len(gg.Points))
+
+	gg, nn := UnmarshalPathGeometry(nt.Encode(b6.NamespaceOSMNode), buffer[0:n])
+	if gg.Len() != len(g.Points) {
+		t.Errorf("Expected length %d, found %d", len(g.Points), gg.Len())
 	} else {
 		for i := range g.Points {
-			if !reflect.DeepEqual(g.Points[i], gg.Points[i]) {
-				t.Errorf("Expected %+v, found %+v at index %d", g.Points[i], gg.Points[i], i)
+			if ll, ok := gg.LatLng(i); ok {
+				if ll != g.Points[i].LatLng {
+					t.Errorf("Expected latlng %v, found %v", g.Points[i].LatLng, ll)
+				}
+			} else if id, ok := gg.PointID(i); ok {
+				if id != g.Points[i].Reference {
+					t.Errorf("Expected reference %v, found %v", g.Points[i].Reference, id)
+				}
 			}
 		}
 	}
 	if n != nn {
 		t.Errorf("Expected marshalled and unmarshaled lengths to be equal (%d vs %d)", n, nn)
 	}
-
 }
 
 func TestFullPointEncoding(t *testing.T) {

--- a/src/diagonal.works/b6/ingest/features.go
+++ b/src/diagonal.works/b6/ingest/features.go
@@ -65,6 +65,25 @@ func (t *Tags) RemoveTag(key string) {
 	*t = (*t)[0:w]
 }
 
+func (t *Tags) RemoveTags(keys []string) {
+	w := 0
+	for r := range *t {
+		var i int
+		for i = 0; i < len(keys); i++ {
+			if (*t)[r].Key == keys[i] {
+				break
+			}
+		}
+		if i == len(keys) {
+			if w != r {
+				(*t)[w] = (*t)[r]
+			}
+			w++
+		}
+	}
+	*t = (*t)[0:w]
+}
+
 func (t Tags) AllTags() []b6.Tag {
 	return t
 }

--- a/src/diagonal.works/b6/ingest/features_test.go
+++ b/src/diagonal.works/b6/ingest/features_test.go
@@ -7,6 +7,23 @@ import (
 	"diagonal.works/b6"
 )
 
+func TestRemoveTags(t *testing.T) {
+	tags := Tags{
+		{Key: "startNode", Value: "23A9FC0E-CBAB-425C-A7C9-B3356F17AF52"},
+		{Key: "roadNumber", Value: "A5202"},
+		{Key: "endNode", Value: "541F7F78-ED83-40D9-9488-3FD36D169B69"},
+		{Key: "class", Value: "A Road"},
+	}
+	tags.RemoveTags([]string{"startNode", "endNode"})
+	expected := Tags{
+		{Key: "roadNumber", Value: "A5202"},
+		{Key: "class", Value: "A Road"},
+	}
+	if !reflect.DeepEqual(expected, tags) {
+		t.Errorf("Expected %+v, found %+v", expected, tags)
+	}
+}
+
 func TestClonePoint(t *testing.T) {
 	caravan := osmPoint(2300722786, 51.5357237, -0.1253052)
 	caravan.AddTag(b6.Tag{Key: "name", Value: "Caravan"})

--- a/src/diagonal.works/b6/ingest/gdal/inputs.go
+++ b/src/diagonal.works/b6/ingest/gdal/inputs.go
@@ -1,0 +1,52 @@
+package gdal
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func isIngestable(filename string) bool {
+	return strings.HasSuffix(filename, ".shp") || strings.HasSuffix(filename, ".geojson")
+}
+
+func FindInputs(filename string, zipped bool, recurse bool, inputs []string) ([]string, error) {
+	s, err := os.Stat(filename)
+	if err != nil {
+		// If we can't stat the file, it may be because it's a gdal virtual
+		// path, like /vsizip/....
+		return append(inputs, filename), nil
+	}
+	if strings.HasSuffix(filename, ".zip") {
+		if zipped {
+			f, err := os.Open(filename)
+			if err != nil {
+				return nil, fmt.Errorf("can't open %s: %s", filename, err)
+			}
+			z, err := zip.NewReader(f, s.Size())
+			for _, zf := range z.File {
+				if isIngestable(zf.Name) {
+					inputs = append(inputs, fmt.Sprintf("/vsizip/%s/%s", filename, zf.Name))
+				}
+			}
+			f.Close()
+		}
+	} else if s.IsDir() {
+		entries, err := os.ReadDir(filename)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %s", filename, err)
+		}
+		for _, entry := range entries {
+			var err error
+			inputs, err = FindInputs(path.Join(filename, entry.Name()), zipped, recurse, inputs)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else if isIngestable(filename) {
+		inputs = append(inputs, filename)
+	}
+	return inputs, nil
+}

--- a/src/diagonal.works/b6/ingest/mutable.go
+++ b/src/diagonal.works/b6/ingest/mutable.go
@@ -425,7 +425,10 @@ func (m *modifiedTagsPath) Get(key string) b6.Tag {
 }
 
 func (m *modifiedTagsPath) Feature(i int) b6.PointFeature {
-	return &modifiedTagsPoint{m.PathFeature.Feature(i), m.tags}
+	if f := m.PathFeature.Feature(i); f != nil {
+		return &modifiedTagsPoint{f, m.tags}
+	}
+	return nil
 }
 
 type modifiedTagsArea struct {
@@ -439,6 +442,17 @@ func (m *modifiedTagsArea) AllTags() []b6.Tag {
 
 func (m *modifiedTagsArea) Get(key string) b6.Tag {
 	return modifyTag(m.AreaFeature, key, m.tags[m.AreaFeature.FeatureID()])
+}
+
+func (m *modifiedTagsArea) Feature(i int) []b6.PathFeature {
+	if f := m.AreaFeature.Feature(i); f != nil {
+		wrapped := make([]b6.PathFeature, len(f))
+		for j, p := range f {
+			wrapped[j] = &modifiedTagsPath{p, m.tags}
+		}
+		return wrapped
+	}
+	return nil
 }
 
 type modifiedTagsRelation struct {

--- a/src/diagonal.works/b6/ui/blocks.go
+++ b/src/diagonal.works/b6/ui/blocks.go
@@ -87,7 +87,6 @@ func (f *FeatureBlockJSON) Fill(feature b6.Feature, w b6.World) {
 				b.Fill(point)
 				f.Points = append(f.Points, b)
 			} else {
-				f.Points = append(f.Points)
 				f.Points = append(f.Points, StringBlockJSON{Type: "string", Value: pointToExpression(path.Point(i))})
 			}
 		}

--- a/src/diagonal.works/b6/world.go
+++ b/src/diagonal.works/b6/world.go
@@ -119,6 +119,9 @@ const (
 	NamespaceUKONSBoundaries       Namespace = "statistics.gov.uk/datasets/regions"
 	NamespaceGBUPRN                Namespace = "ordnancesurvey.co.uk/uprn"
 	NamespaceGBOSTerrain50Contours Namespace = "ordnancesurvey.co.uk/terrain-50/contours"
+	NamespaceGBOSOpenRoadsLinks    Namespace = "ordnancesurvey.co.uk/os-open-roads/links"
+	NamespaceGBOSOpenRoadsNodes    Namespace = "ordnancesurvey.co.uk/os-open-roads/nodes"
+	NamespaceGBOSMapBuildings      Namespace = "www.ordnancesurvey.co.uk/os-open-map-local/buildings"
 	NamespaceGBCodePoint           Namespace = "ordnancesurvey.co.uk/code-point"
 
 	// For GTFS transport data.


### PR DESCRIPTION
As some GDAL transform operations are slow, we previosuly read entire shapefiles into RAM before transforming them. This is impractical for large shapefiles, so we now transform features in batches.

Also correct some issues that surfaced while importing OS open data, for example, tag propagation on modified features.