### PR TITLE
Refactor tests:

### DIFF
--- a/src/diagonal.works/b6/api/functions/access_test.go
+++ b/src/diagonal.works/b6/api/functions/access_test.go
@@ -11,15 +11,11 @@ import (
 
 func TestBuildingAccessibility(t *testing.T) {
 	w := camden.BuildGranarySquareForTests(t)
-	if w == nil {
-		return
-	}
 	m := ingest.NewMutableOverlayWorld(w)
 
 	origin := b6.FindAreaByID(camden.LightermanID, m)
 	if origin == nil {
-		t.Errorf("Failed to find origin")
-		return
+		t.Fatal("Failed to find origin")
 	}
 
 	origins := &api.ArrayFeatureCollection{
@@ -29,17 +25,17 @@ func TestBuildingAccessibility(t *testing.T) {
 	c := api.Context{World: m}
 	accessible, err := buildingAccess(&c, origins, 1000, "walking")
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	count := 0
 	i := accessible.Begin()
 	for {
-		if ok, err := i.Next(); err != nil {
-			t.Errorf("Expected no error, found: %s", err)
-			return
-		} else if !ok {
+		ok, err := i.Next()
+		if err != nil {
+			t.Fatalf("Expected no error, found: %s", err)
+		}
+		if !ok {
 			break
 		}
 		if k := i.Key().(b6.FeatureID); k != origin.FeatureID() {
@@ -47,11 +43,11 @@ func TestBuildingAccessibility(t *testing.T) {
 		}
 		f := m.FindFeatureByID(i.Value().(b6.FeatureID))
 		if b := f.Get("#building"); !b.IsValid() {
-			t.Errorf("Expected a building")
+			t.Error("Expected a building")
 		}
 		count++
 	}
 	if count < 2 {
-		t.Errorf("Expected at least two accessible buildings")
+		t.Error("Expected at least two accessible buildings")
 	}
 }

--- a/src/diagonal.works/b6/api/functions/collections_test.go
+++ b/src/diagonal.works/b6/api/functions/collections_test.go
@@ -3,10 +3,10 @@ package functions
 import (
 	"fmt"
 	"math/rand"
-	"reflect"
 	"testing"
 
 	"diagonal.works/b6/api"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestTake(t *testing.T) {
@@ -24,14 +24,12 @@ func TestTake(t *testing.T) {
 	collection := &api.ArrayAnyFloatCollection{Keys: keys, Values: values}
 	took, err := take(&api.Context{}, collection, n)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	filled := make(map[interface{}]float64)
 	if err := api.FillMap(took, filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if n != len(filled) {
@@ -64,14 +62,12 @@ func TestTopFloat(t *testing.T) {
 	collection := &api.ArrayAnyFloatCollection{Keys: keys, Values: values}
 	selected, err := top(&api.Context{}, collection, n)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	filled := make([]float64, 0, n)
 	if err := api.FillSliceFromValues(selected, &filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if n != len(filled) {
@@ -105,14 +101,12 @@ func TestTopInt(t *testing.T) {
 	collection := &api.ArrayAnyIntCollection{Keys: keys, Values: values}
 	selected, err := top(&api.Context{}, collection, n)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	filled := make([]int, 0, n)
 	if err := api.FillSliceFromValues(selected, &filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if n != len(filled) {
@@ -155,17 +149,16 @@ func TestFilter(t *testing.T) {
 	collection := &api.ArrayAnyFloatCollection{Keys: keys, Values: values}
 	filtered, err := filter(&api.Context{}, collection, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	filled := make(map[interface{}]float64)
 	if err := api.FillMap(filtered, filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if len(filled) == 0 {
-		t.Errorf("Expected at least 1 value")
+		t.Fatalf("Expected at least 1 value")
 	} else {
 		for _, f := range filled {
 			if f <= limit {
@@ -183,20 +176,18 @@ func TestSumByKey(t *testing.T) {
 
 	byKey, err := sumByKey(&api.Context{}, collection)
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 	filled := make(map[string]int)
 	if err := api.FillMap(byKey, filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 	expected := map[string]int{
 		"population:total":    300,
 		"population:children": 50,
 	}
-	if !reflect.DeepEqual(expected, filled) {
-		t.Errorf("Expected %+v, found %+v", expected, filled)
+	if diff := cmp.Diff(expected, filled); diff != "" {
+		t.Errorf("Found diff (-want, +got):\n%s", diff)
 	}
 }
 
@@ -208,20 +199,18 @@ func TestCountValues(t *testing.T) {
 
 	counted, err := countValues(&api.Context{}, collection)
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 	filled := make(map[int]int)
 	if err := api.FillMap(counted, filled); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 	expected := map[int]int{
 		2: 2,
 		3: 1,
 	}
-	if !reflect.DeepEqual(expected, filled) {
-		t.Errorf("Expected %+v, found %+v", expected, filled)
+	if diff := cmp.Diff(expected, filled); diff != "" {
+		t.Errorf("Found diff (-want, +got):\n%s", diff)
 	}
 }
 
@@ -241,14 +230,12 @@ func TestFlatten(t *testing.T) {
 
 	flattened, err := flatten(&api.Context{}, &c)
 	if err != nil {
-		t.Errorf("Expected no error, found %q", err)
-		return
+		t.Fatalf("Expected no error, found %q", err)
 	}
 
 	filled := make(map[string]string)
 	if err := api.FillMap(flattened, filled); err != nil {
-		t.Errorf("Expected no error, found %q", err)
-		return
+		t.Fatalf("Expected no error, found %q", err)
 	}
 
 	expected := map[string]string{
@@ -259,7 +246,7 @@ func TestFlatten(t *testing.T) {
 		"ke": "ve",
 		"kf": "vf",
 	}
-	if !reflect.DeepEqual(expected, filled) {
-		t.Errorf("Expected %+v, found %+v", expected, filled)
+	if diff := cmp.Diff(expected, filled); diff != "" {
+		t.Errorf("Found diff (-want, +got):\n%s", diff)
 	}
 }

--- a/src/diagonal.works/b6/api/functions/geojson_test.go
+++ b/src/diagonal.works/b6/api/functions/geojson_test.go
@@ -11,23 +11,18 @@ import (
 
 func TestGeoJSON(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	context := &api.Context{
 		World: granarySquare,
 	}
 	features, err := find(context, b6.Keyed{Key: "#building"})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	g, err := toGeoJSONCollection(context, features)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	if collection, ok := g.(*geojson.FeatureCollection); ok {
@@ -57,16 +52,18 @@ func TestGeoJSONAreasInvertsLargePolygons(t *testing.T) {
 	p1 := cs.ToS2Polygon()
 	areas, err := geojsonAreas(&api.Context{}, g)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 	i := areas.Begin()
-	if ok, err := i.Next(); !ok || err != nil {
-		t.Errorf("Expected at least one area")
-		return
+	ok, err := i.Next()
+	if err != nil {
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	if !ok {
+		t.Fatal("Expected at least one area")
 	}
 	p2 := i.Value().(b6.Area).Polygon(0)
 	if p2.Area() >= p1.Area() {
-		t.Errorf("Expected clockwise GeoJSON polygons to be inverted")
+		t.Error("Expected clockwise GeoJSON polygons to be inverted")
 	}
 }

--- a/src/diagonal.works/b6/api/functions/geometry_test.go
+++ b/src/diagonal.works/b6/api/functions/geometry_test.go
@@ -16,13 +16,13 @@ func TestDistanceToPointMeters(t *testing.T) {
 	}
 	path := b6.FindPathByID(ingest.FromOSMWayID(377974549), granarySquare)
 	if path == nil {
-		t.Errorf("Failed to find expected path")
+		t.Fatal("Failed to find expected path")
 	}
 
 	point := b6.PointFromLatLngDegrees(51.53586, -0.12564)
 	distance, err := distanceToPointMeters(context, path, point)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	baseline := b6.AngleToMeters(path.Point(0).Distance(point.Point()))

--- a/src/diagonal.works/b6/api/functions/map_test.go
+++ b/src/diagonal.works/b6/api/functions/map_test.go
@@ -27,21 +27,19 @@ func TestMapWithDeadline(t *testing.T) {
 	deadline, _ := context.WithTimeout(context.Background(), 2000*time.Microsecond)
 	c, err := map_(&api.Context{Context: deadline}, input, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-	} else {
-		i := c.Begin()
-		for {
-			var ok bool
-			ok, err = i.Next()
-			if !ok || err != nil {
-				break
-			}
-			if i.Value().(int) != input.Values[seen]+1 {
-				t.Errorf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
-				return
-			}
-			seen++
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	i := c.Begin()
+	for {
+		var ok bool
+		ok, err = i.Next()
+		if !ok || err != nil {
+			break
 		}
+		if i.Value().(int) != input.Values[seen]+1 {
+			t.Fatalf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
+		}
+		seen++
 	}
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected %s, found %s", context.DeadlineExceeded, err)
@@ -49,7 +47,7 @@ func TestMapWithDeadline(t *testing.T) {
 }
 
 func TestMapParallelHappyPath(t *testing.T) {
-	// Use a prime input length, to guarnatee it's not divisible by the
+	// Use a prime input length, to guarantee it's not divisible by the
 	// number of cores
 	input := &api.ArrayIntIntCollection{Values: make([]int, 1031)}
 	r := rand.New(rand.NewSource(42))
@@ -66,23 +64,21 @@ func TestMapParallelHappyPath(t *testing.T) {
 	context := &api.Context{Cores: 8, Context: context.Background(), VM: &api.VM{}}
 	c, err := mapParallel(context, input, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-	} else {
-		i := c.Begin()
-		for {
-			ok, err := i.Next()
-			if err != nil {
-				t.Errorf("Expected no error, found: %s", err)
-				break
-			} else if !ok {
-				break
-			}
-			if i.Value().(int) != input.Values[seen]+1 {
-				t.Errorf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
-				break
-			}
-			seen++
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	i := c.Begin()
+	for {
+		ok, err := i.Next()
+		if err != nil {
+			t.Fatalf("Expected no error, found: %s", err)
 		}
+		if !ok {
+			break
+		}
+		if i.Value().(int) != input.Values[seen]+1 {
+			t.Fatalf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
+		}
+		seen++
 	}
 	if seen != len(input.Values) {
 		t.Errorf("Expected %d values, found %d", len(input.Values), seen)
@@ -111,21 +107,19 @@ func TestMapParallelWithFunctionReturningError(t *testing.T) {
 	context := &api.Context{Cores: 8, Context: context.Background(), VM: &api.VM{}}
 	c, err := mapParallel(context, input, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-	} else {
-		i := c.Begin()
-		for {
-			var ok bool
-			ok, err = i.Next()
-			if !ok || err != nil {
-				break
-			}
-			if i.Value().(int) != input.Values[seen]+1 {
-				t.Errorf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
-				return
-			}
-			seen++
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	i := c.Begin()
+	for {
+		var ok bool
+		ok, err = i.Next()
+		if !ok || err != nil {
+			break
 		}
+		if i.Value().(int) != input.Values[seen]+1 {
+			t.Fatalf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
+		}
+		seen++
 	}
 	if err != broken {
 		t.Errorf("Expected error %s, found %s", broken, err)
@@ -180,21 +174,19 @@ func TestMapParallelWithIteratorReturningError(t *testing.T) {
 	context := &api.Context{Cores: 8, Context: context.Background(), VM: &api.VM{}}
 	c, err := mapParallel(context, input, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-	} else {
-		i := c.Begin()
-		for {
-			var ok bool
-			ok, err = i.Next()
-			if !ok || err != nil {
-				break
-			}
-			if i.Value().(int) != values.Values[seen]+1 {
-				t.Errorf("Expected %d, found %d at position %d", values.Values[seen]+1, i.Value().(int), seen)
-				return
-			}
-			seen++
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	i := c.Begin()
+	for {
+		var ok bool
+		ok, err = i.Next()
+		if !ok || err != nil {
+			break
 		}
+		if i.Value().(int) != values.Values[seen]+1 {
+			t.Fatalf("Expected %d, found %d at position %d", values.Values[seen]+1, i.Value().(int), seen)
+		}
+		seen++
 	}
 	if err != broken {
 		t.Errorf("Expected error %s, found %s", broken, err)
@@ -220,21 +212,19 @@ func TestMapParallelWithDeadline(t *testing.T) {
 	ctx := &api.Context{Cores: cores, Context: deadline, VM: &api.VM{}}
 	c, err := mapParallel(ctx, input, f)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-	} else {
-		i := c.Begin()
-		for {
-			var ok bool
-			ok, err = i.Next()
-			if !ok || err != nil {
-				break
-			}
-			if i.Value().(int) != input.Values[seen]+1 {
-				t.Errorf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
-				return
-			}
-			seen++
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	i := c.Begin()
+	for {
+		var ok bool
+		ok, err = i.Next()
+		if !ok || err != nil {
+			break
 		}
+		if i.Value().(int) != input.Values[seen]+1 {
+			t.Fatalf("Expected %d, found %d at position %d", input.Values[seen]+1, i.Value().(int), seen)
+		}
+		seen++
 	}
 	if err != context.DeadlineExceeded {
 		t.Errorf("Expected %s, found %s", context.DeadlineExceeded, err)

--- a/src/diagonal.works/b6/api/functions/math_test.go
+++ b/src/diagonal.works/b6/api/functions/math_test.go
@@ -25,8 +25,7 @@ func TestPercentiles(t *testing.T) {
 
 	collection, err := percentiles(&api.Context{}, &api.ArrayAnyFloatCollection{Keys: keys, Values: values})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	i := 0
@@ -34,16 +33,14 @@ func TestPercentiles(t *testing.T) {
 	for {
 		ok, err := j.Next()
 		if err != nil {
-			t.Error(err)
-			return
+			t.Fatal(err)
 		}
 		if !ok {
 			break
 		}
 		expected := values[i] / 5.0
 		if math.Abs(j.Value().(float64)-expected) > 0.05 {
-			t.Errorf("Expected a value close to %f, found %f", expected, j.Value().(float64))
-			return
+			t.Fatalf("Expected a value close to %f, found %f", expected, j.Value().(float64))
 		}
 		i++
 	}
@@ -54,23 +51,18 @@ func TestPercentiles(t *testing.T) {
 
 func TestCount(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	context := &api.Context{
 		World: granarySquare,
 	}
 	collection, err := find(context, b6.Keyed{"#building"})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	count, err := count(context, collection)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 	expected := camden.BuildingsInGranarySquare
 	if count != expected {

--- a/src/diagonal.works/b6/api/functions/s2_test.go
+++ b/src/diagonal.works/b6/api/functions/s2_test.go
@@ -19,15 +19,13 @@ func TestS2Points(t *testing.T) {
 
 	area := b6.FindAreaByID(camden.GranarySquareID, granarySquare)
 	if area == nil {
-		t.Errorf("Failed to find Granary Square")
-		return
+		t.Fatal("Failed to find Granary Square")
 	}
 
 	center := s2.PointFromLatLng(s2.LatLngFromDegrees(51.53536, -0.12539))
 	points, err := s2Points(context, area, 21, 21)
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	count := 0
@@ -36,8 +34,7 @@ func TestS2Points(t *testing.T) {
 	for {
 		ok, err := i.Next()
 		if err != nil {
-			t.Errorf("Expected no error, found %s", err)
-			return
+			t.Fatalf("Expected no error, found %s", err)
 		}
 		if !ok {
 			break
@@ -64,8 +61,7 @@ func TestS2Grid(t *testing.T) {
 
 	grid, err := s2Grid(context, rectangle, 21)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	bounds := rectangle.Polygon(0).RectBound()
@@ -74,20 +70,17 @@ func TestS2Grid(t *testing.T) {
 	for {
 		ok, err := i.Next()
 		if err != nil {
-			t.Errorf("Expected no error, found: %s", err)
-			return
+			t.Fatalf("Expected no error, found: %s", err)
 		}
 		if !ok {
 			break
 		}
 		cellID := s2.CellIDFromToken(i.Value().(string))
 		if cellID.Level() != 21 {
-			t.Errorf("Expected cell level 21, found: %d", cellID.Level())
-			return
+			t.Fatalf("Expected cell level 21, found: %d", cellID.Level())
 		}
 		if !s2.CellFromCellID(cellID).RectBound().Intersects(bounds) {
-			t.Errorf("Expected cell to intersect rectangle bounds")
-			return
+			t.Fatal("Expected cell to intersect rectangle bounds")
 		}
 	}
 }
@@ -100,8 +93,7 @@ func TestS2Covering(t *testing.T) {
 
 	covering, err := s2Covering(context, rectangle, 1, 21)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	bounds := rectangle.Polygon(0).RectBound()
@@ -110,16 +102,14 @@ func TestS2Covering(t *testing.T) {
 	for {
 		ok, err := i.Next()
 		if err != nil {
-			t.Errorf("Expected no error, found: %s", err)
-			return
+			t.Fatalf("Expected no error, found: %s", err)
 		}
 		if !ok {
 			break
 		}
 		cellID := s2.CellIDFromToken(i.Value().(string))
 		if !s2.CellFromCellID(cellID).RectBound().Intersects(bounds) {
-			t.Errorf("Expected cell to intersect rectangle bounds")
-			return
+			t.Fatal("Expected cell to intersect rectangle bounds")
 		}
 	}
 }

--- a/src/diagonal.works/b6/api/functions/sightline_test.go
+++ b/src/diagonal.works/b6/api/functions/sightline_test.go
@@ -2,7 +2,6 @@ package functions
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"diagonal.works/b6"
@@ -24,8 +23,7 @@ func TestSightlineFunction(t *testing.T) {
 	from := b6.PointFromLatLngDegrees(51.53545, -0.12561)
 	area, err := sightline(context, from, 250.0)
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if area.Len() != 1 {
@@ -52,9 +50,6 @@ func TestSightline(t *testing.T) {
 
 func ValidateSightline(computeSightline func(from s2.Point, radius s1.Angle, w b6.World) *s2.Polygon, name string, t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	radius := 250.0
 	from := s2.PointFromLatLng(s2.LatLngFromDegrees(51.53545, -0.12561))
@@ -98,9 +93,6 @@ func ValidateSightline(computeSightline func(from s2.Point, radius s1.Angle, w b
 
 func ValidateSightlineInsideBuilding(computeSightline func(from s2.Point, radius s1.Angle, w b6.World) *s2.Polygon, name string, t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	radius := 250.0
 	from := s2.PointFromLatLng(s2.LatLngFromDegrees(51.535280, -0.124357))
@@ -112,9 +104,6 @@ func TestSightlineDoesntHaveSpikes(t *testing.T) {
 	// lead to a very thin field of visibility incorrectly appearing in the
 	// join between two edges of a building. We filter these out.
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	// This location exhibits a spike - detmined visually though Atlas, and
 	// the original implementation of the algorithm
@@ -126,7 +115,7 @@ func TestSightlineDoesntHaveSpikes(t *testing.T) {
 	intersections := countIntersections(sightline.Loop(0), boundary)
 	expected := 2 // There were 6 intersections before spike removal.
 	if intersections != expected {
-		log.Printf("Expected %d intersections, found %d", expected, intersections)
+		t.Errorf("Expected %d intersections, found %d", expected, intersections)
 	}
 }
 
@@ -150,11 +139,9 @@ func TestOccludeWithCenterCloseToEdge(t *testing.T) {
 	center := s2.PointFromLatLng(s2.LatLngFromDegrees(51.51891, -0.09657))
 	o := Occlude(a, b, center, b6.MetersToAngle(250.0))
 	if o == nil {
-		t.Errorf("Expected an occlusion, found nil")
-	} else {
-		if !o.ContainsPoint(s2.PointFromLatLng(s2.LatLngFromDegrees(51.51957, -0.09439))) {
-			t.Errorf("Occlusion didn't contain expected point")
-		}
+		t.Error("Expected an occlusion, found nil")
+	} else if !o.ContainsPoint(s2.PointFromLatLng(s2.LatLngFromDegrees(51.51957, -0.09439))) {
+		t.Error("Occlusion didn't contain expected point")
 	}
 }
 

--- a/src/diagonal.works/b6/api/functions/transit_test.go
+++ b/src/diagonal.works/b6/api/functions/transit_test.go
@@ -11,14 +11,11 @@ import (
 
 func TestFindReachablePoints(t *testing.T) {
 	w := camden.BuildCamdenForTests(t)
-	if w == nil {
-		return
-	}
 	m := ingest.NewMutableOverlayWorld(w)
 
 	origin := b6.FindPointByID(camden.StableStreetBridgeSouthEndID, m)
 	if origin == nil {
-		t.Errorf("Failed to find origin")
+		t.Error("Failed to find origin")
 	}
 
 	context := api.Context{
@@ -28,8 +25,7 @@ func TestFindReachablePoints(t *testing.T) {
 	query := b6.Tagged{Key: "#barrier", Value: "gate"}
 	collection, err := reachablePoints(&context, origin, "walk", 1000.0, query)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	barriers := make(map[b6.PointID]bool)
@@ -37,7 +33,7 @@ func TestFindReachablePoints(t *testing.T) {
 	for {
 		ok, err := i.Next()
 		if err != nil {
-			t.Errorf("Expected no error, found: %s", err)
+			t.Fatalf("Expected no error, found: %s", err)
 		}
 		if !ok {
 			break
@@ -52,24 +48,19 @@ func TestFindReachablePoints(t *testing.T) {
 
 func TestFindReachableFeatures(t *testing.T) {
 	w := camden.BuildCamdenForTests(t)
-	if w == nil {
-		return
-	}
 	m := ingest.NewMutableOverlayWorld(w)
 
 	origin := b6.FindPointByID(camden.StableStreetBridgeSouthEndID, m)
 	if origin == nil {
-		t.Errorf("Failed to find origin")
-		return
+		t.Fatal("Failed to find origin")
 	}
 
 	context := api.Context{
 		World: m,
 	}
-	collection, err := reachableFeatures(&context, origin, "walk", 1000.0, b6.Keyed{"#amenity"})
+	collection, err := reachableFeatures(&context, origin, "walk", 1000.0, b6.Keyed{Key: "#amenity"})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	amenities := make(map[b6.FeatureID]bool)
@@ -77,7 +68,7 @@ func TestFindReachableFeatures(t *testing.T) {
 	for {
 		ok, err := i.Next()
 		if err != nil {
-			t.Errorf("Expected no error, found: %s", err)
+			t.Fatalf("Expected no error, found: %s", err)
 		}
 		if !ok {
 			break
@@ -92,9 +83,6 @@ func TestFindReachableFeatures(t *testing.T) {
 
 func TestPathsToReachFeatures(t *testing.T) {
 	w := camden.BuildCamdenForTests(t)
-	if w == nil {
-		return
-	}
 	m := ingest.NewMutableOverlayWorld(w)
 
 	origin := b6.FindPointByID(camden.StableStreetBridgeSouthEndID, m)
@@ -107,14 +95,12 @@ func TestPathsToReachFeatures(t *testing.T) {
 	}
 	collection, err := pathsToReachFeatures(&context, origin, "walk", 1000.0, b6.Keyed{"#amenity"})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	paths := make(map[b6.FeatureID]int)
 	if err := api.FillMap(collection, paths); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	if len(paths) < 60 {

--- a/src/diagonal.works/b6/api/functions/vm_test.go
+++ b/src/diagonal.works/b6/api/functions/vm_test.go
@@ -12,13 +12,11 @@ import (
 	"diagonal.works/b6/test/camden"
 
 	"github.com/golang/geo/s2"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestEvaluate(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find (intersecting (find-area /area/openstreetmap.org/way/115912092))`
 	if _, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
@@ -28,239 +26,198 @@ func TestEvaluate(t *testing.T) {
 
 func TestMapWithVM(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find (intersecting (find-area /area/openstreetmap.org/way/222021576)) | map {f -> get f "name"}`
-	if result, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		values := []string{}
-		if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
-			t.Errorf("Expected no error, found %q", err)
-		} else {
-			expected := []string{
-				"Caravan", "", "Yumchaa", "", "", "", "", "",
-			}
-			if !reflect.DeepEqual(expected, values) {
-				t.Errorf("Expected %q, found %q", expected, values)
-			}
-		}
+	result, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := []string{}
+
+	if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	expected := []string{
+		"Caravan", "", "Yumchaa", "", "", "", "", "",
+	}
+	if !reflect.DeepEqual(expected, values) {
+		t.Errorf("Expected %q, found %q", expected, values)
 	}
 }
 
 func TestMapParallelWithVM(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find (intersecting (find-area /area/openstreetmap.org/way/222021576)) | map-parallel {f -> get f "name"}`
-	if result, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		values := []string{}
-		if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
-			t.Errorf("Expected no error, found %q", err)
-		} else {
-			expected := []string{
-				"Caravan", "", "Yumchaa", "", "", "", "", "",
-			}
-			if !reflect.DeepEqual(expected, values) {
-				t.Errorf("Expected %q, found %q", expected, values)
-			}
-		}
+	result, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := []string{}
+	if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	expected := []string{
+		"Caravan", "", "Yumchaa", "", "", "", "", "",
+	}
+	if !reflect.DeepEqual(expected, values) {
+		t.Errorf("Expected %q, found %q", expected, values)
 	}
 }
 
 func TestMapWithVMAndPartialFunction(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find (intersecting (find-area /area/openstreetmap.org/way/222021576)) | map (get "name")`
-	if result, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Errorf("Expected no error, found %q", err)
-		return
-	} else {
-		values := []string{}
-		if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
-			t.Errorf("Expected no error, found %q", err)
-		} else {
-			expected := []string{
-				"Caravan", "", "Yumchaa", "", "", "", "", "",
-			}
-			if !reflect.DeepEqual(expected, values) {
-				t.Errorf("Expected %q, found %q", expected, values)
-			}
-		}
+	result, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	values := []string{}
+	if err := api.FillSliceFromValues(result.(api.Collection), &values); err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	expected := []string{
+		"Caravan", "", "Yumchaa", "", "", "", "", "",
+	}
+	if !reflect.DeepEqual(expected, values) {
+		t.Errorf("Expected %q, found %q", expected, values)
 	}
 }
 
 func TestMapItems(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `all-tags /n/6082053666 | map-items {p -> pair (second p) 1}`
-	if result, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-	} else {
-		filled := make(map[b6.Tag]int)
-		collection, ok := result.(api.Collection)
-		if !ok {
-			t.Errorf("Expected a collection, found %T", result)
-			return
-		}
-		if err := api.FillMap(collection, filled); err != nil {
-			t.Error(err)
-			return
-		}
-		if len(filled) < 2 {
-			t.Errorf("Expected at least two values, found %d", len(filled))
-		}
-		if count, ok := filled[b6.Tag{Key: "#amenity", Value: "cafe"}]; !ok || count != 1 {
-			t.Errorf("Expected a count of 1 for amenity tag, found %+v", filled)
-		}
+	result, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	filled := make(map[b6.Tag]int)
+	collection, ok := result.(api.Collection)
+	if !ok {
+		t.Fatalf("Expected a collection, found %T", result)
+	}
+	if err := api.FillMap(collection, filled); err != nil {
+		t.Fatal(err)
+	}
+	if len(filled) < 2 {
+		t.Errorf("Expected at least two values, found %d", len(filled))
+	}
+	if count, ok := filled[b6.Tag{Key: "#amenity", Value: "cafe"}]; !ok || count != 1 {
+		t.Errorf("Expected a count of 1 for amenity tag, found %+v", filled)
 	}
 }
 
 func TestWithVMAndPipelineInLamba(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find [#building] | map {b -> area b | gt 1000.0} | count-values`
-	if result, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-	} else {
-		collection, ok := result.(api.Collection)
-		if !ok {
-			t.Errorf("Expected a collection, found %T", result)
-			return
-		}
-		filled := make(map[bool]int)
-		if err := api.FillMap(collection, filled); err != nil {
-			t.Error(err)
-			return
-		}
-		if filled[true] < filled[false] {
-			t.Errorf("Expected more buildings over 1000m2 than not")
-		}
-		total := 0
-		for _, n := range filled {
-			total += n
-		}
-		if total != camden.BuildingsInGranarySquare {
-			t.Errorf("Expected values for %d buildings, found %d", camden.BuildingsInGranarySquare, total)
-		}
+	result, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collection, ok := result.(api.Collection)
+	if !ok {
+		t.Fatalf("Expected a collection, found %T", result)
+	}
+	filled := make(map[bool]int)
+	if err := api.FillMap(collection, filled); err != nil {
+		t.Fatal(err)
+	}
+	if filled[true] < filled[false] {
+		t.Error("Expected more buildings over 1000m2 than not")
+	}
+	total := 0
+	for _, n := range filled {
+		total += n
+	}
+	if total != camden.BuildingsInGranarySquare {
+		t.Errorf("Expected values for %d buildings, found %d", camden.BuildingsInGranarySquare, total)
 	}
 }
 
 func TestReturnFunctions(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	e := `find (keyed "#building") | to-geojson-collection | map-geometries (apply-to-area {a -> centroid a})`
-	if v, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		if g, ok := v.(*geojson.FeatureCollection); ok {
-			cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53531, -0.12521)), b6.MetersToAngle(1000))
-			for _, f := range g.Features {
-				if p, ok := f.Geometry.Coordinates.(geojson.Point); ok {
-					if !cap.ContainsPoint(p.ToS2Point()) {
-						t.Errorf("Expected %s to be within Granary Square", p.ToS2LatLng())
-					}
-				} else {
-					t.Errorf("Expected geojson.Point, found %T", f.Geometry.Coordinates)
+	v, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g, ok := v.(*geojson.FeatureCollection); ok {
+		cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53531, -0.12521)), b6.MetersToAngle(1000))
+		for _, f := range g.Features {
+			if p, ok := f.Geometry.Coordinates.(geojson.Point); ok {
+				if !cap.ContainsPoint(p.ToS2Point()) {
+					t.Errorf("Expected %s to be within Granary Square", p.ToS2LatLng())
 				}
+			} else {
+				t.Errorf("Expected geojson.Point, found %T", f.Geometry.Coordinates)
 			}
-		} else {
-			t.Errorf("Expected geojson.FeatureCollection, found %T", v)
 		}
+	} else {
+		t.Errorf("Expected geojson.FeatureCollection, found %T", v)
 	}
 }
 
 func TestPassSpecificFunctionWhereGenericNeeded(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 	e := `find (keyed "#building") | map centroid`
 	if _, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
 		t.Error(err)
-		return
 	}
 }
 
 func TestInterfaceConversionForArguments(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
+
 	// find-feature returns a b6.Feature (that happens to implement
 	// b6.Area), are area expects a b6.Area
 	e := `find-feature /area/openstreetmap.org/way/427900370 | area`
-	if v, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		if f, ok := v.(float64); ok {
-			if f < 300 || f > 400 {
-				t.Errorf("Area outside expected range")
-			}
-		} else {
-			t.Errorf("Expected a float, found %T", v)
-		}
+	v, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("Expected a float, found %T", v)
+	}
+	if f < 300 || f > 400 {
+		t.Error("Area outside expected range")
 	}
 }
 
 func TestConvertQueryToFunctionReturningBool(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 	e := `find [#amenity] | filter [addr:postcode]`
-	if v, err := api.EvaluateString(e, NewContext(granarySquare)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		n := 0
-		i := v.(api.Collection).Begin()
-		for {
-			ok, err := i.Next()
-			if err != nil {
-				t.Error(err)
-				return
-			} else if !ok {
-				break
-			}
-			if !i.Value().(b6.Feature).Get("addr:postcode").IsValid() {
-				t.Errorf("Expected a addr:postcode tag, found none")
-			}
-			n++
+	v, err := api.EvaluateString(e, NewContext(granarySquare))
+	if err != nil {
+		t.Fatal(err)
+
+	}
+	n := 0
+	i := v.(api.Collection).Begin()
+	for {
+		ok, err := i.Next()
+		if err != nil {
+			t.Fatal(err)
 		}
-		if n == 0 {
-			t.Errorf("Expected at least 1 value")
+		if !ok {
+			break
 		}
+		if !i.Value().(b6.Feature).Get("addr:postcode").IsValid() {
+			t.Error("Expected a addr:postcode tag, found none")
+		}
+		n++
+	}
+	if n == 0 {
+		t.Error("Expected at least 1 value")
 	}
 }
 
 func TestConvertQueryToFunctionReturningBoolWithSpecificFeature(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 	apply := func(c *api.Context, f func(*api.Context, b6.PointFeature) (bool, error)) (bool, error) {
 		return f(c, b6.FindPointByID(ingest.FromOSMNodeID(camden.VermuteriaNode), c.World))
 	}
@@ -272,9 +229,11 @@ func TestConvertQueryToFunctionReturningBoolWithSpecificFeature(t *testing.T) {
 		FunctionWrappers: Wrappers(),
 	}
 	e := "apply-to-example-point [#amenity]"
-	if v, err := api.EvaluateString(e, c); err != nil {
-		t.Error(err)
-	} else if !v.(bool) {
+	v, err := api.EvaluateString(e, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.(bool) {
 		t.Error("Expected true, found false")
 	}
 }
@@ -297,9 +256,11 @@ func TestConvertIntAndFloat64ToNumber(t *testing.T) {
 		},
 	}
 	for _, e := range []string{"increment 1", "increment 1.0"} {
-		if v, err := api.EvaluateString(e, c); err != nil {
-			t.Error(err)
-		} else if v, ok := v.(int); !ok || v != 2 {
+		v, err := api.EvaluateString(e, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v, ok := v.(int); !ok || v != 2 {
 			t.Errorf("Expected 2, found %v", v)
 		}
 	}
@@ -317,9 +278,11 @@ func TestCallLambdaWithNoArguments(t *testing.T) {
 		FunctionWrappers: Wrappers(),
 	}
 	e := "call {-> 42}"
-	if v, err := api.EvaluateString(e, c); err != nil {
-		t.Error(err)
-	} else if i, ok := v.(int64); !ok || i != 42 {
+	v, err := api.EvaluateString(e, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i, ok := v.(int64); !ok || i != 42 {
 		t.Errorf("Expected 42, found %T %v", v, v)
 	}
 }
@@ -337,7 +300,7 @@ func TestIncorrectlyPassNumberAsFunction(t *testing.T) {
 	e := "call 42"
 	_, err := api.EvaluateString(e, c)
 	if err == nil {
-		t.Errorf("Expected an error")
+		t.Error("Expected an error")
 	}
 }
 
@@ -365,43 +328,39 @@ func TestReturnAnErrorFromALambda(t *testing.T) {
 func TestMapLiteralCollection(t *testing.T) {
 	w := ingest.NewBasicMutableWorld()
 	e := `map {highway="motorway": 2, highway="primary": 6} (add 1)`
-	if result, err := api.EvaluateString(e, NewContext(w)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		collection := make(map[b6.Tag]int)
-		if err := api.FillMap(result.(api.Collection), collection); err != nil {
-			t.Errorf("Expected no error, found %q", err)
-		} else {
-			expected := map[b6.Tag]int{
-				b6.Tag{Key: "highway", Value: "motorway"}: 3,
-				b6.Tag{Key: "highway", Value: "primary"}:  7,
-			}
-			if !reflect.DeepEqual(expected, collection) {
-				t.Errorf("Expected %q, found %q", expected, collection)
-			}
-		}
+	result, err := api.EvaluateString(e, NewContext(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collection := make(map[b6.Tag]int)
+	if err := api.FillMap(result.(api.Collection), collection); err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	expected := map[b6.Tag]int{
+		{Key: "highway", Value: "motorway"}: 3,
+		{Key: "highway", Value: "primary"}:  7,
+	}
+	if diff := cmp.Diff(expected, collection); diff != "" {
+		t.Errorf("Found diff (-want, +got):\n%s", diff)
 	}
 }
 
 func TestMapLiteralCollectionWithImplicitKeys(t *testing.T) {
 	w := ingest.NewBasicMutableWorld()
 	e := `map {36, 42} (add 1)`
-	if result, err := api.EvaluateString(e, NewContext(w)); err != nil {
-		t.Error(err)
-		return
-	} else {
-		collection := make(map[int]int)
-		if err := api.FillMap(result.(api.Collection), collection); err != nil {
-			t.Errorf("Expected no error, found %q", err)
-		} else {
-			expected := map[int]int{
-				0: 37,
-				1: 43,
-			}
-			if !reflect.DeepEqual(expected, collection) {
-				t.Errorf("Expected %q, found %q", expected, collection)
-			}
-		}
+	result, err := api.EvaluateString(e, NewContext(w))
+	if err != nil {
+		t.Fatal(err)
+	}
+	collection := make(map[int]int)
+	if err := api.FillMap(result.(api.Collection), collection); err != nil {
+		t.Fatalf("Expected no error, found %q", err)
+	}
+	expected := map[int]int{
+		0: 37,
+		1: 43,
+	}
+	if diff := cmp.Diff(expected, collection); diff != "" {
+		t.Errorf("Found diff (-want, +got):\n%s", diff)
 	}
 }

--- a/src/diagonal.works/b6/api/shell_test.go
+++ b/src/diagonal.works/b6/api/shell_test.go
@@ -35,10 +35,8 @@ func (fs testFunctionArgCounts) ArgCount(symbol string) (int, bool) {
 }
 
 func (fs testFunctionArgCounts) IsVariadic(symbol string) (bool, bool) {
-	if _, ok := fs[symbol]; ok {
-		return false, true
-	}
-	return false, false
+	_, ok := fs[symbol]
+	return false, ok
 }
 
 func TestParseExpression(t *testing.T) {
@@ -863,7 +861,7 @@ func TestOrderTokens(t *testing.T) {
 	e := `show-accessibility [#building=school] 900 "walking" {b -> pair "#building" (building-category b)}`
 	top, err := ParseExpression(e)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 	tokens := OrderTokens(top)
 	expected := []*pb.NodeProto{

--- a/src/diagonal.works/b6/encoding/arrays_test.go
+++ b/src/diagonal.works/b6/encoding/arrays_test.go
@@ -7,9 +7,6 @@ import (
 
 func TestByteArrays(t *testing.T) {
 	namesByID, _ := loadGranarySquareForTests(t)
-	if namesByID == nil {
-		return
-	}
 
 	names := make([]string, 0, len(namesByID))
 	for _, name := range namesByID {
@@ -26,16 +23,14 @@ func TestByteArrays(t *testing.T) {
 	builder.WriteHeader(&output, offset)
 	for i, name := range names {
 		if err := builder.WriteItem(&output, i, []byte(name)); err != nil {
-			t.Errorf("Expected no error from WriteItem(), found: %s", err)
-			return
+			t.Fatalf("Expected no error from WriteItem(), found: %s", err)
 		}
 	}
 
 	// Ensure the end offset really is beyond the map data by writing over it
 	var zeros [1024]byte
 	if _, err := output.WriteAt(zeros[0:], int64(offset+Offset(builder.Length()))); err != nil {
-		t.Errorf("Failed to pad output")
-		return
+		t.Fatal("Failed to pad output")
 	}
 
 	b := NewByteArrays(output.Bytes()[offset:])
@@ -48,9 +43,6 @@ func TestByteArrays(t *testing.T) {
 
 func TestByteArrayReservesAreCumulative(t *testing.T) {
 	namesByID, _ := loadGranarySquareForTests(t)
-	if namesByID == nil {
-		return
-	}
 
 	names := make([]string, 0, len(namesByID))
 	ids := make([]string, 0, len(namesByID))
@@ -70,8 +62,7 @@ func TestByteArrayReservesAreCumulative(t *testing.T) {
 	builder.WriteHeader(&output, offset)
 	for i := 0; i < len(namesByID); i++ {
 		if err := builder.WriteItem(&output, i, []byte(names[i]), []byte(ids[i])); err != nil {
-			t.Errorf("Expected no error from WriteItem(), found: %s", err)
-			return
+			t.Fatalf("Expected no error from WriteItem(), found: %s", err)
 		}
 	}
 

--- a/src/diagonal.works/b6/encoding/strings_test.go
+++ b/src/diagonal.works/b6/encoding/strings_test.go
@@ -6,9 +6,6 @@ import (
 
 func TestBuildStringTable(t *testing.T) {
 	names, amenities := loadGranarySquareForTests(t)
-	if names == nil || amenities == nil {
-		return
-	}
 
 	start := Offset(42)
 	builder := NewStringTableBuilder()
@@ -26,13 +23,13 @@ func TestBuildStringTable(t *testing.T) {
 	}
 
 	if builder.Lookup("bench") > builder.Lookup("cafe") || builder.Lookup("cafe") > builder.Lookup("Vermuteria") {
-		t.Errorf("Expected the most frequent strings to have the smallest IDs")
+		t.Error("Expected the most frequent strings to have the smallest IDs")
 	}
 
 	// Ensure the end offset really is beyond the string data by writing over it
 	var zeros [1024]byte
 	if _, err := output.WriteAt(zeros[0:], int64(offset+Offset(builder.Length()))); err != nil {
-		t.Errorf("Failed to pad output")
+		t.Error("Failed to pad output")
 	}
 
 	strings := NewStringTable(output.Bytes()[start:])

--- a/src/diagonal.works/b6/encoding/testing.go
+++ b/src/diagonal.works/b6/encoding/testing.go
@@ -8,6 +8,7 @@ import (
 )
 
 func loadGranarySquareForTests(t *testing.T) (map[osm.NodeID]string, map[osm.NodeID]string) {
+	t.Helper()
 	names := make(map[osm.NodeID]string)
 	amenities := make(map[osm.NodeID]string)
 	var maxNodeID osm.NodeID
@@ -27,13 +28,11 @@ func loadGranarySquareForTests(t *testing.T) (map[osm.NodeID]string, map[osm.Nod
 	}
 	input, err := os.Open("../../../../data/tests/granary-square.osm.pbf")
 	if err != nil {
-		t.Errorf("Failed to open test data: %s", err)
-		return nil, nil
+		t.Fatalf("Failed to open test data: %s", err)
 	}
 	defer input.Close()
 	if err = osm.ReadPBF(input, emit); err != nil {
-		t.Errorf("Failed to read test data: %s", err)
-		return nil, nil
+		t.Fatalf("Failed to read test data: %s", err)
 	}
 	return names, amenities
 }

--- a/src/diagonal.works/b6/encoding/uint64map_test.go
+++ b/src/diagonal.works/b6/encoding/uint64map_test.go
@@ -15,9 +15,6 @@ const (
 
 func TestUint64Map(t *testing.T) {
 	names, amenities := loadGranarySquareForTests(t)
-	if names == nil || amenities == nil {
-		return
-	}
 
 	const NameTag = 0
 	const AmenityTag = 1
@@ -38,22 +35,19 @@ func TestUint64Map(t *testing.T) {
 	builder.WriteHeader(&output, offset)
 	for id, name := range names {
 		if err := builder.WriteItem(uint64(id), NameTag, []byte(name), &output); err != nil {
-			t.Errorf("Expected no error from WriteItem(), found: %s", err)
-			return
+			t.Fatalf("Expected no error from WriteItem(), found: %s", err)
 		}
 	}
 	for id, amenity := range amenities {
 		if err := builder.WriteItem(uint64(id), AmenityTag, []byte(amenity), &output); err != nil {
-			t.Errorf("Expected no error from WriteItem(), found: %s", err)
-			return
+			t.Fatalf("Expected no error from WriteItem(), found: %s", err)
 		}
 	}
 
 	// Ensure the end offset really is beyond the map data by writing over it
 	var zeros [1024]byte
 	if _, err := output.WriteAt(zeros[0:], int64(offset+Offset(builder.Length()))); err != nil {
-		t.Errorf("Failed to pad output")
-		return
+		t.Fatal("Failed to pad output")
 	}
 
 	tests := []struct {
@@ -134,7 +128,7 @@ func ValidateEachItem(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 		}
 	}
 	if name, ok := found[uint64(camden.VermuteriaNode)]; !ok || name != "Vermuteria" {
-		t.Errorf("Expected to iterate past Vermuteria")
+		t.Error("Expected to iterate past Vermuteria")
 	}
 }
 
@@ -161,7 +155,7 @@ func ValidateIterator(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 	}
 
 	if name, ok := found[uint64(camden.VermuteriaNode)]; !ok || name != "Vermuteria" {
-		t.Errorf("Expected to iterate past Vermuteria")
+		t.Error("Expected to iterate past Vermuteria")
 	}
 }
 
@@ -173,7 +167,7 @@ func ValidateFindFirst(m *Uint64Map, ids map[uint64]struct{}, t *testing.T) {
 
 	tag, ok := m.FindFirst(uint64(camden.VermuteriaNode))
 	if !ok {
-		t.Errorf("Expected to find name or amenity for Vermuteria")
+		t.Error("Expected to find name or amenity for Vermuteria")
 	} else if (tag.Tag == TestNameTag && string(tag.Data) != "Vermuteria") || (tag.Tag == TestAmenityTag && string(tag.Data) != "cafe") {
 		t.Errorf("Expected to find name or amenity for Vermuteria, found %s", v)
 	}

--- a/src/diagonal.works/b6/geojson/geojson_test.go
+++ b/src/diagonal.works/b6/geojson/geojson_test.go
@@ -13,8 +13,7 @@ func TestMarshalPointFeature(t *testing.T) {
 	feature := NewFeatureFromS2LatLng(s2.LatLngFromDegrees(51.5353602, -0.1260527))
 	actual, err := json.Marshal(feature)
 	if err != nil {
-		t.Errorf("json.Marshal failed: %s", err)
-		return
+		t.Fatalf("json.Marshal failed: %s", err)
 	}
 
 	expected := `{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.1260527,51.5353602]},"properties":{}}`
@@ -35,7 +34,7 @@ func TestUnmarshalPointFeature(t *testing.T) {
 			t.Errorf("Point not within expected bounds")
 		}
 	} else {
-		t.Errorf("Unexpected geometry type")
+		t.Error("Unexpected geometry type")
 	}
 }
 
@@ -52,8 +51,7 @@ func TestMarshalPolygon(t *testing.T) {
 	j := NewFeatureFromS2Polygon(polygon)
 	coordinates, ok := j.Geometry.Coordinates.(Polygon)
 	if !ok {
-		t.Errorf("Wrong geometry type")
-		return
+		t.Fatal("Wrong geometry type")
 	}
 	if len(coordinates[0]) != polygon.Loop(0).NumVertices()+1 {
 		t.Errorf("Expected GeoJSON linear ring to be explicitly closed")
@@ -88,12 +86,10 @@ func TestMarshalPolygonWithHole(t *testing.T) {
 	j := NewFeatureFromS2Polygon(polygon)
 	coordinates, ok := j.Geometry.Coordinates.(Polygon)
 	if !ok {
-		t.Errorf("Wrong geometry type")
-		return
+		t.Fatal("Wrong geometry type")
 	}
 	if len(coordinates) != 2 {
-		t.Errorf("Expected GeoJSON polygon to have two linear rings")
-		return
+		t.Fatal("Expected GeoJSON polygon to have two linear rings")
 	}
 
 	points := make([]s2.Point, 3)
@@ -102,24 +98,24 @@ func TestMarshalPolygonWithHole(t *testing.T) {
 	}
 	center := s2.PointFromLatLng(s2.LatLngFromDegrees(2.5, 1.5))
 	if !s2.OrderedCCW(points[0], points[1], points[2], center) {
-		t.Errorf("Expected exterior loop to be ordered counterclockwise, per RFC7946")
+		t.Error("Expected exterior loop to be ordered counterclockwise, per RFC7946")
 	}
 	for i := range points {
 		points[i] = coordinates[1][i].ToS2Point()
 	}
 	if s2.OrderedCCW(points[0], points[1], points[2], center) {
-		t.Errorf("Expected interor loop to be ordered clockwise, per RFC7946")
+		t.Error("Expected interor loop to be ordered clockwise, per RFC7946")
 	}
 }
 
 func TestMarshalPolygonProto(t *testing.T) {
 	polygon := &pb.PolygonProto{
 		Loops: []*pb.LoopProto{
-			&pb.LoopProto{
+			{
 				Points: []*pb.PointProto{
-					&pb.PointProto{LatE7: 515356929, LngE7: -1276359},
-					&pb.PointProto{LatE7: 515353710, LngE7: -1273698},
-					&pb.PointProto{LatE7: 515350393, LngE7: -1270861},
+					{LatE7: 515356929, LngE7: -1276359},
+					{LatE7: 515353710, LngE7: -1273698},
+					{LatE7: 515350393, LngE7: -1270861},
 				},
 			},
 		},
@@ -127,8 +123,7 @@ func TestMarshalPolygonProto(t *testing.T) {
 	j := PolygonProtoToGeoJSON(polygon)
 	coordinates, ok := j.Geometry.Coordinates.(Polygon)
 	if !ok {
-		t.Errorf("Wrong geometry type")
-		return
+		t.Fatal("Wrong geometry type")
 	}
 	if len(coordinates[0]) != len(polygon.Loops[0].Points)+1 {
 		t.Errorf("Expected GeoJSON linear ring to be explicitly closed")
@@ -136,8 +131,7 @@ func TestMarshalPolygonProto(t *testing.T) {
 
 	actual, err := json.Marshal(j)
 	if err != nil {
-		t.Errorf("json.Marshal failed: %s", err)
-		return
+		t.Fatalf("json.Marshal failed: %s", err)
 	}
 	expected := `{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[-0.1276359,51.5356929],[-0.1273698,51.535371],[-0.1270861,51.5350393],[-0.1276359,51.5356929]]]},"properties":{}}`
 	if string(actual) != expected {

--- a/src/diagonal.works/b6/go.mod
+++ b/src/diagonal.works/b6/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/apache/beam v2.32.0+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/google/go-cmp v0.5.9
 	github.com/lukeroth/gdal v0.0.0-20220614134811-3c605a05e283
 	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
 	golang.org/x/mod v0.10.0
@@ -25,7 +26,6 @@ require (
 	cloud.google.com/go/iam v0.13.0 // indirect
 	cloud.google.com/go/storage v1.30.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect

--- a/src/diagonal.works/b6/graph/graph_test.go
+++ b/src/diagonal.works/b6/graph/graph_test.go
@@ -12,30 +12,23 @@ import (
 
 func TestShortestPath(t *testing.T) {
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	fromPath := b6.FindPathByID(ingest.FromOSMWayID(687471322), camden)
 	if fromPath == nil {
-		t.Errorf("Failed to find way")
-		return
+		t.Fatal("Failed to find way")
 	}
 	from := fromPath.Feature(0)
 	if from == nil {
-		t.Errorf("Expected a PointFeature")
-		return
+		t.Fatal("Expected a PointFeature")
 	}
 
 	toPath := b6.FindPathByID(ingest.FromOSMWayID(367808662), camden)
 	if toPath == nil {
-		t.Errorf("Failed to find way")
-		return
+		t.Fatal("Failed to find way")
 	}
 	to := toPath.Feature(0)
 	if to == nil {
-		t.Errorf("Expected a PointFeature")
-		return
+		t.Fatal("Expected a PointFeature")
 	}
 
 	path := ComputeShortestPath(from.PointID(), to.PointID(), 1000.0, BusWeights{}, camden)
@@ -81,27 +74,25 @@ func TestShortestPathWithOverriddenWeight(t *testing.T) {
 
 	w, err := ingest.BuildWorldFromOSM(nodes, ways, []osm.Relation{}, &ingest.BuildOptions{Cores: 2})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	from := ingest.FromOSMNodeID(7799663850)
 	to := ingest.FromOSMNodeID(5336117979)
 	path := ComputeShortestPath(from, to, 500.0, SimpleWeights{}, w)
 	if len(path) != 1 || path[0].Feature.PathID().Value != uint64(ways[0].ID) {
-		t.Errorf("Expected shortest path to use road")
+		t.Error("Expected shortest path to use road")
 	}
 
 	// Override the weight of the cyclepath, and ensure we're routed down it
 	ways[1].Tags = []osm.Tag{{Key: "diagonal:weight", Value: "0.1"}}
 	w, err = ingest.BuildWorldFromOSM(nodes, ways, []osm.Relation{}, &ingest.BuildOptions{Cores: 2})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	path = ComputeShortestPath(from, to, 500.0, SimpleWeights{}, w)
 	if len(path) != 1 || path[0].Feature.PathID().Value != uint64(ways[1].ID) {
-		t.Errorf("Expected shortest path to use cycleway")
+		t.Error("Expected shortest path to use cycleway")
 	}
 }
 
@@ -120,8 +111,7 @@ func TestShortestPathWithTwoJoinedPaths(t *testing.T) {
 
 	w, err := ingest.BuildWorldFromOSM(nodes, ways, []osm.Relation{}, &ingest.BuildOptions{Cores: 2})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	from := ingest.FromOSMNodeID(5384190494)
 	to := ingest.FromOSMNodeID(5384190463)
@@ -152,8 +142,7 @@ func TestAccessibilityWithTwoJoinedPaths(t *testing.T) {
 
 	w, err := ingest.BuildWorldFromOSM(nodes, ways, []osm.Relation{}, &ingest.BuildOptions{Cores: 2})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	from := ingest.FromOSMNodeID(5384190494)
 
@@ -173,20 +162,15 @@ func TestShortestPathTakesIntoAccountOneWayStreets(t *testing.T) {
 	// test case is the road junction here: 51.5452312, -0.1415558, where the West
 	// hand fork is shorter when heading South, but oneway in the wrong direction.
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	from := b6.FindPointByID(ingest.FromOSMNodeID(33000703), camden)
 	if from == nil {
-		t.Errorf("Failed to find from node")
-		return
+		t.Fatal("Failed to find from node")
 	}
 
 	to := b6.FindPointByID(ingest.FromOSMNodeID(970237231), camden)
 	if to == nil {
-		t.Errorf("Failed to find to node")
-		return
+		t.Fatal("Failed to find to node")
 	}
 
 	path := ComputeShortestPath(from.PointID(), to.PointID(), 500.0, BusWeights{}, camden)
@@ -229,8 +213,7 @@ func TestInterpolateShortestPathDistances(t *testing.T) {
 
 	w, err := ingest.BuildWorldFromOSM(nodes, ways, []osm.Relation{}, &ingest.BuildOptions{Cores: 2})
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	path := b6.FindPathByID(ingest.FromOSMWayID(558345071), w)
 
@@ -265,15 +248,11 @@ func TestInterpolateShortestPathDistances(t *testing.T) {
 
 func TestAccessibility(t *testing.T) {
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	// Generate routes from the South end of Coal Drops Yard
 	from := b6.FindPointByID(ingest.FromOSMNodeID(6083735356), camden)
 	if from == nil {
-		t.Errorf("Failed to find from node")
-		return
+		t.Fatal("Failed to find from node")
 	}
 	distances, counts := ComputeAccessibility(from.PointID(), 500.0, SimpleWeights{}, camden)
 
@@ -305,15 +284,12 @@ func TestAccessibility(t *testing.T) {
 		}
 	}
 	if !foundNonIntersectionWithDistance {
-		t.Errorf("Expected non-intersection points to also have a distances")
+		t.Error("Expected non-intersection points to also have a distances")
 	}
 }
 
 func TestBusWeights(t *testing.T) {
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	tests := []struct {
 		id      osm.WayID
@@ -339,14 +315,10 @@ func TestBusWeights(t *testing.T) {
 
 func TestShortestPathFromConnectedBuildingWithNoEntrance(t *testing.T) {
 	w := camden.BuildCamdenForTests(t)
-	if w == nil {
-		return
-	}
 
 	lighterman := b6.FindAreaByID(ingest.AreaIDFromOSMWayID(camden.LightermanWay), w)
 	if lighterman == nil {
-		t.Error("Expected to find The Lighterman")
-		return
+		t.Fatal("Expected to find The Lighterman")
 	}
 
 	entrances := 0
@@ -361,8 +333,7 @@ func TestShortestPathFromConnectedBuildingWithNoEntrance(t *testing.T) {
 	}
 
 	if entrances > 0 {
-		t.Errorf("Expected The Lightman to have no entrances, found %d", entrances)
-		return
+		t.Fatalf("Expected The Lightman to have no entrances, found %d", entrances)
 	}
 
 	weights := SimpleHighwayWeights{}
@@ -371,20 +342,16 @@ func TestShortestPathFromConnectedBuildingWithNoEntrance(t *testing.T) {
 	distances := search.PointDistances()
 
 	if _, ok := distances[camden.StableStreetBridgeNorthEndID]; !ok {
-		t.Errorf("Expected to find a route to Stable Street bridge")
+		t.Error("Expected to find a route to Stable Street bridge")
 	}
 }
 
 func TestShortestPathFromBuildingWithMoreThanOneEntrance(t *testing.T) {
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	stPancras := b6.FindAreaByID(ingest.AreaIDFromOSMWayID(4256246), camden)
 	if stPancras == nil {
-		t.Error("Expected to find St Pancras")
-		return
+		t.Fatal("Expected to find St Pancras")
 	}
 
 	entrances := 0
@@ -399,8 +366,7 @@ func TestShortestPathFromBuildingWithMoreThanOneEntrance(t *testing.T) {
 	}
 
 	if entrances < 2 {
-		t.Errorf("Expected St Pancras to have many entrances, found %d", entrances)
-		return
+		t.Fatalf("Expected St Pancras to have many entrances, found %d", entrances)
 	}
 
 	weights := SimpleHighwayWeights{}
@@ -426,15 +392,11 @@ func TestShortestPathFromBuildingWithMoreThanOneEntrance(t *testing.T) {
 
 func TestShortestPathReturnsBuildings(t *testing.T) {
 	w := camden.BuildCamdenForTests(t)
-	if w == nil {
-		return
-	}
 
 	// Generate routes from the South end of Coal Drops Yard
 	from := b6.FindPointByID(ingest.FromOSMNodeID(6083735356), w)
 	if from == nil {
-		t.Errorf("Failed to find from node")
-		return
+		t.Fatal("Failed to find from node")
 	}
 	s := NewShortestPathSearchFromPoint(from.PointID())
 	s.ExpandSearch(500.0, SimpleWeights{}, PointsAndAreas, w)
@@ -460,9 +422,6 @@ func TestShortestPathReturnsBuildings(t *testing.T) {
 
 func TestElevationWeights(t *testing.T) {
 	camden := camden.BuildCamdenForTests(t)
-	if camden == nil {
-		return
-	}
 
 	camdenWithHill := ingest.NewMutableTagsOverlayWorld(camden)
 	camdenWithHill.AddTag(ingest.FromOSMNodeID(4931754283).FeatureID(), b6.Tag{Key: "ele", Value: "100"})

--- a/src/diagonal.works/b6/ingest/change_test.go
+++ b/src/diagonal.works/b6/ingest/change_test.go
@@ -22,25 +22,22 @@ func TestAddPoints(t *testing.T) {
 	w := NewBasicMutableWorld()
 	ids, err := add.Apply(w)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	added := b6.FindPointByID(p1.PointID, w)
 	if added == nil || added.Point().Distance(s2.PointFromLatLng(p1.Location)) > b6.MetersToAngle(1.0) {
-		t.Errorf("Expected to find p2 under its given ID")
+		t.Error("Expected to find p2 under its given ID")
 	}
 
-	if allocated, ok := ids[p2.FeatureID()]; ok {
-		added := b6.FindPointByID(allocated.ToPointID(), w)
-		if added == nil || added.Point().Distance(s2.PointFromLatLng(p2.Location)) > b6.MetersToAngle(1.0) {
-			t.Errorf("Expected to find p2 under a new ID")
-		}
-	} else {
-		t.Errorf("Expected a new ID for %s", p2.FeatureID())
-		return
+	allocated, ok := ids[p2.FeatureID()]
+	if !ok {
+		t.Fatalf("Expected a new ID for %s", p2.FeatureID())
 	}
-
+	added = b6.FindPointByID(allocated.ToPointID(), w)
+	if added == nil || added.Point().Distance(s2.PointFromLatLng(p2.Location)) > b6.MetersToAngle(1.0) {
+		t.Error("Expected to find p2 under a new ID")
+	}
 }
 
 func TestAddPaths(t *testing.T) {
@@ -66,32 +63,28 @@ func TestAddPaths(t *testing.T) {
 
 	ids, err := add.Apply(w)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
-	if allocated, ok := ids[p2.FeatureID()]; ok {
-		added := b6.FindPointByID(allocated.ToPointID(), w)
-		if added == nil || added.Point().Distance(s2.PointFromLatLng(p2.Location)) > b6.MetersToAngle(1.0) {
-			t.Errorf("Expected to find p2 under a new ID")
-		}
-	} else {
-		t.Errorf("Expected a new ID for %s", p2.FeatureID())
-		return
+	allocated, ok := ids[p2.FeatureID()]
+	if !ok {
+		t.Fatalf("Expected a new ID for %s", p2.FeatureID())
+	}
+	addedPoint := b6.FindPointByID(allocated.ToPointID(), w)
+	if addedPoint == nil || addedPoint.Point().Distance(s2.PointFromLatLng(p2.Location)) > b6.MetersToAngle(1.0) {
+		t.Error("Expected to find p2 under a new ID")
 	}
 
-	if allocated, ok := ids[path.FeatureID()]; ok {
-		added := b6.FindPathByID(allocated.ToPathID(), w)
-		if added == nil {
-			t.Errorf("Expected to find path under a new ID")
-		} else {
-			if p := added.Feature(1); p == nil || p.FeatureID() != ids[p2.FeatureID()] {
-				t.Errorf("Expected path to reference newly generated ID")
-			}
-		}
-	} else {
-		t.Errorf("Expected a new ID for %s", path.FeatureID())
-		return
+	allocated, ok = ids[path.FeatureID()]
+	if !ok {
+		t.Fatalf("Expected a new ID for %s", path.FeatureID())
+	}
+	addedPath := b6.FindPathByID(allocated.ToPathID(), w)
+	if addedPath == nil {
+		t.Fatal("Expected to find path under a new ID")
+	}
+	if p := addedPath.Feature(1); p == nil || p.FeatureID() != ids[p2.FeatureID()] {
+		t.Error("Expected path to reference newly generated ID")
 	}
 }
 
@@ -127,22 +120,19 @@ func TestAddAreas(t *testing.T) {
 
 	ids, err := add.Apply(w)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
-	if allocated, ok := ids[area.FeatureID()]; ok {
-		added := b6.FindAreaByID(allocated.ToAreaID(), w)
-		if added == nil {
-			t.Errorf("Expected to find area under a new ID")
-		} else {
-			if added.Feature(0)[0].PathID().FeatureID() != ids[path.FeatureID()] {
-				t.Errorf("Expected path to reference newly generated ID")
-			}
-		}
-	} else {
-		t.Errorf("Expected a new ID for %s", area.FeatureID())
-		return
+	allocated, ok := ids[area.FeatureID()]
+	if !ok {
+		t.Fatalf("Expected a new ID for %s", area.FeatureID())
+	}
+	added := b6.FindAreaByID(allocated.ToAreaID(), w)
+	if added == nil {
+		t.Fatal("Expected to find area under a new ID")
+	}
+	if added.Feature(0)[0].PathID().FeatureID() != ids[path.FeatureID()] {
+		t.Error("Expected path to reference newly generated ID")
 	}
 }
 
@@ -168,17 +158,15 @@ func TestAddRelations(t *testing.T) {
 
 	ids, err := add.Apply(w)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	added := b6.FindRelationByID(relation.RelationID, w)
 	if added == nil {
-		t.Errorf("Expected to find relation under a new ID")
-	} else {
-		if added.Member(1).ID != ids[p2.FeatureID()] {
-			t.Errorf("Expected relation member to reference newly generated ID")
-		}
+		t.Fatal("Expected to find relation under a new ID")
+	}
+	if added.Member(1).ID != ids[p2.FeatureID()] {
+		t.Error("Expected relation member to reference newly generated ID")
 	}
 }
 
@@ -202,14 +190,12 @@ func TestMergeChanges(t *testing.T) {
 	w := NewBasicMutableWorld()
 	_, err := merged.Apply(w)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	found := b6.FindPathByID(path.PathID, w)
 	if found == nil {
-		t.Error("Expected to find added path")
-		return
+		t.Fatal("Expected to find added path")
 	}
 
 	expected := 200.0
@@ -239,13 +225,11 @@ func TestMergeChangesLeavesWorldUnmodfiedFollowingError(t *testing.T) {
 	w := NewBasicMutableWorld()
 	_, err := merged.Apply(w)
 	if err == nil {
-		t.Error("Expected an error, found none")
-		return
+		t.Fatal("Expected an error, found none")
 	}
 
 	found := b6.FindPointByID(point.PointID, w)
 	if found != nil {
 		t.Error("Expected world to be unchanged following failure")
-		return
 	}
 }

--- a/src/diagonal.works/b6/ingest/compact/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/compact/overlay_test.go
@@ -14,7 +14,7 @@ import (
 func TestOverlayPathOnExistingWorld(t *testing.T) {
 	nodes, ways, relations, err := osm.ReadWholePBF(test.Data(test.GranarySquarePBF))
 	if err != nil {
-		t.Errorf("Failed to build granary square: %s", err)
+		t.Fatalf("Failed to build granary square: %s", err)
 	}
 
 	osmSource := ingest.MemoryOSMSource{Nodes: nodes, Ways: ways, Relations: relations}
@@ -23,8 +23,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
 	index, err := BuildInMemory(source, &options)
 	if err != nil {
-		t.Errorf("Failed to build base index: %s", err)
-		return
+		t.Fatalf("Failed to build base index: %s", err)
 	}
 
 	path := ingest.NewPathFeature(2)
@@ -35,16 +34,15 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 
 	w, err := NewWorldFromData(index)
 	if err != nil {
-		t.Errorf("Failed to create base world: %s", err)
+		t.Fatalf("Failed to create base world: %s", err)
 	}
 	source = ingest.MemoryFeatureSource([]ingest.Feature{path})
 	overlay, err := BuildOverlayInMemory(source, &options, w)
 	if err != nil {
-		t.Errorf("Failed to build overlay index: %s", err)
-		return
+		t.Fatalf("Failed to build overlay index: %s", err)
 	}
 	if err := w.Merge(overlay); err != nil {
-		t.Errorf("Failed to merge overlay index: %s", err)
+		t.Fatalf("Failed to merge overlay index: %s", err)
 	}
 
 	highways := w.FindFeatures(b6.Keyed{"#highway"})
@@ -56,7 +54,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Expected to find overlaid path via FindFeatures")
+		t.Error("Expected to find overlaid path via FindFeatures")
 	}
 
 	ps := w.FindPathsByPoint(ingest.FromOSMNodeID(camden.LightermanEntranceNode))
@@ -68,6 +66,6 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("Expected to find overlaid path via FindPathsByPoint")
+		t.Error("Expected to find overlaid path via FindPathsByPoint")
 	}
 }

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -79,13 +79,11 @@ func TestPathSegmentsWithSameNamespaceInMultipleBlocks(t *testing.T) {
 
 	w := NewWorld()
 	if err := mergeOSM(nodes, ways[0], []osm.Relation{}, nil, w); err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	if err := mergeOSM([]osm.Node{}, ways[1], []osm.Relation{}, w, w); err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	id := ingest.FromOSMNodeID(nodes[0].ID)

--- a/src/diagonal.works/b6/ingest/features_test.go
+++ b/src/diagonal.works/b6/ingest/features_test.go
@@ -82,13 +82,13 @@ func TestMergePoint(t *testing.T) {
 	m := caravan.Clone()
 	m.MergeFrom(lighterman)
 	if !reflect.DeepEqual(lighterman, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 
 	m = lighterman.Clone()
 	m.MergeFrom(caravan)
 	if !reflect.DeepEqual(caravan, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 }
 
@@ -112,13 +112,13 @@ func TestMergePath(t *testing.T) {
 	m := ab.Clone()
 	m.MergeFrom(cde)
 	if !reflect.DeepEqual(cde, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 
 	m = cde.Clone()
 	m.MergeFrom(ab)
 	if !reflect.DeepEqual(ab, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 }
 
@@ -179,12 +179,12 @@ func TestMergeRelation(t *testing.T) {
 	m := c6.Clone()
 	m.MergeFrom(cs3)
 	if !reflect.DeepEqual(cs3, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 
 	m = cs3.Clone()
 	m.MergeFrom(c6)
 	if !reflect.DeepEqual(c6, m) {
-		t.Errorf("Expected features to be equal after merge")
+		t.Error("Expected features to be equal after merge")
 	}
 }

--- a/src/diagonal.works/b6/ingest/gdal/source_test.go
+++ b/src/diagonal.works/b6/ingest/gdal/source_test.go
@@ -29,19 +29,17 @@ func TestReadFeaturesFromLSOABoundaries(t *testing.T) {
 	}
 	err := source.Read(ingest.ReadOptions{}, emit, context.Background())
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
-	if found != nil {
-		expected := []b6.Tag{{Key: "#boundary", Value: "lsoa"}, {Key: "name", Value: "Camden 018B"}}
-		for _, tag := range expected {
-			if found.Get(tag.Key) != tag {
-				t.Errorf("Expected to find %s", tag)
-			}
+	if found == nil {
+		t.Fatal("Expected to find boundary")
+	}
+	expected := []b6.Tag{{Key: "#boundary", Value: "lsoa"}, {Key: "name", Value: "Camden 018B"}}
+	for _, tag := range expected {
+		if found.Get(tag.Key) != tag {
+			t.Errorf("Expected to find %s", tag)
 		}
-	} else {
-		t.Errorf("Expected to find boundary")
 	}
 }
 
@@ -65,17 +63,15 @@ func TestReadFeaturesFromLSOABoundariesCopyingAllFields(t *testing.T) {
 	}
 	err := source.Read(ingest.ReadOptions{}, emit, context.Background())
 	if err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
-	if found != nil {
-		expected := []b6.Tag{{Key: "code", Value: "E01000858"}, {Key: "LSOA11NM", Value: "Camden 018B"}}
-		for _, tag := range expected {
-			if found.Get(tag.Key) != tag {
-				t.Errorf("Expected to find %s", tag)
-			}
+	if found == nil {
+		t.Fatal("Expected to find boundary")
+	}
+	expected := []b6.Tag{{Key: "code", Value: "E01000858"}, {Key: "LSOA11NM", Value: "Camden 018B"}}
+	for _, tag := range expected {
+		if found.Get(tag.Key) != tag {
+			t.Errorf("Expected to find %s", tag)
 		}
-	} else {
-		t.Errorf("Expected to find boundary")
 	}
 }

--- a/src/diagonal.works/b6/ingest/ids_test.go
+++ b/src/diagonal.works/b6/ingest/ids_test.go
@@ -12,15 +12,13 @@ func TestIDFromLatLng(t *testing.T) {
 	actual, ok := LatLngFromID(NewLatLngID(expected))
 
 	if !ok {
-		t.Errorf("Failed to convert world.FeatureID to s2.LatLng")
-		return
+		t.Fatal("Failed to convert world.FeatureID to s2.LatLng")
 	}
 	if s2.PointFromLatLng(expected).Distance(s2.PointFromLatLng(actual)) > b6.MetersToAngle(0.01) {
 		t.Errorf("Expected %v to be close to %v", expected, actual)
 	}
 
-	actual, ok = LatLngFromID(FromOSMNodeID(2309943870))
-	if ok {
-		t.Errorf("Incorrectly converted world.FeatureID to s2.LatLng")
+	if _, ok := LatLngFromID(FromOSMNodeID(2309943870)); ok {
+		t.Error("Incorrectly converted world.FeatureID to s2.LatLng")
 	}
 }

--- a/src/diagonal.works/b6/ingest/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/overlay_test.go
@@ -37,8 +37,7 @@ func TestOverlayWorldReturnsPathsFromAllIndices(t *testing.T) {
 	for i, w := range ways {
 		var err error
 		if worlds[i], err = BuildWorldFromOSM(nodes, w, []osm.Relation{}, &BuildOptions{Cores: 2}); err != nil {
-			t.Errorf("Failed to build world: %s", err)
-			return
+			t.Fatalf("Failed to build world: %s", err)
 		}
 	}
 	overlay := NewOverlayWorld(worlds[0], worlds[1])
@@ -48,8 +47,7 @@ func TestOverlayWorldReturnsPathsFromAllIndices(t *testing.T) {
 
 	expected := []osm.WayID{140633010, 557698825, 642639444, 807925586}
 	if len(found) != len(expected) {
-		t.Errorf("Expected length %d, found %d", len(expected), len(found))
-		return
+		t.Fatalf("Expected length %d, found %d", len(expected), len(found))
 	}
 
 	for i, id := range expected {
@@ -95,8 +93,7 @@ func TestOverlayWorldReplacesPathsFromOneIndexWithAnother(t *testing.T) {
 	for i, w := range ways {
 		var err error
 		if worlds[i], err = BuildWorldFromOSM(nodes, w, []osm.Relation{}, &BuildOptions{Cores: 2}); err != nil {
-			t.Errorf("Failed to build world: %s", err)
-			return
+			t.Fatalf("Failed to build world: %s", err)
 		}
 	}
 	overlay := NewOverlayWorld(worlds[1], worlds[0])

--- a/src/diagonal.works/b6/ingest/source_test.go
+++ b/src/diagonal.works/b6/ingest/source_test.go
@@ -32,8 +32,7 @@ func TestParalliseEmit(t *testing.T) {
 		}
 	}
 	if err := wait(); err != nil {
-		t.Errorf("Expected no error, found %s", err)
-		return
+		t.Fatalf("Expected no error, found %s", err)
 	}
 
 	expected := make(map[b6.FeatureID]struct{})
@@ -46,7 +45,7 @@ func TestParalliseEmit(t *testing.T) {
 		}
 	}
 	if len(expected) != 0 {
-		t.Errorf("Expected all ids to be emitted")
+		t.Error("Expected all ids to be emitted")
 	}
 }
 
@@ -74,6 +73,5 @@ func TestParalliseEmitWithError(t *testing.T) {
 	}
 	if err := wait(); err != broken {
 		t.Errorf("Expected %s, found %s", broken, err)
-		return
 	}
 }

--- a/src/diagonal.works/b6/ingest/spatial_test.go
+++ b/src/diagonal.works/b6/ingest/spatial_test.go
@@ -31,8 +31,7 @@ func TestIntersectsWithCap(t *testing.T) {
 	o := BuildOptions{Cores: 2}
 	w, err := BuildWorldFromOSM(nodes, ways, relations, &o)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	cap := s2.CapFromCenterAngle(s2.PointFromLatLng(s2.LatLngFromDegrees(51.53617, -0.12582)), b6.MetersToAngle(100))
@@ -40,16 +39,16 @@ func TestIntersectsWithCap(t *testing.T) {
 	exactAreas := makeAreaMap(b6.FindAreas(b6.NewIntersectsCap(cap), w))
 
 	if len(roughAreas) <= len(exactAreas) || len(exactAreas) == 0 {
-		t.Errorf("Expected there to be less areas by exact match than rough match")
+		t.Error("Expected there to be less areas by exact match than rough match")
 	}
 
 	lighterman := osm.WayID(427900370)
 	if _, ok := roughAreas[b6.MakeAreaID(b6.NamespaceOSMWay, uint64(lighterman))]; !ok {
-		t.Errorf("Expected rough areas to contain the Lighterman")
+		t.Error("Expected rough areas to contain the Lighterman")
 	}
 
 	if _, ok := exactAreas[b6.MakeAreaID(b6.NamespaceOSMWay, uint64(lighterman))]; ok {
-		t.Errorf("Expected exact areas to not contain the Lighterman")
+		t.Error("Expected exact areas to not contain the Lighterman")
 	}
 }
 
@@ -58,22 +57,20 @@ func TestIntersectsWithAreaFeature(t *testing.T) {
 	o := BuildOptions{Cores: 2}
 	w, err := BuildWorldFromOSM(nodes, ways, relations, &o)
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	coalDropsYard := b6.FindAreaByID(b6.MakeAreaID(b6.NamespaceOSMWay, 222021572), w)
 	if coalDropsYard == nil {
-		t.Errorf("Failed to find Coal Drops Yard")
-		return
+		t.Fatal("Failed to find Coal Drops Yard")
 	}
 
 	points := makePointMap(b6.FindPoints(b6.IntersectsFeature{coalDropsYard.FeatureID()}, w))
 	if _, ok := points[b6.MakePointID(b6.NamespaceOSMNode, 6082053669)]; !ok {
-		t.Errorf("Expected to find Outsiders Store")
+		t.Error("Expected to find Outsiders Store")
 	}
 
 	if _, ok := points[b6.MakePointID(b6.NamespaceOSMNode, 6082053666)]; ok {
-		t.Errorf("Didn't expect to find Vermuteria")
+		t.Error("Didn't expect to find Vermuteria")
 	}
 }

--- a/src/diagonal.works/b6/osm/polygons_test.go
+++ b/src/diagonal.works/b6/osm/polygons_test.go
@@ -50,25 +50,21 @@ func readPBF(filename string) (nodeMap, WayMap, relationMap, error) {
 func TestBoundaryRelationToPolygon(t *testing.T) {
 	nodes, ways, relations, err := readPBF("../../../../data/tests/london-boundaries.osm.pbf")
 	if err != nil {
-		t.Errorf("Failed to read test data: %s", err)
-		return
+		t.Fatalf("Failed to read test data: %s", err)
 	}
 
 	const londonID RelationID = 65606
 	london, ok := relations[londonID]
 	if !ok {
-		t.Errorf("Failed to find feature for London")
-		return
+		t.Fatal("Failed to find feature for London")
 	}
 
 	polygon, err := RelationToPolygon(&london, nodes, ways)
 	if err != nil {
-		t.Errorf("Expected no error, found %v", err)
-		return
+		t.Fatalf("Expected no error, found %v", err)
 	}
 	if polygon == nil || polygon.NumLoops() != 2 {
-		t.Errorf("Expected a polygon with 2 loops")
-		return
+		t.Fatal("Expected a polygon with 2 loops")
 	}
 	expectedArea := 1500.0 * 1000.0 * 1000.0
 	actualArea := units.AreaToMeters2(polygon.Area())
@@ -161,7 +157,7 @@ func TestRelationToPolygonWithMultipleWaysThatDoNotClose(t *testing.T) {
 
 	polygon, err := RelationToPolygon(&relation, ns, ws)
 	if polygon != nil || err == nil {
-		t.Errorf("Expected error, found none")
+		t.Error("Expected error, found none")
 	}
 }
 
@@ -286,30 +282,27 @@ func TestRelationToPolygonWithASingleClosedWay(t *testing.T) {
 func TestSimplifyBoundaryPolygon(t *testing.T) {
 	nodes, ways, relations, err := readPBF("../../../../data/tests/london-boundaries.osm.pbf")
 	if err != nil {
-		t.Errorf("Failed to read test data: %s", err)
-		return
+		t.Fatalf("Failed to read test data: %s", err)
 	}
 
 	const londonID RelationID = 65606
 	london, ok := relations[londonID]
 	if !ok {
-		t.Errorf("Failed to find feature for London")
-		return
+		t.Fatal("Failed to find feature for London")
 	}
 
 	polygon, err := RelationToPolygon(&london, nodes, ways)
 	if err != nil {
-		t.Errorf("Failed to convert London to polygon: %s", err)
-		return
+		t.Fatalf("Failed to convert London to polygon: %s", err)
 	}
 
 	simplified := SimplifyPolygon(polygon, units.Meters2ToArea(100))
 	if polygon == nil {
-		t.Errorf("Expected a polygon, found nil")
+		t.Error("Expected a polygon, found nil")
 	}
 
 	if math.Abs(simplified.Area()-polygon.Area())/polygon.Area() > 0.01 {
-		t.Errorf("Expected areas to be similar")
+		t.Error("Expected areas to be similar")
 	}
 
 	for i := 0; i < polygon.NumLoops(); i++ {

--- a/src/diagonal.works/b6/renderer/query_test.go
+++ b/src/diagonal.works/b6/renderer/query_test.go
@@ -10,23 +10,18 @@ import (
 
 func TestQueryRenderer(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	projection := b6.NewTileMercatorProjection(16)
 	r := NewQueryRenderer(granarySquare, 2)
 	args := &TileArgs{Q: "[#amenity=cafe]"}
 	tile, err := r.Render(projection.TileFromLatLng(s2.LatLngFromDegrees(51.53531, -0.12434)), args)
-	if err == nil {
-		if len(tile.Layers) == 1 && tile.Layers[0].Name == "query" {
-			if len(tile.Layers[0].Features) < 4 {
-				t.Errorf("Expected features in layer")
-			}
-		} else {
-			t.Errorf("Expected one layer named 'query', found %d", len(tile.Layers))
-		}
-	} else {
-		t.Errorf("Expected no error, found: %s", err)
+	if err != nil {
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	if len(tile.Layers) != 1 || tile.Layers[0].Name != "query" {
+		t.Fatalf("Expected one layer named 'query', found %d", len(tile.Layers))
+	}
+	if len(tile.Layers[0].Features) < 4 {
+		t.Errorf("Expected at least 4 features in layer, got %d", len(tile.Layers[0].Features))
 	}
 }

--- a/src/diagonal.works/b6/renderer/renderer_test.go
+++ b/src/diagonal.works/b6/renderer/renderer_test.go
@@ -31,56 +31,48 @@ func TestFillColourFromFeature(t *testing.T) {
 		tileColour, ok := feature.Tags["colour"]
 		if ok != test.ok {
 			t.Errorf("Expected ok %v, found %v", test.ok, ok)
-		} else if ok {
-			if tileColour != test.tileColour {
-				t.Errorf("Expected tile colour %q, found %q", test.tileColour, tileColour)
-			}
+		} else if ok && tileColour != test.tileColour {
+			t.Errorf("Expected tile colour %q, found %q", test.tileColour, tileColour)
 		}
 	}
 }
 
 func TestFeaturesHaveTagsForNamespaceAndID(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
 
 	projection := b6.NewTileMercatorProjection(16)
 	r := BasemapRenderer{RenderRules: BasemapRenderRules, World: granarySquare}
 	tile, err := r.Render(projection.TileFromLatLng(s2.LatLngFromDegrees(51.53531, -0.12434)), &TileArgs{})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	expected := "19813dd2"
 	if id, _ := strconv.ParseUint(expected, 16, 64); osm.WayID(id) != camden.LightermanWay {
-		t.Errorf("Unexpected hex ID for LightermanWay. Test data changed?")
-		return
+		t.Fatal("Unexpected hex ID for LightermanWay. Test data changed?")
 	}
 
+	layer := tile.FindLayer("building")
+	if layer == nil {
+		t.Fatal("Expected to find building layer")
+	}
 	found := false
-	if layer := tile.FindLayer("building"); layer != nil {
-		for _, f := range layer.Features {
-			if ns, ok := f.Tags["ns"]; ok && ns == b6.NamespaceOSMWay.String() {
-				if id, ok := f.Tags["id"]; ok && id == expected {
-					found = true
-					break
-				}
+	for _, f := range layer.Features {
+		if ns, ok := f.Tags["ns"]; ok && ns == b6.NamespaceOSMWay.String() {
+			if id, ok := f.Tags["id"]; ok && id == expected {
+				found = true
+				break
 			}
 		}
-	} else {
-		t.Errorf("Expected to find building layer")
 	}
 	if !found {
-		t.Errorf("Expected Lighterman feature to be tagged with an ID")
+		t.Error("Expected Lighterman feature to be tagged with an ID")
 	}
 }
 
 func TestFeaturesAreOrderedByLayerTag(t *testing.T) {
 	granarySquare := camden.BuildGranarySquareForTests(t)
-	if granarySquare == nil {
-		return
-	}
+
 	mutable := ingest.NewMutableOverlayWorld(granarySquare)
 
 	// Add a roof terrace and second floor to the Lighterman
@@ -89,36 +81,34 @@ func TestFeaturesAreOrderedByLayerTag(t *testing.T) {
 	roof.AreaID = b6.MakeAreaID(b6.NamespacePrivate, 1)
 	roof.AddTag(b6.Tag{Key: "layer", Value: "2"})
 	if err := mutable.AddArea(roof); err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 	basement := ingest.NewAreaFeatureFromWorld(lighterman)
 	basement.AreaID = b6.MakeAreaID(b6.NamespacePrivate, 2)
 	basement.AddTag(b6.Tag{Key: "layer", Value: "-1"})
 	if err := mutable.AddArea(basement); err != nil {
-		t.Errorf("Expected no error, found: %s", err)
-		return
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	projection := b6.NewTileMercatorProjection(16)
 	r := BasemapRenderer{RenderRules: BasemapRenderRules, World: mutable}
 	tile, err := r.Render(projection.TileFromLatLng(s2.LatLngFromDegrees(51.53531, -0.12434)), &TileArgs{})
 	if err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
 
 	order := []b6.FeatureID{basement.FeatureID(), lighterman.FeatureID(), roof.FeatureID()}
-	if layer := tile.FindLayer("building"); layer != nil {
-		next := 0
-		for _, f := range layer.Features {
-			if f.ID == api.TileFeatureIDForPolygon(order[next], 0) {
-				next++
-			}
+	layer := tile.FindLayer("building")
+	if layer == nil {
+		t.Fatal("Expected to find building layer")
+	}
+	next := 0
+	for _, f := range layer.Features {
+		if f.ID == api.TileFeatureIDForPolygon(order[next], 0) {
+			next++
 		}
-		if next != len(order) {
-			t.Errorf("Unexpected feature order while searching for %s", order[next])
-		}
-	} else {
-		t.Errorf("Expected to find building layer")
+	}
+	if next != len(order) {
+		t.Errorf("Unexpected feature order while searching for %s", order[next])
 	}
 }

--- a/src/diagonal.works/b6/test/camden/camden.go
+++ b/src/diagonal.works/b6/test/camden/camden.go
@@ -1,7 +1,6 @@
 package camden
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 
@@ -51,32 +50,31 @@ var (
 )
 
 func BuildGranarySquareForTests(t *testing.T) b6.World {
+	t.Helper()
 	granarySquareLock.Lock()
 	defer granarySquareLock.Unlock()
 	if granarySquare == nil {
-		granarySquare = build(test.Data(test.GranarySquarePBF), t)
+		granarySquare = build(t, test.Data(test.GranarySquarePBF))
 	}
 	return granarySquare
 }
 
 func BuildCamdenForTests(t *testing.T) b6.World {
+	t.Helper()
 	camdenLock.Lock()
 	defer camdenLock.Unlock()
 	if camden == nil {
-		camden = build(test.Data(test.CamdenPBF), t)
+		camden = build(t, test.Data(test.CamdenPBF))
 	}
 	return camden
 }
 
-func build(filename string, t *testing.T) b6.World {
+func build(t *testing.T, filename string) b6.World {
+	t.Helper()
 	o := &ingest.BuildOptions{Cores: 2}
 	w, err := ingest.NewWorldFromPBFFile(filename, o)
 	if err != nil {
-		if t != nil {
-			t.Errorf("Failed to build world: %s", err)
-		} else {
-			panic(fmt.Sprintf("Failed to build world: %s", err))
-		}
+		t.Fatalf("NewWorldFromPBFFile(%s) failed with: %v", filename, err)
 	}
 	return w
 }

--- a/src/diagonal.works/b6/tiles_test.go
+++ b/src/diagonal.works/b6/tiles_test.go
@@ -134,8 +134,7 @@ func TestTileChildren(t *testing.T) {
 
 	expected := 4
 	if len(children) != expected {
-		t.Errorf("Expected %d children, found %d", expected, len(children))
-		return
+		t.Fatalf("Expected %d children, found %d", expected, len(children))
 	}
 
 	expectedTiles := []Tile{

--- a/src/diagonal.works/b6/ui/blocks_test.go
+++ b/src/diagonal.works/b6/ui/blocks_test.go
@@ -33,28 +33,33 @@ func TestMatchingFunctions(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	result := response.Result()
 	if result.StatusCode != http.StatusOK {
-		t.Errorf("Expected status %d, found %d", http.StatusOK, result.StatusCode)
-		return
+		t.Fatalf("Expected status %d, found %d", http.StatusOK, result.StatusCode)
 	}
 
 	// TODO: Use typing - see the comment for the BlocksJSON definition
 	var blocks map[string]interface{}
 	d := json.NewDecoder(result.Body)
 	if err := d.Decode(&blocks); err != nil {
-		t.Errorf("Expected no error, found %s", err)
+		t.Fatalf("Expected no error, found %s", err)
 	}
 	functions := blocks["Functions"].([]interface{})
-	expected := []string{"to-geojson", "closest", "get-string", "reachable"}
-	for _, e := range expected {
-		found := false
-		for _, f := range functions {
-			if e == f.(string) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected function %q as a suggestion for area features", e)
+	var functionNames []string
+	for _, f := range functions {
+		functionNames = append(functionNames, f.(string))
+	}
+
+	for _, e := range []string{"to-geojson", "closest", "get-string", "reachable"} {
+		if !contains(e, functionNames) {
+			t.Errorf("Function %q not included in area features: %v", e, functionNames)
 		}
 	}
+}
+
+func contains(item string, items []string) bool {
+	for _, i := range items {
+		if i == item {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- Use t.Fatal instead of t.Error + return
- Remove a few indentations that made the tests difficult to follow
- Use cmp.Diff instead of DeepEqual when the resulting failure message would be more readable.
- Use Error/Errorf or Fatal/Fatalf as appropriate.

There should be no changes in test functionality, except for the addition of test cases in TestTreeListAdvanceOnDeletedIterator. The fourth test case still fails, so left it commented.

Note that these changes were not exhaustive, and there might be some lines that still follow the old format.