### PR TITLE
Correctly simplify partial and queries.

### DIFF
--- a/python/diagonal_b6/connect.py
+++ b/python/diagonal_b6/connect.py
@@ -18,12 +18,12 @@ class Connection:
         request.request.CopyFrom(node.to_node_proto())
         return expression.from_node_proto(self.stub.Evaluate(request).result)
 
-def connect_insecure(address):
-    channel = grpc.insecure_channel(address)
+def connect_insecure(address, channel_arguments=None):
+    channel = grpc.insecure_channel(address, options=channel_arguments)
     return Connection(api_pb2_grpc.B6Stub(channel))
 
-def connect(address, token, root_certificates=None):
+def connect(address, token, root_certificates=None, channel_arguments=None):
     channel_credentials = grpc.ssl_channel_credentials(root_certificates=root_certificates)
     credentials = grpc.composite_channel_credentials(channel_credentials, grpc.access_token_call_credentials(token))
-    channel = grpc.secure_channel(address, credentials)
+    channel = grpc.secure_channel(address, credentials, options=channel_arguments)
     return Connection(api_pb2_grpc.B6Stub(channel))

--- a/src/diagonal.works/b6/api/shell.go
+++ b/src/diagonal.works/b6/api/shell.go
@@ -745,6 +745,9 @@ func simplifyCallBuildingQuery(expression b6.Expression, functions SymbolArgCoun
 }
 
 func simplifyCallBuildingAndOrOrQuery(symbol string, call *b6.CallExpression) (b6.AnyExpression, bool) {
+	if len(call.Args) != 2 {
+		return nil, false
+	}
 	args := make([]*b6.QueryExpression, 0, 2)
 	for _, arg := range call.Args {
 		if q, ok := arg.AnyExpression.(*b6.QueryExpression); ok {

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -166,6 +166,11 @@ form.shell-form > input {
     display: none;
 }
 
+.palette > .rail {
+    stroke: #9aa4cc;
+    stroke-width: 2px;
+}
+
 .palette > .road-outline {
     stroke: #9aa4cc;
     fill-opacity: 0;
@@ -211,6 +216,11 @@ form.shell-form > input {
     stroke: #37589f;
     stroke-width: 1;
     fill: #93acf6;
+}
+
+.palette > .highlighted-rail {
+    stroke: #37589f;
+    stroke-width: 2px;
 }
 
 .palette > .highlighted-boundary {
@@ -783,6 +793,8 @@ form.shell-form > input {
 
 .message {
     position: absolute;
+    left: 10px;
+    top: 42px;
     z-index: 1;
     padding: 12px;
     border-radius: 4px;

--- a/src/diagonal.works/b6/expression.go
+++ b/src/diagonal.works/b6/expression.go
@@ -11,6 +11,7 @@ import (
 	"diagonal.works/b6/geometry"
 	pb "diagonal.works/b6/proto"
 	"github.com/golang/geo/s2"
+	"gopkg.in/yaml.v2"
 )
 
 // TODO: Use constraints.Integer etc?
@@ -79,6 +80,14 @@ func (e Expression) MarshalYAML() (interface{}, error) {
 		End:   e.End,
 	}
 	return marshalChoiceYAML(&expressionChoices{}, e.AnyExpression, &y)
+}
+
+func (e Expression) Format() string {
+	if j, err := yaml.Marshal(e); err == nil {
+		return string(j)
+	} else {
+		return err.Error()
+	}
 }
 
 type expressionYAML struct {

--- a/src/diagonal.works/b6/renderer/renderer.go
+++ b/src/diagonal.works/b6/renderer/renderer.go
@@ -144,6 +144,7 @@ func (rs RenderRules) IsRendered(tag b6.Tag) bool {
 }
 
 var BasemapRenderRules = RenderRules{
+	{Tag: b6.Tag{Key: "#building", Value: "train_station"}, MinZoom: 12, Layer: BasemapLayerBuilding},
 	{Tag: b6.Tag{Key: "#building"}, MinZoom: 14, Layer: BasemapLayerBuilding},
 	{Tag: b6.Tag{Key: "#highway", Value: "cycleway"}, MinZoom: 16, Layer: BasemapLayerRoad},
 	{Tag: b6.Tag{Key: "#highway", Value: "footway"}, MinZoom: 16, Layer: BasemapLayerRoad},
@@ -174,6 +175,7 @@ var BasemapRenderRules = RenderRules{
 	{Tag: b6.Tag{Key: "#natural", Value: "coastline"}, MinZoom: 12, Layer: BasemapLayerBoundary},
 	{Tag: b6.Tag{Key: "#natural", Value: "heath"}, MinZoom: 14, Layer: BasemapLayerLandUse},
 	{Tag: b6.Tag{Key: "#outline", Value: "contour"}, MinZoom: 14, Layer: BasemapLayerContour},
+	{Tag: b6.Tag{Key: "#railway", Value: "rail"}, MinZoom: 12, Layer: BasemapLayerRoad},
 	{Tag: b6.Tag{Key: "#water"}, MinZoom: 12, Layer: BasemapLayerWater},
 	{Tag: b6.Tag{Key: "#waterway"}, MinZoom: 14, Layer: BasemapLayerWater},
 	{Tag: b6.Tag{Key: "#place", Value: "city"}, MaxZoom: 11, Layer: BasemapLayerLabel},

--- a/src/diagonal.works/b6/ui/labels.go
+++ b/src/diagonal.works/b6/ui/labels.go
@@ -23,7 +23,6 @@ var labelsForTag = []struct {
 	{b6.Tag{Key: "#building", Value: "residential"}, []Label{{"Residential", "Residences"}}},
 	{b6.Tag{Key: "#building", Value: "garage"}, []Label{{"Garage", "Garages"}}},
 	{b6.Tag{Key: "#building", Value: "church"}, []Label{{"Church", "Churches"}}},
-	{b6.Tag{Key: "#building", Value: "detached"}, []Label{{"Detached house", "Detached houses"}}},
 	{b6.Tag{Key: "#building", Value: "school"}, []Label{{"School", "Schools"}}},
 	{b6.Tag{Key: "#building", Value: "apartments"}, []Label{{"Apartments", "Apartments"}}},
 	{b6.Tag{Key: "#building", Value: "commercial"}, []Label{{"Commercial", "Commercial"}}},


### PR DESCRIPTION
In passing: render rail tracks on the map, show error messages for failed backend requests, and remove event handlers when reusing rendered elements.