### PR TITLE
Refactor some tests:

### DIFF
--- a/src/diagonal.works/b6/api/functions/access_test.go
+++ b/src/diagonal.works/b6/api/functions/access_test.go
@@ -6,20 +6,16 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/ingest"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestBuildingAccessibility(t *testing.T) {
-	w := camden.BuildGranarySquareForTests(t)
-	if w == nil {
-		return
-	}
+	w := testcamden.BuildGranarySquare(t)
 	m := ingest.NewMutableOverlayWorld(w)
 
-	origin := b6.FindAreaByID(camden.LightermanID, m)
+	origin := b6.FindAreaByID(testcamden.LightermanID, m)
 	if origin == nil {
-		t.Errorf("Failed to find origin")
-		return
+		t.Fatalf("FindAreaByID(LightermanID) failed to find origin")
 	}
 
 	origins := &api.ArrayFeatureCollection{
@@ -29,21 +25,19 @@ func TestBuildingAccessibility(t *testing.T) {
 	c := api.Context{World: m}
 	accessible, err := buildingAccess(&c, origins, 1000, "walking")
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("buildingAccess() failed with: %v", err)
 	}
 
 	count := 0
 	i := accessible.Begin()
 	for {
 		if ok, err := i.Next(); err != nil {
-			t.Errorf("Expected no error, found: %s", err)
-			return
+			t.Fatalf("i.Next() failed with: %v", err)
 		} else if !ok {
 			break
 		}
 		if k := i.Key().(b6.FeatureID); k != origin.FeatureID() {
-			t.Errorf("Expected origin %s, found %s", origin.FeatureID(), k)
+			t.Errorf("i.Key() got %s, want %s", k, origin.FeatureID())
 		}
 		f := m.FindFeatureByID(i.Value().(b6.FeatureID))
 		if b := f.Get("#building"); !b.IsValid() {
@@ -52,6 +46,6 @@ func TestBuildingAccessibility(t *testing.T) {
 		count++
 	}
 	if count < 2 {
-		t.Errorf("Expected at least two accessible buildings")
+		t.Errorf("got at %d accessible buildings, want at least two", count)
 	}
 }

--- a/src/diagonal.works/b6/api/functions/features_test.go
+++ b/src/diagonal.works/b6/api/functions/features_test.go
@@ -7,18 +7,18 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/ingest"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 
 	"github.com/golang/geo/s2"
 )
 
 func TestAllTags(t *testing.T) {
-	w := camden.BuildCamdenForTests(t)
+	w := testcamden.BuildCamden(t)
 	if w == nil {
 		return
 	}
 
-	vermuteria := b6.FindPointByID(camden.VermuteriaID, w)
+	vermuteria := b6.FindPointByID(testcamden.VermuteriaID, w)
 	if vermuteria == nil {
 		t.Errorf("Failed to find expected test point")
 		return
@@ -56,13 +56,13 @@ func TestAllTags(t *testing.T) {
 }
 
 func TestFindAreasContainingPoints(t *testing.T) {
-	w := camden.BuildCamdenForTests(t)
+	w := testcamden.BuildCamden(t)
 	if w == nil {
 		return
 	}
 	m := ingest.NewMutableOverlayWorld(w)
 
-	vermuteria := b6.FindPointByID(camden.VermuteriaID, m)
+	vermuteria := b6.FindPointByID(testcamden.VermuteriaID, m)
 	if vermuteria == nil {
 		t.Errorf("Failed to find expected test point")
 		return
@@ -72,7 +72,7 @@ func TestFindAreasContainingPoints(t *testing.T) {
 	context := api.Context{
 		World: m,
 	}
-	found, err := findAreasContainingPoints(&context, points, b6.Keyed{"#shop"})
+	found, err := findAreasContainingPoints(&context, points, b6.Keyed{Key: "#shop"})
 	if err != nil {
 		t.Errorf("Expected no error, found: %s", err)
 	}
@@ -83,8 +83,8 @@ func TestFindAreasContainingPoints(t *testing.T) {
 		return
 	}
 
-	if _, ok := areas[camden.CoalDropsYardEnclosureID]; !ok {
-		t.Errorf("Expected points to be contained within %s", camden.CoalDropsYardEnclosureID.FeatureID())
+	if _, ok := areas[testcamden.CoalDropsYardEnclosureID]; !ok {
+		t.Errorf("Expected points to be contained within %s", testcamden.CoalDropsYardEnclosureID.FeatureID())
 	}
 }
 
@@ -131,13 +131,13 @@ func TestPoints(t *testing.T) {
 }
 
 func TestSamplePointsAlongPaths(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 
 	context := &api.Context{
 		World: granarySquare,
 	}
 
-	paths, err := findPathFeatures(context, b6.Keyed{"#highway"})
+	paths, err := findPathFeatures(context, b6.Keyed{Key: "#highway"})
 	if err != nil {
 		t.Errorf("Expected no error, found: %s", err)
 		return
@@ -169,13 +169,13 @@ func TestSamplePointsAlongPaths(t *testing.T) {
 }
 
 func TestSamplePointsAlongPathsIsConsistentAcrossRuns(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 
 	context := &api.Context{
 		World: granarySquare,
 	}
 
-	paths, err := findPathFeatures(context, b6.Keyed{"#highway"})
+	paths, err := findPathFeatures(context, b6.Keyed{Key: "#highway"})
 	if err != nil {
 		t.Errorf("Expected no error, found: %s", err)
 		return
@@ -218,7 +218,7 @@ func TestSamplePointsAlongPathsIsConsistentAcrossRuns(t *testing.T) {
 }
 
 func TestJoin(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 
 	context := &api.Context{
 		World: granarySquare,
@@ -245,7 +245,7 @@ func TestJoin(t *testing.T) {
 }
 
 func TestOrderedJoin(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	path := b6.FindPathByID(ingest.FromOSMWayID(377974549), granarySquare)
 	midVertex := path.Len() / 2
 
@@ -276,7 +276,7 @@ func TestOrderedJoin(t *testing.T) {
 }
 
 func TestInterpolate(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	context := &api.Context{
 		World: granarySquare,
 	}
@@ -298,7 +298,7 @@ func TestInterpolate(t *testing.T) {
 }
 
 func TestOrderedJoinPathsWithNoSharedPoint(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	path := b6.FindPathByID(ingest.FromOSMWayID(377974549), granarySquare)
 	midVertex := path.Len() / 2
 

--- a/src/diagonal.works/b6/api/functions/geojson_test.go
+++ b/src/diagonal.works/b6/api/functions/geojson_test.go
@@ -6,11 +6,11 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/geojson"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestGeoJSON(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}

--- a/src/diagonal.works/b6/api/functions/geometry_test.go
+++ b/src/diagonal.works/b6/api/functions/geometry_test.go
@@ -6,11 +6,11 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/ingest"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestDistanceToPointMeters(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	context := &api.Context{
 		World: granarySquare,
 	}

--- a/src/diagonal.works/b6/api/functions/math_test.go
+++ b/src/diagonal.works/b6/api/functions/math_test.go
@@ -9,7 +9,7 @@ import (
 
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestPercentiles(t *testing.T) {
@@ -53,7 +53,7 @@ func TestPercentiles(t *testing.T) {
 }
 
 func TestCount(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -72,7 +72,7 @@ func TestCount(t *testing.T) {
 		t.Errorf("Expected no error, found: %s", err)
 		return
 	}
-	expected := camden.BuildingsInGranarySquare
+	expected := testcamden.BuildingsInGranarySquare
 	if count != expected {
 		t.Errorf("Expected count to return %d, found %d", expected, count)
 	}

--- a/src/diagonal.works/b6/api/functions/s2_test.go
+++ b/src/diagonal.works/b6/api/functions/s2_test.go
@@ -5,19 +5,19 @@ import (
 
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 
 	"github.com/golang/geo/s2"
 )
 
 func TestS2Points(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 
 	context := &api.Context{
 		World: granarySquare,
 	}
 
-	area := b6.FindAreaByID(camden.GranarySquareID, granarySquare)
+	area := b6.FindAreaByID(testcamden.GranarySquareID, granarySquare)
 	if area == nil {
 		t.Errorf("Failed to find Granary Square")
 		return

--- a/src/diagonal.works/b6/api/functions/sightline_test.go
+++ b/src/diagonal.works/b6/api/functions/sightline_test.go
@@ -8,14 +8,14 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/geojson"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 
 	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 )
 
 func TestSightlineFunction(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 
 	context := &api.Context{
 		World: granarySquare,
@@ -51,7 +51,7 @@ func TestSightline(t *testing.T) {
 }
 
 func ValidateSightline(computeSightline func(from s2.Point, radius s1.Angle, w b6.World) *s2.Polygon, name string, t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -97,7 +97,7 @@ func ValidateSightline(computeSightline func(from s2.Point, radius s1.Angle, w b
 }
 
 func ValidateSightlineInsideBuilding(computeSightline func(from s2.Point, radius s1.Angle, w b6.World) *s2.Polygon, name string, t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -111,7 +111,7 @@ func TestSightlineDoesntHaveSpikes(t *testing.T) {
 	// 'spikes' occur in the sighline polygon when numerical accuracy issues
 	// lead to a very thin field of visibility incorrectly appearing in the
 	// join between two edges of a building. We filter these out.
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}

--- a/src/diagonal.works/b6/api/functions/vm_test.go
+++ b/src/diagonal.works/b6/api/functions/vm_test.go
@@ -9,13 +9,13 @@ import (
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/geojson"
 	"diagonal.works/b6/ingest"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 
 	"github.com/golang/geo/s2"
 )
 
 func TestEvaluate(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -27,7 +27,7 @@ func TestEvaluate(t *testing.T) {
 }
 
 func TestMapWithVM(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -52,7 +52,7 @@ func TestMapWithVM(t *testing.T) {
 }
 
 func TestMapParallelWithVM(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -77,7 +77,7 @@ func TestMapParallelWithVM(t *testing.T) {
 }
 
 func TestMapWithVMAndPartialFunction(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -102,7 +102,7 @@ func TestMapWithVMAndPartialFunction(t *testing.T) {
 }
 
 func TestMapItems(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -131,7 +131,7 @@ func TestMapItems(t *testing.T) {
 }
 
 func TestWithVMAndPipelineInLamba(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -157,14 +157,14 @@ func TestWithVMAndPipelineInLamba(t *testing.T) {
 		for _, n := range filled {
 			total += n
 		}
-		if total != camden.BuildingsInGranarySquare {
-			t.Errorf("Expected values for %d buildings, found %d", camden.BuildingsInGranarySquare, total)
+		if total != testcamden.BuildingsInGranarySquare {
+			t.Errorf("Expected values for %d buildings, found %d", testcamden.BuildingsInGranarySquare, total)
 		}
 	}
 }
 
 func TestReturnFunctions(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -192,7 +192,7 @@ func TestReturnFunctions(t *testing.T) {
 }
 
 func TestPassSpecificFunctionWhereGenericNeeded(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -204,7 +204,7 @@ func TestPassSpecificFunctionWhereGenericNeeded(t *testing.T) {
 }
 
 func TestInterfaceConversionForArguments(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -226,7 +226,7 @@ func TestInterfaceConversionForArguments(t *testing.T) {
 }
 
 func TestConvertQueryToFunctionReturningBool(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -257,12 +257,12 @@ func TestConvertQueryToFunctionReturningBool(t *testing.T) {
 }
 
 func TestConvertQueryToFunctionReturningBoolWithSpecificFeature(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
 	apply := func(c *api.Context, f func(*api.Context, b6.PointFeature) (bool, error)) (bool, error) {
-		return f(c, b6.FindPointByID(ingest.FromOSMNodeID(camden.VermuteriaNode), c.World))
+		return f(c, b6.FindPointByID(ingest.FromOSMNodeID(testcamden.VermuteriaNode), c.World))
 	}
 	c := &api.Context{
 		World: granarySquare,

--- a/src/diagonal.works/b6/api/shell_test.go
+++ b/src/diagonal.works/b6/api/shell_test.go
@@ -7,7 +7,7 @@ import (
 
 	"diagonal.works/b6"
 	pb "diagonal.works/b6/proto"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
@@ -957,8 +957,8 @@ func TestToFeatureIDExpression(t *testing.T) {
 		ID    b6.FeatureID
 		Token string
 	}{
-		{camden.StableStreetBridgeID.FeatureID(), "/w/140633010"},
-		{camden.LightermanID.FeatureID(), "/a/427900370"},
+		{testcamden.StableStreetBridgeID.FeatureID(), "/w/140633010"},
+		{testcamden.LightermanID.FeatureID(), "/a/427900370"},
 		{b6.MakePointID(b6.NamespaceGBUPRN, 116000008).FeatureID(), "/gb/uprn/116000008"},
 		{b6.FeatureIDFromUKONSCode("E01000953", 2011, b6.FeatureTypeArea).FeatureID(), "/uk/ons/2011/E01000953"},
 	}

--- a/src/diagonal.works/b6/encoding/uint64map_test.go
+++ b/src/diagonal.works/b6/encoding/uint64map_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 const (
@@ -78,7 +78,7 @@ func TestUint64Map(t *testing.T) {
 
 func ValidateFillTagged(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 	tagged := make([]Tagged, 0, 1)
-	tagged = m.FillTagged(uint64(camden.VermuteriaNode), tagged)
+	tagged = m.FillTagged(uint64(testcamden.VermuteriaNode), tagged)
 	if len(tagged) != 2 {
 		t.Errorf("Expected 2 entries, found %d", len(tagged))
 	} else {
@@ -133,7 +133,7 @@ func ValidateEachItem(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 			t.Errorf("Expected to see id %d", id)
 		}
 	}
-	if name, ok := found[uint64(camden.VermuteriaNode)]; !ok || name != "Vermuteria" {
+	if name, ok := found[uint64(testcamden.VermuteriaNode)]; !ok || name != "Vermuteria" {
 		t.Errorf("Expected to iterate past Vermuteria")
 	}
 }
@@ -160,18 +160,18 @@ func ValidateIterator(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 		found[i.ID()] = string(i.Data(0))
 	}
 
-	if name, ok := found[uint64(camden.VermuteriaNode)]; !ok || name != "Vermuteria" {
+	if name, ok := found[uint64(testcamden.VermuteriaNode)]; !ok || name != "Vermuteria" {
 		t.Errorf("Expected to iterate past Vermuteria")
 	}
 }
 
 func ValidateFindFirst(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
-	v := m.FindFirstWithTag(uint64(camden.VermuteriaNode), TestNameTag)
+	v := m.FindFirstWithTag(uint64(testcamden.VermuteriaNode), TestNameTag)
 	if v == nil || string(v) != "Vermuteria" {
 		t.Errorf("Expected to lookup name for Vermuteria, found %s", v)
 	}
 
-	tag, ok := m.FindFirst(uint64(camden.VermuteriaNode))
+	tag, ok := m.FindFirst(uint64(testcamden.VermuteriaNode))
 	if !ok {
 		t.Errorf("Expected to find name or amenity for Vermuteria")
 	} else if (tag.Tag == TestNameTag && string(tag.Data) != "Vermuteria") || (tag.Tag == TestAmenityTag && string(tag.Data) != "cafe") {

--- a/src/diagonal.works/b6/graph/connectivity_test.go
+++ b/src/diagonal.works/b6/graph/connectivity_test.go
@@ -6,11 +6,11 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/osm"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestBuildStreetNetwork(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -283,7 +283,7 @@ func TestConnectGranarySquare(t *testing.T) {
 		{"ConnectUsingExistingPoints", ValidateConnectUsingExistingPoints},
 	}
 
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}

--- a/src/diagonal.works/b6/graph/graph_test.go
+++ b/src/diagonal.works/b6/graph/graph_test.go
@@ -7,11 +7,11 @@ import (
 	"diagonal.works/b6"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/osm"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestShortestPath(t *testing.T) {
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}
@@ -172,7 +172,7 @@ func TestShortestPathTakesIntoAccountOneWayStreets(t *testing.T) {
 	// Tests that shortest path routing doesn't take you down one way streets. The
 	// test case is the road junction here: 51.5452312, -0.1415558, where the West
 	// hand fork is shorter when heading South, but oneway in the wrong direction.
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}
@@ -264,7 +264,7 @@ func TestInterpolateShortestPathDistances(t *testing.T) {
 }
 
 func TestAccessibility(t *testing.T) {
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}
@@ -310,7 +310,7 @@ func TestAccessibility(t *testing.T) {
 }
 
 func TestBusWeights(t *testing.T) {
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}
@@ -338,12 +338,12 @@ func TestBusWeights(t *testing.T) {
 }
 
 func TestShortestPathFromConnectedBuildingWithNoEntrance(t *testing.T) {
-	w := camden.BuildCamdenForTests(t)
+	w := testcamden.BuildCamden(t)
 	if w == nil {
 		return
 	}
 
-	lighterman := b6.FindAreaByID(ingest.AreaIDFromOSMWayID(camden.LightermanWay), w)
+	lighterman := b6.FindAreaByID(ingest.AreaIDFromOSMWayID(testcamden.LightermanWay), w)
 	if lighterman == nil {
 		t.Error("Expected to find The Lighterman")
 		return
@@ -370,13 +370,13 @@ func TestShortestPathFromConnectedBuildingWithNoEntrance(t *testing.T) {
 	search.ExpandSearch(100.0, weights, Points, w)
 	distances := search.PointDistances()
 
-	if _, ok := distances[camden.StableStreetBridgeNorthEndID]; !ok {
+	if _, ok := distances[testcamden.StableStreetBridgeNorthEndID]; !ok {
 		t.Errorf("Expected to find a route to Stable Street bridge")
 	}
 }
 
 func TestShortestPathFromBuildingWithMoreThanOneEntrance(t *testing.T) {
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}
@@ -425,7 +425,7 @@ func TestShortestPathFromBuildingWithMoreThanOneEntrance(t *testing.T) {
 }
 
 func TestShortestPathReturnsBuildings(t *testing.T) {
-	w := camden.BuildCamdenForTests(t)
+	w := testcamden.BuildCamden(t)
 	if w == nil {
 		return
 	}
@@ -439,7 +439,7 @@ func TestShortestPathReturnsBuildings(t *testing.T) {
 	s := NewShortestPathSearchFromPoint(from.PointID())
 	s.ExpandSearch(500.0, SimpleWeights{}, PointsAndAreas, w)
 
-	expected := ingest.AreaIDFromOSMWayID(camden.CoalDropsYardWestBuildingWay)
+	expected := ingest.AreaIDFromOSMWayID(testcamden.CoalDropsYardWestBuildingWay)
 	if _, ok := s.AreaDistances()[expected]; !ok {
 		t.Errorf("Expected to find building when searching from a point")
 	}
@@ -452,14 +452,14 @@ func TestShortestPathReturnsBuildings(t *testing.T) {
 	s = NewShortestPathSearchFromBuilding(theGranary, weights, w)
 	s.ExpandSearch(500.0, weights, PointsAndAreas, w)
 
-	expected = ingest.AreaIDFromOSMWayID(camden.LightermanWay)
+	expected = ingest.AreaIDFromOSMWayID(testcamden.LightermanWay)
 	if _, ok := s.AreaDistances()[expected]; !ok {
 		t.Errorf("Expected to find building when searching from a building")
 	}
 }
 
 func TestElevationWeights(t *testing.T) {
-	camden := camden.BuildCamdenForTests(t)
+	camden := testcamden.BuildCamden(t)
 	if camden == nil {
 		return
 	}

--- a/src/diagonal.works/b6/grpc/service_test.go
+++ b/src/diagonal.works/b6/grpc/service_test.go
@@ -10,7 +10,7 @@ import (
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/ingest"
 	pb "diagonal.works/b6/proto"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func findInTagsProto(tags []*pb.TagProto, key string) (string, bool) {
@@ -32,7 +32,7 @@ func TestGRPC(t *testing.T) {
 		{"RejectRequestsWithDifferentMajorVersion", ValidateRejectRequestsWithDifferentMajorVersion},
 	}
 
-	base := camden.BuildGranarySquareForTests(t)
+	base := testcamden.BuildGranarySquare(t)
 	if base == nil {
 		return
 	}
@@ -60,7 +60,7 @@ func ValidateEvaluate(service pb.B6Server, w b6.World, t *testing.T) {
 		if node := response.GetResult(); node != nil {
 			if literal := node.GetLiteral(); literal != nil {
 				if collection := literal.GetCollectionValue(); collection != nil {
-					expected := camden.BuildingsInGranarySquare
+					expected := testcamden.BuildingsInGranarySquare
 					if len(collection.Values) != expected {
 						t.Errorf("Expected %d values, found %d", expected, len(collection.Values))
 					}

--- a/src/diagonal.works/b6/ingest/compact/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/compact/overlay_test.go
@@ -8,7 +8,7 @@ import (
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/osm"
 	"diagonal.works/b6/test"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestOverlayPathOnExistingWorld(t *testing.T) {
@@ -30,8 +30,8 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 	path := ingest.NewPathFeature(2)
 	path.PathID = b6.MakePathID(b6.NamespaceDiagonalAccessPoints, 42)
 	path.Tags.AddTag(b6.Tag{Key: "#highway", Value: "cycleway"})
-	path.SetPointID(0, ingest.FromOSMNodeID(camden.LightermanEntranceNode))
-	path.SetPointID(1, ingest.FromOSMNodeID(camden.StableStreetBridgeNorthEndNode))
+	path.SetPointID(0, ingest.FromOSMNodeID(testcamden.LightermanEntranceNode))
+	path.SetPointID(1, ingest.FromOSMNodeID(testcamden.StableStreetBridgeNorthEndNode))
 
 	w, err := NewWorldFromData(index)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 		t.Errorf("Expected to find overlaid path via FindFeatures")
 	}
 
-	ps := w.FindPathsByPoint(ingest.FromOSMNodeID(camden.LightermanEntranceNode))
+	ps := w.FindPathsByPoint(ingest.FromOSMNodeID(testcamden.LightermanEntranceNode))
 	found = false
 	for ps.Next() {
 		if ps.FeatureID() == path.FeatureID() {

--- a/src/diagonal.works/b6/renderer/query_test.go
+++ b/src/diagonal.works/b6/renderer/query_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"diagonal.works/b6"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 	"github.com/golang/geo/s2"
 )
 
 func TestQueryRenderer(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}

--- a/src/diagonal.works/b6/renderer/renderer_test.go
+++ b/src/diagonal.works/b6/renderer/renderer_test.go
@@ -8,7 +8,7 @@ import (
 	"diagonal.works/b6/api"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/osm"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 	"github.com/golang/geo/s2"
 )
 
@@ -40,7 +40,7 @@ func TestFillColourFromFeature(t *testing.T) {
 }
 
 func TestFeaturesHaveTagsForNamespaceAndID(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
@@ -53,7 +53,7 @@ func TestFeaturesHaveTagsForNamespaceAndID(t *testing.T) {
 	}
 
 	expected := "19813dd2"
-	if id, _ := strconv.ParseUint(expected, 16, 64); osm.WayID(id) != camden.LightermanWay {
+	if id, _ := strconv.ParseUint(expected, 16, 64); osm.WayID(id) != testcamden.LightermanWay {
 		t.Errorf("Unexpected hex ID for LightermanWay. Test data changed?")
 		return
 	}
@@ -77,14 +77,14 @@ func TestFeaturesHaveTagsForNamespaceAndID(t *testing.T) {
 }
 
 func TestFeaturesAreOrderedByLayerTag(t *testing.T) {
-	granarySquare := camden.BuildGranarySquareForTests(t)
+	granarySquare := testcamden.BuildGranarySquare(t)
 	if granarySquare == nil {
 		return
 	}
 	mutable := ingest.NewMutableOverlayWorld(granarySquare)
 
 	// Add a roof terrace and second floor to the Lighterman
-	lighterman := b6.FindAreaByID(camden.LightermanID, mutable)
+	lighterman := b6.FindAreaByID(testcamden.LightermanID, mutable)
 	roof := ingest.NewAreaFeatureFromWorld(lighterman)
 	roof.AreaID = b6.MakeAreaID(b6.NamespacePrivate, 1)
 	roof.AddTag(b6.Tag{Key: "layer", Value: "2"})

--- a/src/diagonal.works/b6/test/data.go
+++ b/src/diagonal.works/b6/test/data.go
@@ -4,9 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
-
-	"diagonal.works/b6"
 )
 
 const (
@@ -26,12 +23,4 @@ func testDataDirectory() string {
 
 func Data(filename string) string {
 	return filepath.Join(testDataDirectory(), filename)
-}
-
-func FindFeatureByID(id b6.FeatureID, w b6.World, t *testing.T) b6.Feature {
-	feature := w.FindFeatureByID(id)
-	if feature == nil {
-		t.Errorf("Failed to find feature expected to be present in test data: %s", id)
-	}
-	return feature
 }

--- a/src/diagonal.works/b6/test/testcamden/camden.go
+++ b/src/diagonal.works/b6/test/testcamden/camden.go
@@ -1,7 +1,6 @@
-package camden
+package testcamden
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 
@@ -50,33 +49,29 @@ var (
 	camdenLock sync.Mutex
 )
 
-func BuildGranarySquareForTests(t *testing.T) b6.World {
+func BuildGranarySquare(t *testing.T) b6.World {
 	granarySquareLock.Lock()
 	defer granarySquareLock.Unlock()
 	if granarySquare == nil {
-		granarySquare = build(test.Data(test.GranarySquarePBF), t)
+		granarySquare = build(t, test.Data(test.GranarySquarePBF))
 	}
 	return granarySquare
 }
 
-func BuildCamdenForTests(t *testing.T) b6.World {
+func BuildCamden(t *testing.T) b6.World {
 	camdenLock.Lock()
 	defer camdenLock.Unlock()
 	if camden == nil {
-		camden = build(test.Data(test.CamdenPBF), t)
+		camden = build(t, test.Data(test.CamdenPBF))
 	}
 	return camden
 }
 
-func build(filename string, t *testing.T) b6.World {
+func build(t *testing.T, filename string) b6.World {
 	o := &ingest.BuildOptions{Cores: 2}
 	w, err := ingest.NewWorldFromPBFFile(filename, o)
 	if err != nil {
-		if t != nil {
-			t.Errorf("Failed to build world: %s", err)
-		} else {
-			panic(fmt.Sprintf("Failed to build world: %s", err))
-		}
+		t.Fatalf("Failed to build world: %v", err)
 	}
 	return w
 }

--- a/src/diagonal.works/b6/ui/blocks_test.go
+++ b/src/diagonal.works/b6/ui/blocks_test.go
@@ -11,11 +11,11 @@ import (
 	"diagonal.works/b6/api/functions"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/renderer"
-	"diagonal.works/b6/test/camden"
+	"diagonal.works/b6/test/testcamden"
 )
 
 func TestMatchingFunctions(t *testing.T) {
-	base := camden.BuildGranarySquareForTests(t)
+	base := testcamden.BuildGranarySquare(t)
 	w := ingest.NewMutableOverlayWorld(base)
 
 	handler := BlockHandler{


### PR DESCRIPTION
- Rename test/camden package to "testcamden" which makes it more
  obvious that this is only for testing. Remove the ForTests suffix.
- A few minor changes, mostly in transit_test.go:
  - Remove a few non-nil checks after the helper test methods are
    invoked; it doesn't seem like they're needed.
  - Use t.Fatal instead of "t.Error + return"; t.Fatal stops and
    fails the test.
  (These changes could be applied to other files, for consistency,
  but I've only applied them to transit_test.go as I was looking at
  a possible minor code change in one of the tested functions).
