### PR TITLE
Support expressions as features.

### DIFF
--- a/src/diagonal.works/b6/api/collections.go
+++ b/src/diagonal.works/b6/api/collections.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"diagonal.works/b6"
-	"diagonal.works/b6/ingest"
 
 	"github.com/golang/geo/s2"
 )
@@ -696,8 +695,8 @@ func FillSliceFromValues(c Collection, toFill interface{}) error {
 	return nil
 }
 
-func CollectionToTags(c Collection) (ingest.Tags, error) {
-	tags := make(ingest.Tags, 0)
+func CollectionToTags(c Collection) (b6.Tags, error) {
+	tags := make(b6.Tags, 0)
 	i := c.Begin()
 	for {
 		ok, err := i.Next()

--- a/src/diagonal.works/b6/expression.go
+++ b/src/diagonal.works/b6/expression.go
@@ -1,0 +1,368 @@
+package b6
+
+import (
+	"fmt"
+
+	pb "diagonal.works/b6/proto"
+)
+
+type AnyExpression interface {
+	ToProto() *pb.NodeProto
+	FromProto(node *pb.NodeProto)
+	Clone() Expression
+}
+
+type Expression struct {
+	AnyExpression
+}
+
+func (e Expression) MarshalYAML() (interface{}, error) {
+	// Fast track types that are handled natively by YAML
+	switch e := e.AnyExpression.(type) {
+	case *IntExpression:
+		return int(*e), nil
+	case *StringExpression:
+		return string(*e), nil
+	}
+	var kind string
+	switch e.AnyExpression.(type) {
+	case *SymbolExpression:
+		kind = "symbol"
+	case *IntExpression:
+		kind = "int"
+	case *StringExpression:
+		kind = "string"
+	case *CallExpression:
+		kind = "call"
+	case *LambdaExpression:
+		kind = "lambda"
+	case *FeatureIDExpression:
+		kind = "id"
+	default:
+		return nil, fmt.Errorf("Can't marshal expression yaml: %T", e.AnyExpression)
+	}
+	return map[string]interface{}{
+		kind: e.AnyExpression,
+	}, nil
+}
+
+func (e *Expression) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Fast track types that are handled natively by YAML
+	var v interface{}
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+	switch v := v.(type) {
+	case int:
+		i := IntExpression(v)
+		e.AnyExpression = &i
+		return nil
+	case string:
+		s := StringExpression(v)
+		e.AnyExpression = &s
+		return nil
+	}
+	var y struct {
+		Symbol *SymbolExpression
+		Int    *IntExpression
+		String *StringExpression
+		Call   *CallExpression
+		Lambda *LambdaExpression
+		ID     *FeatureIDExpression
+	}
+	if err := unmarshal(&y); err != nil {
+		return err
+	}
+	if y.Symbol != nil {
+		e.AnyExpression = y.Symbol
+	} else if y.Int != nil {
+		e.AnyExpression = y.Int
+	} else if y.String != nil {
+		e.AnyExpression = y.String
+	} else if y.Call != nil {
+		e.AnyExpression = y.Call
+	} else if y.Lambda != nil {
+		e.AnyExpression = y.Lambda
+	} else if y.ID != nil {
+		e.AnyExpression = y.ID
+	} else {
+		return fmt.Errorf("Can't unmarshal expression yaml: %+v", y)
+	}
+	return nil
+}
+
+func (e *Expression) ToProto() *pb.NodeProto {
+	return e.AnyExpression.ToProto()
+}
+
+func (e *Expression) FromProto(node *pb.NodeProto) {
+	switch n := node.Node.(type) {
+	case *pb.NodeProto_Symbol:
+		e.AnyExpression = new(SymbolExpression)
+	case *pb.NodeProto_Call:
+		e.AnyExpression = &CallExpression{}
+	case *pb.NodeProto_Lambda_:
+		e.AnyExpression = &LambdaExpression{}
+	case *pb.NodeProto_Literal:
+		switch n.Literal.Value.(type) {
+		case *pb.LiteralNodeProto_IntValue:
+			e.AnyExpression = new(IntExpression)
+		case *pb.LiteralNodeProto_StringValue:
+			e.AnyExpression = new(StringExpression)
+		default:
+			panic(fmt.Sprintf("Can't convert %T from literal proto", n.Literal.Value))
+		}
+	default:
+		panic(fmt.Sprintf("Can't convert expression from proto %T", node.Node))
+	}
+	e.AnyExpression.FromProto(node)
+}
+
+type AnyLiteral interface {
+	AnyExpression
+	Literal() interface{}
+}
+
+type Literal struct {
+	AnyLiteral
+}
+
+func (l *Literal) ToProto() *pb.NodeProto {
+	return l.AnyLiteral.ToProto()
+}
+
+func (l *Literal) FromProto(node *pb.NodeProto) {
+	var e Expression
+	e.FromProto(node)
+	if literal, ok := e.AnyExpression.(AnyLiteral); ok {
+		l.AnyLiteral = literal
+	} else {
+		panic(fmt.Sprintf("Can't convert literal from proto %T", node.Node))
+	}
+}
+
+func (l Literal) MarshalYAML() (interface{}, error) {
+	e := Expression{AnyExpression: l.AnyLiteral}
+	return e.MarshalYAML()
+}
+
+func (l *Literal) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var e Expression
+	e.UnmarshalYAML(unmarshal)
+	if literal, ok := e.AnyExpression.(AnyLiteral); ok {
+		l.AnyLiteral = literal
+	} else {
+		return fmt.Errorf("Can't convert literal from yaml %T", e.AnyExpression)
+	}
+	return nil
+}
+
+func FromLiteral(l interface{}) Literal {
+	switch l := l.(type) {
+	case int:
+		i := IntExpression(l)
+		return Literal{AnyLiteral: &i}
+	case string:
+		s := StringExpression(l)
+		return Literal{AnyLiteral: &s}
+	case FeatureID:
+		id := FeatureIDExpression(l)
+		return Literal{AnyLiteral: &id}
+	}
+	panic(fmt.Sprintf("Can't make literal from %T", l))
+
+}
+
+type SymbolExpression string
+
+func (s *SymbolExpression) ToProto() *pb.NodeProto {
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Symbol{
+			Symbol: string(*s),
+		},
+	}
+}
+
+func (s *SymbolExpression) FromProto(node *pb.NodeProto) {
+	*s = SymbolExpression(node.GetSymbol())
+}
+
+func (s *SymbolExpression) Clone() Expression {
+	clone := *s
+	return Expression{AnyExpression: &clone}
+}
+
+func NewSymbolExpression(symbol string) Expression {
+	s := SymbolExpression(symbol)
+	return Expression{AnyExpression: &s}
+}
+
+type IntExpression int
+
+func (i *IntExpression) ToProto() *pb.NodeProto {
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Literal{
+			Literal: &pb.LiteralNodeProto{
+				Value: &pb.LiteralNodeProto_IntValue{
+					IntValue: int64(*i),
+				},
+			},
+		},
+	}
+}
+
+func (i *IntExpression) FromProto(node *pb.NodeProto) {
+	*i = IntExpression(node.GetLiteral().GetIntValue())
+}
+
+func (i *IntExpression) Clone() Expression {
+	clone := *i
+	return Expression{AnyExpression: &clone}
+}
+
+func (i IntExpression) Literal() interface{} {
+	return int(i)
+}
+
+func NewIntExpression(value int) Expression {
+	i := IntExpression(value)
+	return Expression{AnyExpression: &i}
+}
+
+type StringExpression string
+
+func (s *StringExpression) ToProto() *pb.NodeProto {
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Literal{
+			Literal: &pb.LiteralNodeProto{
+				Value: &pb.LiteralNodeProto_StringValue{
+					StringValue: string(*s),
+				},
+			},
+		},
+	}
+}
+
+func (s *StringExpression) FromProto(node *pb.NodeProto) {
+	*s = StringExpression(node.GetLiteral().GetStringValue())
+}
+
+func (s *StringExpression) Clone() Expression {
+	clone := *s
+	return Expression{AnyExpression: &clone}
+}
+
+func (s StringExpression) Literal() interface{} {
+	return string(s)
+}
+
+type FeatureIDExpression FeatureID
+
+func (f *FeatureIDExpression) ToProto() *pb.NodeProto {
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Literal{
+			Literal: &pb.LiteralNodeProto{
+				Value: &pb.LiteralNodeProto_FeatureIDValue{
+					FeatureIDValue: NewProtoFromFeatureID(FeatureID(*f)),
+				},
+			},
+		},
+	}
+}
+
+func (f *FeatureIDExpression) FromProto(node *pb.NodeProto) {
+	*f = FeatureIDExpression(NewFeatureIDFromProto(node.GetLiteral().GetFeatureIDValue()))
+}
+
+func (f FeatureIDExpression) MarshalYAML() (interface{}, error) {
+	return FeatureID(f).MarshalYAML()
+}
+
+func (f *FeatureIDExpression) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return (*FeatureID)(f).UnmarshalYAML(unmarshal)
+}
+
+func (f *FeatureIDExpression) Clone() Expression {
+	clone := *f
+	return Expression{AnyExpression: &clone}
+}
+
+func (f FeatureIDExpression) Literal() interface{} {
+	return FeatureID(f)
+}
+
+type CallExpression struct {
+	Function  Expression   `yaml:",omitempty"`
+	Args      []Expression `yaml:",omitempty"`
+	Pipelined bool         `yaml:",omitempty"`
+}
+
+func (c *CallExpression) ToProto() *pb.NodeProto {
+	args := make([]*pb.NodeProto, len(c.Args))
+	for i, arg := range c.Args {
+		args[i] = arg.ToProto()
+	}
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Call{
+			Call: &pb.CallNodeProto{
+				Function:  c.Function.ToProto(),
+				Args:      args,
+				Pipelined: c.Pipelined,
+			},
+		},
+	}
+}
+
+func (c *CallExpression) FromProto(node *pb.NodeProto) {
+	call := node.GetCall()
+	c.Function.FromProto(call.Function)
+	c.Args = make([]Expression, len(call.Args))
+	for i, arg := range call.Args {
+		c.Args[i].FromProto(arg)
+	}
+	c.Pipelined = call.Pipelined
+}
+
+func (c *CallExpression) Clone() Expression {
+	args := make([]Expression, len(c.Args))
+	for i, arg := range c.Args {
+		args[i] = arg.Clone()
+	}
+	return Expression{AnyExpression: &CallExpression{
+		Function: c.Function.Clone(),
+		Args:     args,
+	}}
+}
+
+type LambdaExpression struct {
+	Args       []string   `yaml:",omitempty"`
+	Expression Expression `yaml:",omitempty"`
+}
+
+func (l *LambdaExpression) ToProto() *pb.NodeProto {
+	return &pb.NodeProto{
+		Node: &pb.NodeProto_Lambda_{
+			Lambda_: &pb.LambdaNodeProto{
+				Args: l.Args,
+				Node: l.Expression.ToProto(),
+			},
+		},
+	}
+}
+
+func (l *LambdaExpression) FromProto(node *pb.NodeProto) {
+	lambda := node.GetLambda_()
+	l.Args = lambda.Args
+	l.Expression.FromProto(lambda.Node)
+}
+
+func (l *LambdaExpression) Clone() Expression {
+	names := make([]string, len(l.Args))
+	for i, name := range l.Args {
+		names[i] = name
+	}
+	return Expression{AnyExpression: &LambdaExpression{
+		Args:       names,
+		Expression: l.Expression.Clone(),
+	}}
+}

