### PR TITLE
Bucket interaction and visualization 

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -302,7 +302,8 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
                     const color = bucketedBuildingFill[bucket]
                         .getFill()
                         .getColor();
-                    if (state.showBucket == bucket && state.showBucket > 0) {
+
+                    if (state.showBucket == bucket && state.showBucket > -1) {
                         return new Style({
                             fill: new Fill({ color }),
                             stroke: new Stroke({ color: '#4f5a7d', width: 1 }),
@@ -1036,12 +1037,15 @@ class SwatchLineRenderer {
 
             line.on('click', function (e) {
                 e.stopPropagation();
+                const isSelected = line.classed('selected');
 
                 stack.target
                     .selectAll('.line-swatch')
                     .classed('selected', false);
 
-                line.attr('class', `${line.attr('class')} ${'selected'}`);
+                if (!isSelected) {
+                    line.attr('class', `${line.attr('class')} ${'selected'}`);
+                }
 
                 stack.toggleShowBucket(index);
             });

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1031,8 +1031,18 @@ class SwatchLineRenderer {
                 (d) =>
                     `range-icon index-${d.swatch.index ? d.swatch.index : 0}`,
             );
+
+            line.attr('class', `${line.attr('class')} ${'interactive'}`);
+
             line.on('click', function (e) {
                 e.stopPropagation();
+
+                stack.target
+                    .selectAll('.line-swatch')
+                    .classed('selected', false);
+
+                line.attr('class', `${line.attr('class')} ${'selected'}`);
+
                 stack.toggleShowBucket(index);
             });
         }

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1172,6 +1172,7 @@ class ChoiceLineRenderer {
             .selectAll('span')
             .data((d) => this._mergeAtoms(d))
             .join('span');
+
         renderFromProto(atoms, 'atom', stack);
     }
 
@@ -1386,6 +1387,7 @@ class UI {
             this.openDockIndex = index;
             if (docked.__stack__) {
                 this.state.bucketed = {};
+                docked.__stack__.toggleShowBucket(-1);
                 docked.__stack__.addToMap();
             }
         } else {

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -48,6 +48,15 @@
     src: url('https://diagonal.works/fonts/unica77-bold.woff2') format('woff2');
 }
 
+:root {
+    --bucket-0: #f1eef6;
+    --bucket-1: #d0d1e6;
+    --bucket-2: #a6bddb;
+    --bucket-3: #74a9cf;
+    --bucket-4: #2b8cbe;
+    --bucket-5: #045a8d;
+}
+
 html {
     background: white;
     font-family: 'Unica 77', sans-serif;
@@ -348,37 +357,37 @@ form.shell-form > input {
 }
 
 .palette > .bucketed-0 {
-    fill: #ffffff;
+    fill: var(--bucket-0);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
 
 .palette > .bucketed-1 {
-    fill: #a9aec5;
+    fill: var(--bucket-1);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
 
 .palette > .bucketed-2 {
-    fill: #9ccdeb;
+    fill: var(--bucket-2);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
 
 .palette > .bucketed-3 {
-    fill: #bce6ee;
+    fill: var(--bucket-3);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
 
 .palette > .bucketed-4 {
-    fill: #d6f5e6;
+    fill: var(--bucket-4);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
 
 .palette > .bucketed-5 {
-    fill: #f4fde5;
+    fill: var(--bucket-5);
     stroke: #4f5a7d;
     stroke-width: 0.3;
 }
@@ -560,32 +569,32 @@ form.shell-form > input {
 }
 
 .range-icon.index-0 {
-    background-color: #ffffff;
+    background-color: var(--bucket-0);
     border: 1px solid var(--border-color);
 }
 
 .range-icon.index-1 {
-    background-color: #a9aec5;
+    background-color: var(--bucket-1);
     border: 1px solid var(--border-color);
 }
 
 .range-icon.index-2 {
-    background-color: #9ccdeb;
+    background-color: var(--bucket-2);
     border: 1px solid var(--border-color);
 }
 
 .range-icon.index-3 {
-    background-color: #bce6ee;
+    background-color: var(--bucket-3);
     border: 1px solid var(--border-color);
 }
 
 .range-icon.index-4 {
-    background-color: #d6f5e6;
+    background-color: var(--bucket-4);
     border: 1px solid var(--border-color);
 }
 
 .range-icon.index-5 {
-    background-color: #f4fde5;
+    background-color: var(--bucket-5);
     border: 1px solid var(--border-color);
 }
 

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -555,34 +555,38 @@ form.shell-form > input {
     height: 12px;
 }
 
+.range-icon {
+    --border-color: #a9aec5; /* Graphite 50 */
+}
+
 .range-icon.index-0 {
     background-color: #ffffff;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .range-icon.index-1 {
     background-color: #a9aec5;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .range-icon.index-2 {
     background-color: #9ccdeb;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .range-icon.index-3 {
     background-color: #bce6ee;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .range-icon.index-4 {
     background-color: #d6f5e6;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .range-icon.index-5 {
     background-color: #f4fde5;
-    border: 1px solid #dbdeec; /* Graphite 30 */
+    border: 1px solid var(--border-color);
 }
 
 .line-histogram-bar .range-icon {

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -651,6 +651,25 @@ form.shell-form > input {
     margin-top: 4px;
 }
 
+.interactive {
+    cursor: pointer;
+    transition-property: background-color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+}
+
+.interactive:hover {
+    background-color: #f8f9fc; /* Graphite 10 */
+}
+
+.selected {
+    background-color: #dbdeec; /* Graphite 30 */
+}
+
+.selected:hover {
+    background-color: #c3c6d9; /* Graphite 40 */
+}
+
 .substack .line-swatch {
     border-top-color: white;
 }

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -49,12 +49,12 @@
 }
 
 :root {
-    --bucket-0: #fff;
-    --bucket-1: #d0d1e6;
-    --bucket-2: #a6bddb;
-    --bucket-3: #74a9cf;
-    --bucket-4: #2b8cbe;
-    --bucket-5: #045a8d;
+    --bucket-0: #ffffff;
+    --bucket-1: #a9aec5;
+    --bucket-2: #9ccdeb;
+    --bucket-3: #bce6ee;
+    --bucket-4: #d6f5e6;
+    --bucket-5: #f4fde5;
 }
 
 html {

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -49,7 +49,7 @@
 }
 
 :root {
-    --bucket-0: #f1eef6;
+    --bucket-0: #fff;
     --bucket-1: #d0d1e6;
     --bucket-2: #a6bddb;
     --bucket-3: #74a9cf;


### PR DESCRIPTION
#### Goal

The goal of this PR is to fix the issues identified with the visualization of the buckets. Namely:
- [x] Visual feedback on the button when a bucket is selected
- [x] Bucket selection should reset when changing AQ.
- [x] Add a darker outline around symbols in legend
- [x] How to highlight buildings in the 0 bucket on the map?

#### Description

In addition to the issues described above, this PR includes some additional experiments around the color encoding used in the bucket visualization:

- 🧪 Experiment 1: Color Scale
In addition to the issues above, there might be an opportunity to test different color scales. Our current color scale is similar to [viridis](https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html), where the lowest value (1) is a darker shade of blue/purple, and the highest value (5) is a light yellow. This means that there's little contrast between 0 (white) and 5, and a large contrast between 0 and 1 - this may be unintuitive when reading the map. A classed sequential color scale could be a better-suited alternative. 
**Decision:** While it's agreed that we should revisit the color scale, this will be tackled in a subsequent PR as it required more exploration.

- 🧪 Experiment 2: Highlight
Currently, the interaction on the legend works as a filter. This means that when we select a legend item, the behavior is to keep the buildings in the selected bucket in color and use the default color (white) to fill the rest. Because the default color can also mean 0 on the scale, this might cause some confusion. Additionally, it might be useful to keep the context of the other values when highlighting a bucket. We experiment instead with a highlight behavior, where we keep the colors, increase the stroke of the selected bucket, and decrease the opacity of the rest.
**Decision:**: Added in this PR.

![Screen Recording 2024-02-07 at 09 07 14](https://github.com/diagonalworks/diagonal-b6/assets/23224854/b1bb8f12-c3c3-4b86-aecb-27ba722b6caa)



#### Comments

#### References
https://blog.datawrapper.de/classed-vs-unclassed-color-scales/
https://blog.datawrapper.de/color-keys-for-data-visualizations/
https://blog.datawrapper.de/which-color-scale-to-use-in-data-vis/
