### PR TITLE
Wrap the b6 JS in a module, for inclusion in other projects.

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1245,4 +1245,4 @@ function main() {
     d3.json("/bootstrap").then(response => setup(response));
 }
 
-main();
+export default main;

--- a/src/diagonal.works/b6/cmd/b6/js/main.js
+++ b/src/diagonal.works/b6/cmd/b6/js/main.js
@@ -1,0 +1,3 @@
+import main from "./b6.js";
+
+main();

--- a/src/diagonal.works/b6/cmd/b6/js/package.json
+++ b/src/diagonal.works/b6/cmd/b6/js/package.json
@@ -4,6 +4,9 @@
         "build": "rollup -c",
         "start": "rollup -c --watch"
     },
+    "files": ["b6.js"],
+    "main": "b6.js",
+    "module": "b6.js",
     "dependencies": {
         "@rollup/plugin-commonjs": "^21.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/src/diagonal.works/b6/cmd/b6/js/rollup.config.js
+++ b/src/diagonal.works/b6/cmd/b6/js/rollup.config.js
@@ -2,13 +2,13 @@ import resolve from "@rollup/plugin-node-resolve";
 import cjs from "@rollup/plugin-commonjs";
 
 export default {
-    input: "b6.js",
+    input: "main.js",
     output: {
         file: "bundle.js",
         format: "iife",
     },
 	plugins: [
-		resolve(),
+        resolve(),
         cjs()
     ]
 };


### PR DESCRIPTION
Wrap the b6 JS in a module, for inclusion in other projects. This change doesn't introduce a sane API, rather just adds the necessary build infrastructure.