### PR TITLE
Fix unnecessary scroll bars

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -431,7 +431,6 @@ form.shell-form > input {
 }
 
 .line {
-    width: 282px;
     max-width: 282px;
     height: 20px;
     box-sizing: content-box;

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -713,7 +713,7 @@ form.shell-form > input {
 }
 
 .stack > .substack > .scrollable {
-    overflow-y: scroll;
+    overflow-y: auto;
     box-sizing: content-box;
     max-height: 269px;
 }

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -725,7 +725,7 @@ form.shell-form > input {
 }
 
 .stack > .substack.collapsable.collapsable-open > .scrollable {
-    overflow-y: scroll;
+    overflow-y: auto;
     max-height: 269px;
     transition: max-height 0.5s ease-in-out;
 }


### PR DESCRIPTION
#### Goal
Fix the issue where unnecessary scroll bars were showing on stacks.

#### Description
How to reproduce on Mac:
Go to System Settings > Appearance > Scroll bar behavior and set "Show scroll bars" to "Always".

Changes `overflow-y: scroll` to `overflow-y: auto` so that scroll bars are only shown when content overflows.

Additionally, because the width of line elements was fixed, it would result in the following "ghost" borders (image below) when some elements in the stack had scrollbars. We remove this, this also avoids a width change when elements become scrollable, avoiding a layout shift.

<img width="180" alt="Screenshot 2024-01-25 at 12 03 33" src="https://github.com/diagonalworks/diagonal-b6/assets/23224854/57c0d58e-d3e9-4f92-baae-aefc8c178703">


#### Comments
The first commit 2ca47f1 in the PR includes slight changes due to formatting. Is there somewhere where we define these formatting configs? 