### PR TITLE
Destroy gdal features to support ingest of large files.

### DIFF
--- a/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	_ "net/http/pprof"
 	"os"
 	"runtime"
@@ -31,6 +32,7 @@ var idStrategies = map[string]gdal.IDStrategy{
 func main() {
 	inputFlag := flag.String("input", "", "Input shapefile")
 	outputFlag := flag.String("output", "", "Output index")
+	layerFlag := flag.String("layer", "", "Name of layer to ingest, empty for all")
 	namespaceFlag := flag.String("namespace", "", "Namespace for features")
 	idFlag := flag.String("id", "", "Field to use for ID generation")
 	idStategyFlag := flag.String("id-strategy", "", "Strategy to use for ID generation")
@@ -109,8 +111,10 @@ func main() {
 
 	source := make(ingest.MergedFeatureSource, len(inputs))
 	for i, ii := range inputs {
+		log.Printf("input: %s", ii)
 		source[i] = &gdal.Source{
 			Filename:      ii,
+			Layer:         *layerFlag,
 			Namespace:     b6.Namespace(*namespaceFlag),
 			IDField:       *idFlag,
 			IDStrategy:    strategy,

--- a/src/diagonal.works/b6/encoding/uint64map.go
+++ b/src/diagonal.works/b6/encoding/uint64map.go
@@ -137,6 +137,8 @@ func (b *Buffer) Close() error { return nil }
 
 func (b *Buffer) Bytes() []byte { return b.buffer }
 
+func (b *Buffer) Len() int { return len(b.buffer) }
+
 type Uint64MapBuilder struct {
 	Layout   Uint64MapLayout
 	buckets  *ByteArraysBuilder

--- a/src/diagonal.works/b6/ingest/compact/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/compact/overlay_test.go
@@ -54,7 +54,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("Expected to find overlaid path via FindFeatures")
+		t.Fatal("Expected to find overlaid path via FindFeatures")
 	}
 
 	ps := w.FindPathsByPoint(ingest.FromOSMNodeID(camden.LightermanEntranceNode))

--- a/src/diagonal.works/b6/ingest/compact/world.go
+++ b/src/diagonal.works/b6/ingest/compact/world.go
@@ -192,6 +192,28 @@ func (f *FeaturesByID) Namespaces() []b6.Namespace {
 	return sorted
 }
 
+func (f *FeaturesByID) FillNamespaceTable(nt *NamespaceTable) error {
+	if nt.ToEncoded == nil {
+		nt.ToEncoded = make(map[b6.Namespace]Namespace)
+	}
+	for _, fbs := range f.features {
+		for _, fb := range fbs {
+			for i, ns := range fb.NamespaceTable.FromEncoded {
+				for len(nt.FromEncoded) < i+1 {
+					nt.FromEncoded = append(nt.FromEncoded, b6.NamespaceInvalid)
+				}
+				if nt.FromEncoded[i] == b6.NamespaceInvalid {
+					nt.FromEncoded[i] = ns
+					nt.ToEncoded[ns] = Namespace(i)
+				} else if nt.FromEncoded[i] != ns {
+					return fmt.Errorf("duplicate namespace for namespace %d: %s vs %s", i, nt.FromEncoded[i], ns)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 type marshalledPoint struct {
 	id      b6.PointID
 	point   MarshalledPoint

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -38,7 +38,7 @@ func TestWorld(t *testing.T) {
 		w := NewWorld()
 		return w, mergeOSM(nodes, ways, relations, nil, w)
 	}
-	ingest.ValidateWorld("Region", build, t)
+	ingest.ValidateWorld("Compact", build, t)
 }
 
 func TestPathSegmentsWithSameNamespaceInMultipleBlocks(t *testing.T) {

--- a/src/diagonal.works/b6/ingest/gdal/inputs.go
+++ b/src/diagonal.works/b6/ingest/gdal/inputs.go
@@ -34,15 +34,19 @@ func FindInputs(filename string, zipped bool, recurse bool, inputs []string) ([]
 			f.Close()
 		}
 	} else if s.IsDir() {
-		entries, err := os.ReadDir(filename)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %s", filename, err)
-		}
-		for _, entry := range entries {
-			var err error
-			inputs, err = FindInputs(path.Join(filename, entry.Name()), zipped, recurse, inputs)
+		if strings.HasSuffix(filename, ".gdb") {
+			inputs = append(inputs, filename)
+		} else {
+			entries, err := os.ReadDir(filename)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%s: %s", filename, err)
+			}
+			for _, entry := range entries {
+				var err error
+				inputs, err = FindInputs(path.Join(filename, entry.Name()), zipped, recurse, inputs)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	} else if isIngestable(filename) {


### PR DESCRIPTION
Correctly destroy the resources used by gdal features during ingest, to avoid memory exhaustion when importing large files. In passing, add support for ingesting a named layer, and separate writing features from the search index itself, to allow for garbage collection between the two phases.