### PR TITLE
Support merging changes, and parsing geojson files.

### DIFF
--- a/src/diagonal.works/b6/api/collections.go
+++ b/src/diagonal.works/b6/api/collections.go
@@ -73,6 +73,7 @@ type FeatureIDStringStringPairCollection Collection
 type AnyFloatCollection Collection
 type AnyGeometryCollection Collection
 type AnyRenderableCollection Collection
+type AnyChangeCollection Collection
 
 type ArrayAnyCollection struct {
 	Keys   []interface{}
@@ -369,39 +370,37 @@ var _ Collection = &ArrayPathFeatureCollection{}
 var _ Countable = &ArrayPathFeatureCollection{}
 
 type ArrayAreaCollection struct {
-	Keys   []string
-	Values []b6.Area
-	i      int
+	Areas []b6.Area
+	i     int
 }
 
-func (a *ArrayAreaCollection) Count() int { return len(a.Keys) }
+func (a *ArrayAreaCollection) Count() int { return len(a.Areas) }
 
 func (a *ArrayAreaCollection) Begin() CollectionIterator {
 	return &ArrayAreaCollection{
-		Keys:   a.Keys,
-		Values: a.Values,
+		Areas: a.Areas,
 	}
 }
 
 func (a *ArrayAreaCollection) Key() interface{} {
-	return a.StringKey()
+	return a.IntKey()
 }
 
 func (a *ArrayAreaCollection) Value() interface{} {
 	return a.AreaValue()
 }
 
-func (a *ArrayAreaCollection) StringKey() string {
-	return a.Keys[a.i-1]
+func (a *ArrayAreaCollection) IntKey() int {
+	return a.i - 1
 }
 
 func (a *ArrayAreaCollection) AreaValue() b6.Area {
-	return a.Values[a.i-1]
+	return a.Areas[a.i-1]
 }
 
 func (a *ArrayAreaCollection) Next() (bool, error) {
 	a.i++
-	return a.i <= len(a.Keys), nil
+	return a.i <= len(a.Areas), nil
 }
 
 var _ Collection = &ArrayAreaCollection{}

--- a/src/diagonal.works/b6/api/functions/change.go
+++ b/src/diagonal.works/b6/api/functions/change.go
@@ -58,6 +58,25 @@ func removeTags(c *api.Context, collection api.FeatureIDStringCollection) (inges
 	return tags, nil
 }
 
+func mergeChanges(c *api.Context, collection api.AnyChangeCollection) (ingest.Change, error) {
+	i := collection.Begin()
+	merged := make(ingest.MergedChange, 0)
+	for {
+		ok, err := i.Next()
+		if err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		}
+		if c, ok := i.Value().(ingest.Change); ok {
+			merged = append(merged, c)
+		} else {
+			return nil, fmt.Errorf("Expected Change, found %T", i.Value())
+		}
+	}
+	return merged, nil
+}
+
 func withChange(c *api.Context, change ingest.Change, f func(c *api.Context) (interface{}, error)) (interface{}, error) {
 	modified := *c
 	m := ingest.NewMutableOverlayWorld(c.World)

--- a/src/diagonal.works/b6/api/functions/functions.go
+++ b/src/diagonal.works/b6/api/functions/functions.go
@@ -117,6 +117,7 @@ var functions = api.FunctionSymbols{
 	"add-point":    addPoint,
 	// geojson
 	"parse-geojson":         parseGeoJSON,
+	"parse-geojson-file":    parseGeoJSONFile,
 	"to-geojson":            toGeoJSON,
 	"to-geojson-collection": toGeoJSONCollection,
 	"import-geojson":        importGeoJSON,
@@ -127,11 +128,12 @@ var functions = api.FunctionSymbols{
 	"apply-to-area":         applyToArea,
 	"map-geometries":        mapGeometries,
 	// change
-	"add-tag":     addTag,
-	"add-tags":    addTags,
-	"remove-tag":  removeTag,
-	"remove-tags": removeTags,
-	"with-change": withChange,
+	"add-tag":       addTag,
+	"add-tags":      addTags,
+	"remove-tag":    removeTag,
+	"remove-tags":   removeTags,
+	"merge-changes": mergeChanges,
+	"with-change":   withChange,
 	// debug
 	"debug-tokens":    debugTokens,
 	"debug-all-query": debugAllQuery,

--- a/src/diagonal.works/b6/api/functions/geojson_test.go
+++ b/src/diagonal.works/b6/api/functions/geojson_test.go
@@ -18,7 +18,7 @@ func TestGeoJSON(t *testing.T) {
 	context := &api.Context{
 		World: granarySquare,
 	}
-	features, err := find(context, b6.Keyed{"#building"})
+	features, err := find(context, b6.Keyed{Key: "#building"})
 	if err != nil {
 		t.Errorf("Expected no error, found: %s", err)
 		return

--- a/src/diagonal.works/b6/api/protos.go
+++ b/src/diagonal.works/b6/api/protos.go
@@ -277,7 +277,7 @@ func ToProto(v interface{}) (*pb.NodeProto, error) {
 			},
 		}, nil
 	default:
-		panic(fmt.Sprintf("can't convert %T to proto", v))
+		return nil, fmt.Errorf("can't return values of type %T", v)
 	}
 }
 

--- a/src/diagonal.works/b6/cmd/b6-api/b6-api.go
+++ b/src/diagonal.works/b6/cmd/b6-api/b6-api.go
@@ -113,6 +113,8 @@ func collectionForType(t reflect.Type) Collection {
 		return Collection{Name: n, Key: "FeatureID", Value: "StringStringPair"}
 	case "FeatureIDFeatureIDCollection":
 		return Collection{Name: n, Key: "FeatureID", Value: "FeatureID"}
+	case "AnyChangeCollection":
+		return Collection{Name: n, Key: "any", Value: "Change"}
 	}
 	panic(fmt.Sprintf("Can't handle collection %s", t))
 }

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var filter func(g b6.Feature, c *api.Context) (bool, error)
+	var filter func(c *api.Context, g b6.Feature) (bool, error)
 	apiContext := functions.NewContext(b6.EmptyWorld{})
 	if *filterFlag != "" {
 		expression, err := api.ParseExpression(*filterFlag)
@@ -47,7 +47,7 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-		filter = func(f b6.Feature, c *api.Context) (bool, error) {
+		filter = func(c *api.Context, f b6.Feature) (bool, error) {
 			if p, ok := f.(b6.PointFeature); ok {
 				return crop.ContainsPoint(p.Point()), nil
 			}

--- a/src/diagonal.works/b6/ingest/gb/uprn/source.go
+++ b/src/diagonal.works/b6/ingest/gb/uprn/source.go
@@ -21,11 +21,11 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/io/filesystem"
 )
 
-type Filter func(f b6.Feature, c *api.Context) (bool, error)
+type Filter func(c *api.Context, f b6.Feature) (bool, error)
 
 type Source struct {
 	Filename string
-	Filter   func(f b6.Feature, c *api.Context) (bool, error)
+	Filter   Filter
 	Context  *api.Context
 	JoinTags ingest.JoinTags
 }
@@ -159,7 +159,7 @@ func filter(filter Filter, emit ingest.Emit, options ingest.ReadOptions, ctx *ap
 		var err error
 		keep := true
 		if p, ok := f.(*ingest.PointFeature); ok {
-			if keep, err = filter(point{p}, ctxs[goroutine]); err != nil {
+			if keep, err = filter(ctxs[goroutine], point{p}); err != nil {
 				return err
 			}
 		}

--- a/src/diagonal.works/b6/spatial.go
+++ b/src/diagonal.works/b6/spatial.go
@@ -336,7 +336,7 @@ func (i IntersectsFeature) toGeometryQuery(w World) Query {
 		case Path:
 			return IntersectsPolyline{f.Polyline()}
 		case Area:
-			return IntersectsMultiPolygon{f.MultiPolygon()}
+			return IntersectsMultiPolygon{MultiPolygon: f.MultiPolygon()}
 		}
 	}
 	return Empty{}
@@ -650,7 +650,7 @@ func NewQueryFromProto(p *pb.QueryProto) (Query, error) {
 	case *pb.QueryProto_IntersectsPolyline:
 		return IntersectsPolyline{PolylineProtoToS2Polyline(q.IntersectsPolyline)}, nil
 	case *pb.QueryProto_IntersectsMultiPolygon:
-		return IntersectsMultiPolygon{MultiPolygonProtoToS2MultiPolygon(q.IntersectsMultiPolygon)}, nil
+		return IntersectsMultiPolygon{MultiPolygon: MultiPolygonProtoToS2MultiPolygon(q.IntersectsMultiPolygon)}, nil
 	case *pb.QueryProto_Typed:
 		if q.Typed.Query != nil {
 			child, err := NewQueryFromProto(q.Typed.Query)

--- a/src/diagonal.works/b6/ui/blocks.go
+++ b/src/diagonal.works/b6/ui/blocks.go
@@ -729,6 +729,12 @@ func fillResponseFromResult(response *BlockResponseJSON, result interface{}, rul
 				GeoJSON: r,
 			}
 			response.Blocks = append(response.Blocks, block)
+		case *geojson.Geometry:
+			block := GeometryBlockJSON{
+				Type:    "geojson-feature",
+				GeoJSON: geojson.NewFeatureWithGeometry(*r),
+			}
+			response.Blocks = append(response.Blocks, block)
 		case string:
 			response.Blocks = append(response.Blocks, StringBlockJSON{Type: "string-result", Value: r})
 		case b6.Point:


### PR DESCRIPTION
In passing, turn panics into errors when we can't convert a value we're trying to return over GRPC, correct loop inversion when parsing geojson, correct filtering for UPRN import following the Context parameter position switch, and render geojson objects that are plain geometries rather than features.

Fixes #60.