### PR TITLE
Add transit weights for `accessible`.

### DIFF
--- a/src/diagonal.works/b6/ui/lines.go
+++ b/src/diagonal.works/b6/ui/lines.go
@@ -388,6 +388,17 @@ func fillSubstacksFromFeature(substacks []*pb.SubstackProto, f b6.Feature, w b6.
 	}
 	substacks = append(substacks, substack)
 
+	if point, ok := f.(b6.PointFeature); ok {
+		paths := b6.AllPaths(w.FindPathsByPoint(point.PointID()))
+		substack := &pb.SubstackProto{Collapsable: true}
+		line := leftRightValueLineFromValues("Paths", len(paths), w)
+		substack.Lines = append(substack.Lines, line)
+		for _, path := range paths {
+			substack.Lines = append(substack.Lines, ValueLineFromValue(path, w))
+		}
+		substacks = append(substacks, substack)
+	}
+
 	if path, ok := f.(b6.PathFeature); ok {
 		substack := &pb.SubstackProto{Collapsable: true}
 		line := leftRightValueLineFromValues("Points", path.Len(), w)

--- a/src/diagonal.works/b6/ui/lines_test.go
+++ b/src/diagonal.works/b6/ui/lines_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"testing"
 
+	"diagonal.works/b6/api"
+	"diagonal.works/b6/api/functions"
 	"diagonal.works/b6/ingest"
 	"diagonal.works/b6/test/camden"
 
@@ -41,10 +43,17 @@ func sendExpressionToTestUI(e string, t *testing.T) *UIResponseJSON {
 	w := ingest.NewMutableOverlayWorld(base)
 
 	handler := StackHandler{
-		UI: NewDefaultUI(w),
+		UI: &OpenSourceUI{
+			World:           w,
+			FunctionSymbols: functions.Functions(),
+			Adaptors:        functions.Adaptors(),
+			Options: api.Options{
+				Cores: 2,
+			},
+		},
 	}
 
-	url := fmt.Sprintf("http://b6.diagonal.works/blocks?e=%s", url.QueryEscape(e))
+	url := fmt.Sprintf("http://b6.diagonal.works/stack?e=%s", url.QueryEscape(e))
 	request := httptest.NewRequest("GET", url, nil)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)

--- a/src/diagonal.works/b6/ui/ui_test.go
+++ b/src/diagonal.works/b6/ui/ui_test.go
@@ -11,7 +11,9 @@ import (
 
 func TestStateFilledFromStartupQuery(t *testing.T) {
 	handler := StartupHandler{
-		UI: NewDefaultUI(b6.EmptyWorld{}),
+		UI: &OpenSourceUI{
+			World: b6.EmptyWorld{},
+		},
 	}
 
 	url := "http://b6.diagonal.works/startup?ll=51.5321489,-0.1253271&z=18&d=2&e=find-feature+/n/3501612811"


### PR DESCRIPTION
Add transit weights for `accessible`. Also change the maximum weight supplied to be a time, rather than a constant without units. In passing, show the paths referenced by a point in the UI.