### PR TITLE
Support map() with functions that return a literal.

### DIFF
--- a/python/diagonal_b6/b6_test.py
+++ b/python/diagonal_b6/b6_test.py
@@ -472,12 +472,20 @@ class B6Test(unittest.TestCase):
         self.assertGreater(area, 2400.0)
         self.assertLess(area, 2500.0)
 
-    def test_evaluate_with_changed_world(self):
+    def test_reachable_with_changed_world(self):
         close_road = b6.remove_tag(b6.osm_way_id(STABLE_STREET_BRIDGE_ID), "#highway")
         reachable = b6.find_point(b6.osm_node_id(STABLE_STREET_BRIDGE_SOUTH_END_ID)).reachable("walk", 200.0, b6.keyed("#amenity")).get_string("name")
         before = len(self.connection(reachable))
         after = len(self.connection(b6.with_change(close_road, lambda: reachable)))
         self.assertGreater(before, after)
+
+    def test_remove_tags(self):
+        roads = b6.find(b6.keyed("#highway"))
+        before = self.connection(roads.count())
+        close_roads = b6.remove_tags(roads.map(lambda road: "#highway"))
+        after = self.connection(b6.with_change(close_roads, lambda: roads.count()))
+        self.assertGreater(before, 0)
+        self.assertEqual(after, 0)
 
     def test_merge_changes(self):
         roads = b6.find(b6.keyed("#highway"))

--- a/python/diagonal_b6/features.py
+++ b/python/diagonal_b6/features.py
@@ -172,7 +172,7 @@ class RelationMember:
 def from_id_proto(p):
     return FeatureID(p.type, p.namespace, p.value)
 
-expression.register_literal("featureIDValue", from_id_proto)
+expression.register_literal_from_proto("featureIDValue", from_id_proto)
 
 def from_applied_change_proto(change):
     applied = {}
@@ -180,7 +180,7 @@ def from_applied_change_proto(change):
         applied[from_id_proto(change.original[i])] = from_id_proto(change.modified[i])
     return applied
 
-expression.register_literal("appliedChangeValue", from_applied_change_proto)
+expression.register_literal_from_proto("appliedChangeValue", from_applied_change_proto)
 
 def id_to_proto(id):
     pb = features_pb2.FeatureIDProto()
@@ -218,7 +218,7 @@ def from_proto(p):
         return None
     raise Exception("Unexpected feature %s" % (p,))
 
-expression.register_literal("featureValue", from_proto)
+expression.register_literal_from_proto("featureValue", from_proto)
 
 def osm_node_id(id):
     return FeatureID(FEATURE_TYPE_POINT, NAMESPACE_OSM_NODE, id)

--- a/python/diagonal_b6/generate_api.py
+++ b/python/diagonal_b6/generate_api.py
@@ -6,6 +6,14 @@ import json
 from copy import copy
 from datetime import datetime
 
+SPECIAL_FUNCTIONS = ("map", "filter")
+
+COLLECTION_PARENTS = {
+    "PointFeatureCollection": "PointCollection",
+    "PathFeatureCollection": "PathCollection",
+    "AreaFeatureCollection": "AreaCollection",
+}
+
 def name_for_function(name):
     if name in ["or", "and"]:
         return name + "_"
@@ -47,6 +55,13 @@ def name_for_collection_of_result(t, collections):
         if key == "any" and value == t:
             return name_for_result(name)
     return "CollectionResult"
+
+BUILTIN_RESULTS = {
+    str: name_for_result("string"),
+    int: name_for_result("int"),
+    float: name_for_result("float64"),
+    bool: name_for_result("bool"),
+}
 
 def output_traits(t, functions, collections, hints, parents):
     if len(parents.get(t, [])) > 0:
@@ -114,14 +129,6 @@ def output_function_arg_result(t, hints):
     print("        raise NotImplementedError()")
     print("")
 
-SPECIAL_FUNCTIONS = ("map", "filter")
-
-COLLECTION_PARENTS = {
-    "PointFeatureCollection": "PointCollection",
-    "PathFeatureCollection": "PathCollection",
-    "AreaFeatureCollection": "AreaCollection",
-}
-
 def ancestors(t, parents):
     queue = copy(parents.get(t, []))
     ancestors = []
@@ -140,7 +147,7 @@ def main():
     print("from typing import Callable")
     print("")
     print("import diagonal_b6.expression")
-    print("from diagonal_b6.expression import Call, Symbol, Lambda, Result")
+    print("from diagonal_b6.expression import Call, Symbol, Lambda, Result, register_builtin_result")
     print("")
     print("VERSION = %s" % repr(api["Version"]))
     print("")
@@ -227,6 +234,9 @@ def main():
                 print("    args.extend(a%d)" % (len(f["Args"]) - 1))
             print("    return %s(Call(Symbol(%s), args))" % (name_for_result(f["Result"]), repr(f["Name"])))
         print("")
+
+    for type, result in BUILTIN_RESULTS.items():
+        print("register_builtin_result(%s,%s)" % (type.__name__, result))
 
 if __name__ == "__main__":
     main()

--- a/python/diagonal_b6/geometry.py
+++ b/python/diagonal_b6/geometry.py
@@ -6,7 +6,7 @@ from diagonal_b6 import geometry_pb2
 def from_point_proto(p):
     return (float(p.lat_e7) / 1e7, float(p.lng_e7) / 1e7)
 
-expression.register_literal("pointValue", from_point_proto)
+expression.register_literal_from_proto("pointValue", from_point_proto)
 
 def to_point_proto(ll):
     p = geometry_pb2.PointProto()
@@ -17,12 +17,12 @@ def to_point_proto(ll):
 def from_polyline_proto(p):
     return Polyline(p)
 
-expression.register_literal("pathValue", from_polyline_proto)
+expression.register_literal_from_proto("pathValue", from_polyline_proto)
 
 def from_multipolygon_proto(p):
     return MultiPolygon(p)
 
-expression.register_literal("areaValue", from_multipolygon_proto)
+expression.register_literal_from_proto("areaValue", from_multipolygon_proto)
 
 class Polyline(expression.Node):
 

--- a/python/diagonal_b6/query.py
+++ b/python/diagonal_b6/query.py
@@ -44,7 +44,7 @@ class Query(expression.Literal):
 def from_proto(pb):
     return Query(pb)
 
-expression.register_literal("queryValue", from_proto)
+expression.register_literal_from_proto("queryValue", from_proto)
 
 def union(*queries):
     q = api_pb2.QueryProto()


### PR DESCRIPTION
Support map() with functions that return a literal. Previously, we only supported b6 expressions, eg:
b6.map(buildings, lambda: building: building.area()) as we relied on inferring the type of the collection from the expression. To support literals, we build a map of literal types to the corresponding expression result type in the generated code.