### PR TITLE
Fix TestTreeListAdvanceOnDeletedIterator/AdvanceBeyondEnd

### DIFF
--- a/src/diagonal.works/b6/search/tree_test.go
+++ b/src/diagonal.works/b6/search/tree_test.go
@@ -156,8 +156,8 @@ func TestTreeListNextOnDeletedIterator(t *testing.T) {
 }
 
 func TestTreeListAdvanceOnDeletedIterator(t *testing.T) {
-	//4, 5, 6, 10, 12, 13, 15, 16
 	input := []int{10, 5, 15, 4, 6, 13, 16, 12}
+	// Same, but sorted: 4, 5, 6, 10, 12, 13, 15, 16
 	cases := []struct {
 		name     string
 		delete   int
@@ -168,8 +168,7 @@ func TestTreeListAdvanceOnDeletedIterator(t *testing.T) {
 		{"HappyPath", 6, 10, true, []int{10, 12, 13, 15, 16}},
 		{"AdvanceToDeleted", 6, 6, true, []int{10, 12, 13, 15, 16}},
 		{"AdvanceToPrevious", 6, 5, true, []int{10, 12, 13, 15, 16}},
-		// TODO: Make this test case pass.
-		// {"AdvanceBeyondEnd", 6, 17, true, []int{}},
+		{"AdvanceBeyondEnd", 6, 17, false, []int{}},
 	}
 
 	for _, c := range cases {
@@ -205,7 +204,6 @@ func TestTreeListAdvanceOnDeletedIterator(t *testing.T) {
 				if !equals(result, c.expected) {
 					t.Errorf("Expected %v, found %v with delete: %d advance: %d", c.expected, result, c.delete, c.advance)
 				}
-
 			} else if i.Next() {
 				t.Error("Expected Next() to return false if Advance() returned false")
 			}


### PR DESCRIPTION
I think Advance should return false instead of true, as we're advancing beyond the end of the structure. Also, there was code to handle the case there Advance returns false, but none of the existing tests set 'ok' to 'false'.