--- a/src/diagonal.works/b6/ingest/change.go
+++ b/src/diagonal.works/b6/ingest/change.go
@@ -21,6 +21,7 @@ type AddFeatures struct {
 	Areas        []*AreaFeature
 	Relations    []*RelationFeature
 	Collections  []*CollectionFeature
+	Expressions  []*ExpressionFeature
 	IDsToReplace map[b6.Namespace]b6.Namespace
 }
 
@@ -103,6 +104,12 @@ func (a *AddFeatures) Apply(w MutableWorld) (AppliedChange, error) {
 		// ID replacement not supported for collections.
 		// TODO delete replacement for all features, no longer necessary.
 		if err := w.AddCollection(collection); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, expression := range a.Expressions {
+		if err := w.AddExpression(expression); err != nil {
 			return nil, err
 		}
 	}

--- a/src/diagonal.works/b6/ingest/features_test.go
+++ b/src/diagonal.works/b6/ingest/features_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestRemoveTags(t *testing.T) {
-	tags := Tags{
+	tags := b6.Tags{
 		{Key: "startNode", Value: "23A9FC0E-CBAB-425C-A7C9-B3356F17AF52"},
 		{Key: "roadNumber", Value: "A5202"},
 		{Key: "endNode", Value: "541F7F78-ED83-40D9-9488-3FD36D169B69"},
 		{Key: "class", Value: "A Road"},
 	}
 	tags.RemoveTags([]string{"startNode", "endNode"})
-	expected := Tags{
+	expected := b6.Tags{
 		{Key: "roadNumber", Value: "A5202"},
 		{Key: "class", Value: "A Road"},
 	}

--- a/src/diagonal.works/b6/ingest/tokens.go
+++ b/src/diagonal.works/b6/ingest/tokens.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/geo/s2"
 )
 
-func TokensForFeature(feature b6.PhysicalFeature) []string {
+func TokensForFeature(feature b6.Feature) []string {
 	if feature.FeatureID().Type == b6.FeatureTypePoint && len(feature.AllTags()) == 0 {
 		return []string{}
 	}
@@ -14,8 +14,10 @@ func TokensForFeature(feature b6.PhysicalFeature) []string {
 	tokens := make([]string, 0, 64) // Best guess
 	tokens = append(tokens, search.AllToken)
 
-	covering := feature.Covering(s2.RegionCoverer{MaxLevel: search.MaxIndexedCellLevel, MaxCells: 5})
-	tokens = search.TokensForCovering(covering, tokens)
+	if p, ok := feature.(b6.PhysicalFeature); ok {
+		covering := p.Covering(s2.RegionCoverer{MaxLevel: search.MaxIndexedCellLevel, MaxCells: 5})
+		tokens = search.TokensForCovering(covering, tokens)
+	}
 
 	for _, tag := range feature.AllTags() {
 		if token, ok := b6.TokenForTag(tag); ok {

--- a/src/diagonal.works/b6/ingest/validate.go
+++ b/src/diagonal.works/b6/ingest/validate.go
@@ -95,3 +95,10 @@ func ValidateCollection(c *CollectionFeature) error {
 	}
 	return nil
 }
+
+func ValidateExpression(e *ExpressionFeature) error {
+	if !e.ExpressionID.IsValid() {
+		return fmt.Errorf("%s: invalid ID", e.ExpressionID)
+	}
+	return nil
+}

--- a/src/diagonal.works/b6/renderer/renderer_test.go
+++ b/src/diagonal.works/b6/renderer/renderer_test.go
@@ -25,7 +25,7 @@ func TestFillColourFromFeature(t *testing.T) {
 		{"red", false, ""},
 	}
 	for _, test := range tests {
-		tags := ingest.Tags{{Key: "diagonal:colour", Value: test.featureColour}}
+		tags := b6.Tags{{Key: "diagonal:colour", Value: test.featureColour}}
 		feature := NewFeature(&Point{})
 		fillColourFromFeature(feature, tags)
 		tileColour, ok := feature.Tags["colour"]


### PR DESCRIPTION
Support expressions as features within the world. Adds a new, non proto, based representation for expressions, which will become the standard internal representation for, eg, the VM in a future CL. Support exporting expressions as YAML, though not yet in a compact world. Moves Tags from b6/ingest to b6/ for wider reuse.