### PR TITLE
Use collections, not relations, for the render context feature.

### DIFF
--- a/src/diagonal.works/b6/api/functions/graph_test.go
+++ b/src/diagonal.works/b6/api/functions/graph_test.go
@@ -84,7 +84,7 @@ func TestAccessibilityFlipped(t *testing.T) {
 	}
 }
 
-func accessibilityForGranarySquare(options []b6.Tag, w b6.World) (b6.Collection[b6.Identifiable, b6.FeatureID], error) {
+func accessibilityForGranarySquare(options []b6.Tag, w b6.World) (b6.Collection[b6.FeatureID, b6.FeatureID], error) {
 	context := &api.Context{
 		World:   w,
 		Cores:   2,
@@ -98,7 +98,7 @@ func accessibilityForGranarySquare(options []b6.Tag, w b6.World) (b6.Collection[
 	return accessible(context, ids, b6.Keyed{Key: "entrance"}, 500, b6.ArrayValuesCollection[b6.Tag](options).Collection())
 }
 
-func fillODsFromCollection(ods map[graph.OD]struct{}, c b6.Collection[b6.Identifiable, b6.FeatureID]) error {
+func fillODsFromCollection(ods map[graph.OD]struct{}, c b6.Collection[b6.FeatureID, b6.FeatureID]) error {
 	i := c.Begin()
 	for {
 		ok, err := i.Next()
@@ -107,7 +107,7 @@ func fillODsFromCollection(ods map[graph.OD]struct{}, c b6.Collection[b6.Identif
 		} else if !ok {
 			break
 		}
-		ods[graph.OD{Origin: i.Key().FeatureID(), Destination: i.Value().FeatureID()}] = struct{}{}
+		ods[graph.OD{Origin: i.Key(), Destination: i.Value()}] = struct{}{}
 	}
 	return nil
 }

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1214,6 +1214,8 @@ const featureTypes = {
     "FeatureTypePath": "path",
     "FeatureTypeArea": "area",
     "FeatureTypeRelation": "relation",
+    "FeatureTypeCollection": "collection",
+    "FeatureTypeExpression": "expression",
 }
 
 function idTokenFromProto(p) {
@@ -1454,6 +1456,10 @@ class Styles {
 }
 
 function setup(startupResponse) {
+    if (startupResponse.error) {
+        console.log(startupResponse.error); // TODO: show a banner
+        return;
+    }
     const state = {highlighted: {}, bucketed: {}};
     const styles = new Styles(StyleClasses);
     const mapCenter = startupResponse.mapCenter || InitialCenter;

--- a/src/diagonal.works/b6/ingest/compact/read.go
+++ b/src/diagonal.works/b6/ingest/compact/read.go
@@ -179,7 +179,7 @@ func ReadWorld(input string, cores int) (b6.World, error) {
 			changed = true
 			log.Printf("Apply %s", tr.Filename)
 			if _, err := tr.Change.Apply(m); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%s: %w", tr.Filename, err)
 			}
 		}
 	}

--- a/src/diagonal.works/b6/ingest/yaml.go
+++ b/src/diagonal.works/b6/ingest/yaml.go
@@ -151,12 +151,19 @@ func (i ingestedYAML) Apply(m MutableWorld) (b6.Collection[b6.FeatureID, b6.Feat
 // TODO: find a neat way of moving these functions alongside MarshalYAML
 // on the feature implementations themselves.
 func newPointFromYAML(y *exportedYAML) (*PointFeature, error) {
+	if y.ID.Type != b6.FeatureTypePoint {
+		return nil, fmt.Errorf("expected a point for %s", y.ID)
+	}
 	p := NewPointFeature(y.ID.ToPointID(), y.Point.LatLng)
 	p.Tags = y.Tags
 	return p, nil
 }
 
 func newPathFromYAML(y *exportedYAML) (*PathFeature, error) {
+	if y.ID.Type != b6.FeatureTypePath {
+		return nil, fmt.Errorf("expected a path for %s", y.ID)
+	}
+
 	p := NewPathFeature(len(y.Path))
 	p.PathID = y.ID.ToPathID()
 	for i := range y.Path {
@@ -179,6 +186,10 @@ func newPathFromYAML(y *exportedYAML) (*PathFeature, error) {
 }
 
 func newAreaFromYAML(y *exportedYAML) (*AreaFeature, error) {
+	if y.ID.Type != b6.FeatureTypeArea {
+		return nil, fmt.Errorf("expected an area for %s", y.ID)
+	}
+
 	a := NewAreaFeature(len(y.Area))
 	a.AreaID = y.ID.ToAreaID()
 	for i := range y.Area {
@@ -227,6 +238,9 @@ func newAreaFromYAML(y *exportedYAML) (*AreaFeature, error) {
 }
 
 func newRelationFromYAML(y *exportedYAML) (*RelationFeature, error) {
+	if y.ID.Type != b6.FeatureTypeRelation {
+		return nil, fmt.Errorf("expected a relation for %s", y.ID)
+	}
 	r := NewRelationFeature(len(y.Relation))
 	r.RelationID = y.ID.ToRelationID()
 	r.Members = y.Relation
@@ -235,8 +249,11 @@ func newRelationFromYAML(y *exportedYAML) (*RelationFeature, error) {
 }
 
 func newCollectionFeatureFromYAML(y *exportedYAML) (*CollectionFeature, error) {
-	var keys, values []interface{}
+	if y.ID.Type != b6.FeatureTypeCollection {
+		return nil, fmt.Errorf("expected a collection for %s", y.ID)
+	}
 
+	var keys, values []interface{}
 	i := y.Collection.BeginUntyped()
 	for {
 		ok, err := i.Next()
@@ -258,6 +275,10 @@ func newCollectionFeatureFromYAML(y *exportedYAML) (*CollectionFeature, error) {
 }
 
 func newExpressionFromYAML(y *exportedYAML) (*ExpressionFeature, error) {
+	if y.ID.Type != b6.FeatureTypeExpression {
+		return nil, fmt.Errorf("expected an expression for %s", y.ID)
+	}
+
 	return &ExpressionFeature{
 		ExpressionID: y.ID.ToExpressionID(),
 		Tags:         y.Tags,

--- a/src/diagonal.works/b6/ingest/yaml_test.go
+++ b/src/diagonal.works/b6/ingest/yaml_test.go
@@ -3,7 +3,6 @@ package ingest
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"testing"
 
 	"diagonal.works/b6"
@@ -121,9 +120,8 @@ func TestExportModificationsAsYAML(t *testing.T) {
 
 	var buffer bytes.Buffer
 	if err := ExportChangesAsYAML(m, &buffer); err != nil {
-		t.Errorf("Expected no error, found: %s", err)
+		t.Fatalf("Expected no error, found: %s", err)
 	}
-	log.Printf("yaml: %s", buffer.Bytes())
 
 	ingested := NewMutableOverlayWorld(base)
 	change := IngestChangesFromYAML(&buffer)


### PR DESCRIPTION
Also return errors when exporting Features as YAML, as we don't actually support that. Handle collection and expression IDs in the JS code, and remove Identifiable from the return type of accessible(), in preparation for not supporting it.