### PR TITLE
Add prettier and eslint

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/.eslintrc.json
+++ b/src/diagonal.works/b6/cmd/b6/js/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": ["eslint:recommended", "prettier"],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "rules": {}
+}

--- a/src/diagonal.works/b6/cmd/b6/js/.eslintrc.json
+++ b/src/diagonal.works/b6/cmd/b6/js/.eslintrc.json
@@ -8,5 +8,6 @@
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
-    "rules": {}
+    "rules": {},
+    "ignorePatterns": ["bundle.js"]
 }

--- a/src/diagonal.works/b6/cmd/b6/js/.prettierignore
+++ b/src/diagonal.works/b6/cmd/b6/js/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+build
+dist

--- a/src/diagonal.works/b6/cmd/b6/js/.prettierignore
+++ b/src/diagonal.works/b6/cmd/b6/js/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 build
 dist
+bundle.js

--- a/src/diagonal.works/b6/cmd/b6/js/.prettierrc
+++ b/src/diagonal.works/b6/cmd/b6/js/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "trailingComma": "es5",
+    "trailingComma": "all",
     "tabWidth": 4,
     "semi": true,
     "singleQuote": true,

--- a/src/diagonal.works/b6/cmd/b6/js/.prettierrc
+++ b/src/diagonal.works/b6/cmd/b6/js/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "trailingComma": "all",
+    "trailingComma": "es5",
     "tabWidth": 4,
     "semi": true,
     "singleQuote": true,

--- a/src/diagonal.works/b6/cmd/b6/js/.prettierrc
+++ b/src/diagonal.works/b6/cmd/b6/js/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 80,
+    "useTabs": false,
+    "bracketSpacing": true,
+    "arrowParens": "always",
+    "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/src/diagonal.works/b6/cmd/b6/js/Makefile
+++ b/src/diagonal.works/b6/cmd/b6/js/Makefile
@@ -4,4 +4,7 @@ bundle.js:
 	npm install
 	npm run build
 
+format:
+	npx prettier . --write       
+  
 .PHONY: bundle.js

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1,52 +1,52 @@
-import * as d3 from "d3";
+import * as d3 from 'd3';
 
-import {defaults as InteractionDefaults} from "ol/interaction";
-import {fromLonLat, toLonLat} from "ol/proj";
-import Circle from "ol/style/Circle";
-import Fill from "ol/style/Fill";
-import GeoJSONFormat from "ol/format/GeoJSON";
-import Map from "ol/Map";
-import MVT from "ol/format/MVT";
-import Stroke from "ol/style/Stroke";
-import Style from "ol/style/Style";
-import Icon from "ol/style/Icon";
-import Text from "ol/style/Text";
-import VectorLayer from "ol/layer/Vector";
-import VectorSource from "ol/source/Vector";
-import VectorTileLayer from "ol/layer/VectorTile";
-import VectorTileSource from "ol/source/VectorTile";
-import View from "ol/View";
-import Zoom from "ol/control/Zoom";
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Zoom from 'ol/control/Zoom';
+import GeoJSONFormat from 'ol/format/GeoJSON';
+import MVT from 'ol/format/MVT';
+import { defaults as InteractionDefaults } from 'ol/interaction';
+import VectorLayer from 'ol/layer/Vector';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import { fromLonLat, toLonLat } from 'ol/proj';
+import VectorSource from 'ol/source/Vector';
+import VectorTileSource from 'ol/source/VectorTile';
+import Circle from 'ol/style/Circle';
+import Fill from 'ol/style/Fill';
+import Icon from 'ol/style/Icon';
+import Stroke from 'ol/style/Stroke';
+import Style from 'ol/style/Style';
+import Text from 'ol/style/Text';
 
-const LineHeight = 20 + (2 * 12);
+const LineHeight = 20 + 2 * 12;
 const LineBorderWidth = 1;
 const InsetSquishXS = 8;
 
-const InitialCenter = {latE7: 515361156, lngE7: -1255161};
+const InitialCenter = { latE7: 515361156, lngE7: -1255161 };
 const InitalZoom = 16;
 const RoadWidths = {
-    "motorway": 36.0,
-    "trunk": 36.0,
-    "primary": 32.0,
-    "secondary": 26.0,
-    "tertiary": 26.0,
-    "street": 18.0,
-    "unclassified": 18.0,
-    "service": 18.0,
-    "residential": 18.0,
-    "cycleway": 8.0,
-    "footway": 8.0,
-    "path": 8.0,
-}
-const GeoJSONFillColour = "#364153";
+    motorway: 36.0,
+    trunk: 36.0,
+    primary: 32.0,
+    secondary: 26.0,
+    tertiary: 26.0,
+    street: 18.0,
+    unclassified: 18.0,
+    service: 18.0,
+    residential: 18.0,
+    cycleway: 8.0,
+    footway: 8.0,
+    path: 8.0,
+};
+const GeoJSONFillColour = '#364153';
 
 function scaleWidth(width, resolution) {
-    return width * (0.30 / resolution);
+    return width * (0.3 / resolution);
 }
 
 function roadWidth(feature, resolution) {
-    if (RoadWidths[feature.get("highway")]) {
-        return scaleWidth(RoadWidths[feature.get("highway")], resolution);
+    if (RoadWidths[feature.get('highway')]) {
+        return scaleWidth(RoadWidths[feature.get('highway')], resolution);
     }
     return 0;
 }
@@ -56,84 +56,89 @@ function waterwayWidth(resolution) {
 }
 
 function newGeoJSONStyle(state, styles) {
-    const point = styles.lookupCircle("geojson-point");
-    const path = styles.lookupStyle("geojson-path");
-    const area = styles.lookupStyle("geojson-area");
+    const point = styles.lookupCircle('geojson-point');
+    const path = styles.lookupStyle('geojson-path');
+    const area = styles.lookupStyle('geojson-area');
 
-    return function(feature, resolution) {
+    return function (feature, resolution) {
         var s = point;
         switch (feature.getGeometry().getType()) {
-            case "LineString":
-            case "MultiLineString":
+            case 'LineString':
+            case 'MultiLineString':
                 s = path;
-            case "Polygon":
-            case "MultiPolygon":
+            case 'Polygon':
+            case 'MultiPolygon':
                 s = area;
         }
-        if (feature.get("-b6-style")) {
-            s = styles.lookupStyle(feature.get("-b6-style"));
-        } else if (feature.get("-b6-circle")) {
-            s = styles.lookupCircle(feature.get("-b6-circle"));
-        } else if (feature.get("-b6-icon")) {
-            s = styles.lookupIcon(feature.get("-b6-icon"));
+        if (feature.get('-b6-style')) {
+            s = styles.lookupStyle(feature.get('-b6-style'));
+        } else if (feature.get('-b6-circle')) {
+            s = styles.lookupCircle(feature.get('-b6-circle'));
+        } else if (feature.get('-b6-icon')) {
+            s = styles.lookupIcon(feature.get('-b6-icon'));
         }
-        const label = feature.get("name") || feature.get("label");
+        const label = feature.get('name') || feature.get('label');
         if (label) {
             s = s.clone();
-            s.setText(new Text({
-                text: label,
-                textAlign: "left",
-                offsetX: 6,
-                offsetY: 1,
-                font: '"Roboto" 12px',
-            }));
+            s.setText(
+                new Text({
+                    text: label,
+                    textAlign: 'left',
+                    offsetX: 6,
+                    offsetY: 1,
+                    font: '"Roboto" 12px',
+                }),
+            );
         }
         return s;
-    }
+    };
 }
 
 function setupMap(target, state, styles, mapCenter, mapZoom) {
     const zoom = new Zoom({
-        zoomInLabel: "",
-        zoomOutLabel: "",
-    })
+        zoomInLabel: '',
+        zoomOutLabel: '',
+    });
 
     const baseSource = new VectorTileSource({
         format: new MVT(),
-        url: "/tiles/base/{z}/{x}/{y}.mvt",
+        url: '/tiles/base/{z}/{x}/{y}.mvt',
         minZoom: 10,
-        maxZoom: 16
+        maxZoom: 16,
     });
 
     var backgroundFill = new Style({
-        fill: new Fill({color: "#eceff7"}),
+        fill: new Fill({ color: '#eceff7' }),
     });
-
 
     const background = new VectorTileLayer({
         source: baseSource,
         style: function (feature, resolution) {
-            if (feature.get("layer") == "background") {
+            if (feature.get('layer') == 'background') {
                 return backgroundFill;
             }
-        }
+        },
     });
 
     const boundaries = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "boundary") {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'boundary') {
                 if (state.featureColours) {
-                    const colour = state.featureColours[idKeyFromFeature(feature)];
+                    const colour =
+                        state.featureColours[idKeyFromFeature(feature)];
                     if (colour) {
                         return new Style({
-                            fill: new Fill({color: colour}),
-                            stroke: new Stroke({color: "#4f5a7d", width: 0.3})
+                            fill: new Fill({ color: colour }),
+                            stroke: new Stroke({
+                                color: '#4f5a7d',
+                                width: 0.3,
+                            }),
                         });
                     }
                 }
-                if (feature.get("natural") == "coastline") {
-                    return styles.lookupStyle("coastline");
+                if (feature.get('natural') == 'coastline') {
+                    return styles.lookupStyle('coastline');
                 }
             }
         },
@@ -141,69 +146,93 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const water = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "water") {
-                if (feature.getType() == "Polygon") {
-                    return styles.lookupStyle("water-area");
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'water') {
+                if (feature.getType() == 'Polygon') {
+                    return styles.lookupStyle('water-area');
                 } else {
                     const width = waterwayWidth(resolution);
                     if (width > 0) {
-                        return styles.lookupStyleWithStokeWidth("water-line", width );
+                        return styles.lookupStyleWithStokeWidth(
+                            'water-line',
+                            width,
+                        );
                     }
                 }
             }
-        }
+        },
     });
-    water.set("clickable", true);
+    water.set('clickable', true);
 
     const landuse = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            const landuse = feature.get("landuse");
-            const leisure = feature.get("leisure");
-            const natural = feature.get("natural");
-            if (feature.get("layer") == "landuse") {
-                if (landuse == "park" || landuse == "grass" || leisure == "pitch" || leisure == "park" || leisure == "garden" || leisure == "playground" || leisure == "nature_reserve") {
-                    return styles.lookupStyle("landuse-greenspace");
-                } else if (landuse == "forest") {
-                    return styles.lookupStyle("landuse-forest");
-                } else if (landuse == "meadow" || natural == "heath") {
-                    return styles.lookupStyle("landuse-nature");
-                } else if (landuse == "commercial" || landuse == "residential" || landuse == "industrial") {
-                    return styles.lookupStyle("landuse-urban");
+        style: function (feature, resolution) {
+            const landuse = feature.get('landuse');
+            const leisure = feature.get('leisure');
+            const natural = feature.get('natural');
+            if (feature.get('layer') == 'landuse') {
+                if (
+                    landuse == 'park' ||
+                    landuse == 'grass' ||
+                    leisure == 'pitch' ||
+                    leisure == 'park' ||
+                    leisure == 'garden' ||
+                    leisure == 'playground' ||
+                    leisure == 'nature_reserve'
+                ) {
+                    return styles.lookupStyle('landuse-greenspace');
+                } else if (landuse == 'forest') {
+                    return styles.lookupStyle('landuse-forest');
+                } else if (landuse == 'meadow' || natural == 'heath') {
+                    return styles.lookupStyle('landuse-nature');
+                } else if (
+                    landuse == 'commercial' ||
+                    landuse == 'residential' ||
+                    landuse == 'industrial'
+                ) {
+                    return styles.lookupStyle('landuse-urban');
                 }
-            } else if (feature.get("layer") == "contour") {
-                return styles.lookupStyle("contour");
+            } else if (feature.get('layer') == 'contour') {
+                return styles.lookupStyle('contour');
             }
         },
     });
-    landuse.set("clickable", true);
+    landuse.set('clickable', true);
 
     const roadOutlines = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "road" && feature.get("highway")) {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'road' && feature.get('highway')) {
                 const width = roadWidth(feature, resolution);
                 if (width > 0) {
-                    return styles.lookupStyleWithStokeWidth("road-outline", width + 2.0);
+                    return styles.lookupStyleWithStokeWidth(
+                        'road-outline',
+                        width + 2.0,
+                    );
                 }
             }
         },
     });
-    roadOutlines.set("clickable", true);
-    roadOutlines.set("position", "MapLayerPositionRoads");
+    roadOutlines.set('clickable', true);
+    roadOutlines.set('position', 'MapLayerPositionRoads');
 
     const roadFills = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "road" && feature.get("highway")) {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'road' && feature.get('highway')) {
                 const width = roadWidth(feature, resolution);
                 if (width > 0) {
                     const id = idKeyFromFeature(feature);
                     if (state.highlighted[id]) {
-                        return styles.lookupStyleWithStokeWidth("highlighted-road-fill", width);
+                        return styles.lookupStyleWithStokeWidth(
+                            'highlighted-road-fill',
+                            width,
+                        );
                     } else {
-                        return styles.lookupStyleWithStokeWidth("road-fill", width);
+                        return styles.lookupStyleWithStokeWidth(
+                            'road-fill',
+                            width,
+                        );
                     }
                 }
             }
@@ -213,10 +242,13 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
     const roadLabels = new VectorTileLayer({
         source: baseSource,
         declutter: true,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "road") {
-                if (feature.get("name")) {
-                    return styles.lookupLineTextWithText("road-label", feature.get("name"));
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'road') {
+                if (feature.get('name')) {
+                    return styles.lookupLineTextWithText(
+                        'road-label',
+                        feature.get('name'),
+                    );
                 }
             }
         },
@@ -224,40 +256,43 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const rails = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "road" && feature.get("railway")) {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'road' && feature.get('railway')) {
                 const id = idKeyFromFeature(feature);
                 if (state.highlighted[id]) {
-                    return styles.lookupStyle("highlighted-rail");
+                    return styles.lookupStyle('highlighted-rail');
                 } else {
-                    return styles.lookupStyle("rail");
+                    return styles.lookupStyle('rail');
                 }
             }
         },
     });
 
     const buildingFill = new Style({
-        fill: new Fill({color: "#ffffff"}),
-        stroke: new Stroke({color: "#4f5a7d", width: 0.3})
+        fill: new Fill({ color: '#ffffff' }),
+        stroke: new Stroke({ color: '#4f5a7d', width: 0.3 }),
     });
 
-    const highlightedBuildingFill = styles.lookupStyle("highlighted-area");
+    const highlightedBuildingFill = styles.lookupStyle('highlighted-area');
 
-    const bucketedBuildingFill = Array.from(Array(6).keys()).map(b => {
+    const bucketedBuildingFill = Array.from(Array(6).keys()).map((b) => {
         return styles.lookupStyle(`bucketed-${b}`);
     });
 
-    const bucketedPoint = Array.from(Array(6).keys()).map(b => {
+    const bucketedPoint = Array.from(Array(6).keys()).map((b) => {
         return styles.lookupCircle(`bucketed-${b}`);
     });
 
     const buildings = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "building") {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'building') {
                 const id = idKeyFromFeature(feature);
                 const bucket = state.bucketed[id];
-                if (bucket && (state.showBucket < 0 || state.showBucket == bucket)) {
+                if (
+                    bucket &&
+                    (state.showBucket < 0 || state.showBucket == bucket)
+                ) {
                     return bucketedBuildingFill[bucket];
                 }
                 if (state.highlighted[id]) {
@@ -267,44 +302,47 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
             }
         },
     });
-    buildings.set("position", "MapLayerPositionBuildings");
-    buildings.set("clickable", true);
+    buildings.set('position', 'MapLayerPositionBuildings');
+    buildings.set('clickable', true);
 
     const points = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "point") {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'point') {
                 const id = idKeyFromFeature(feature);
                 const bucket = state.bucketed[id];
-                if (bucket && (state.showBucket < 0 || state.showBucket == bucket)) {
+                if (
+                    bucket &&
+                    (state.showBucket < 0 || state.showBucket == bucket)
+                ) {
                     return bucketedPoint[bucket];
                 }
                 if (state.highlighted[id]) {
-                    return styles.lookupStyle("highlighted-point");
+                    return styles.lookupStyle('highlighted-point');
                 }
-                return styles.lookupStyle("point");
+                return styles.lookupStyle('point');
             }
         },
     });
 
     const labels = new VectorTileLayer({
         source: baseSource,
-        style: function(feature, resolution) {
-            if (feature.get("layer") == "label") {
+        style: function (feature, resolution) {
+            if (feature.get('layer') == 'label') {
                 return new Style({
                     text: new Text({
-                        text: feature.get("name"),
-                        textAlign: "left",
+                        text: feature.get('name'),
+                        textAlign: 'left',
                         offsetX: 6,
-                        offsetY: 1,    
+                        offsetY: 1,
                         fill: new Fill({
-                            color: "#000000",
+                            color: '#000000',
                         }),
                     }),
                     image: new Circle({
                         radius: 2,
                         fill: new Fill({
-                            color: "#000000",
+                            color: '#000000',
                         }),
                     }),
                 });
@@ -330,7 +368,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
             roadLabels,
             buildings,
             points,
-            labels
+            labels,
         ],
         interactions: InteractionDefaults(),
         controls: [zoom],
@@ -348,23 +386,37 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 }
 
 function lonLatToLiteral(ll) {
-    return `${ll[1].toPrecision(8)}, ${ll[0].toPrecision(8)}`
+    return `${ll[1].toPrecision(8)}, ${ll[0].toPrecision(8)}`;
 }
 
 function showFeature(feature, locked, position, ui, logEvent) {
-    const ns = feature.get("ns");
-    const id = feature.get("id");
-    const types = {"Point": "point", "LineString": "path", "Polygon": "area", "MultiPolygon": "area"};
+    const ns = feature.get('ns');
+    const id = feature.get('id');
+    const types = {
+        Point: 'point',
+        LineString: 'path',
+        Polygon: 'area',
+        MultiPolygon: 'area',
+    };
     if (ns && id && types[feature.getType()]) {
-        const expression = `find-feature /${types[feature.getType()]}/${ns}/${BigInt("0x" + id)}`;
-        ui.evaluateExpressionInNewStack(expression, null, locked, position, logEvent);
+        const expression = `find-feature /${types[feature.getType()]}/${ns}/${BigInt('0x' + id)}`;
+        ui.evaluateExpressionInNewStack(
+            expression,
+            null,
+            locked,
+            position,
+            logEvent,
+        );
     }
 }
 
 const StackOffset = [6, 6]; // Relative coordinates of stacks shown next to the mouse cursor
 
 function elementPosition(element) {
-    return [+element.style("left").replace("px", ""), +element.style("top").replace("px", "")];
+    return [
+        +element.style('left').replace('px', ''),
+        +element.style('top').replace('px', ''),
+    ];
 }
 
 class Stack {
@@ -385,29 +437,41 @@ class Stack {
         this.setupGeoJSON(this.response.proto.geoJSON, this.response.geoJSON);
         const queryLayers = this.response.proto.layers;
         for (const i in queryLayers) {
-            this.layers.push(this.ui.createQueryLayer(queryLayers[i].query, queryLayers[i].before));
+            this.layers.push(
+                this.ui.createQueryLayer(
+                    queryLayers[i].query,
+                    queryLayers[i].before,
+                ),
+            );
         }
     }
 
     render() {
-        const substacks = this.target.selectAll(".substack").data(d => d.proto.stack.substacks).join(
-            enter => {
-                const div = enter.append("div").attr("class", "substack");
-                div.append("div").attr("class", "scrollable");
+        const substacks = this.target
+            .selectAll('.substack')
+            .data((d) => d.proto.stack.substacks)
+            .join((enter) => {
+                const div = enter.append('div').attr('class', 'substack');
+                div.append('div').attr('class', 'scrollable');
                 return div;
-            }
-        );
-        substacks.classed("collapsable", d => d.collapsable);
-        this.target.selectAll(".collapsable").on("click", function(e) {
+            });
+        substacks.classed('collapsable', (d) => d.collapsable);
+        this.target.selectAll('.collapsable').on('click', function (e) {
             e.preventDefault();
             const substack = d3.select(this);
-            substack.classed("collapsable-open", !substack.classed("collapsable-open"));
+            substack.classed(
+                'collapsable-open',
+                !substack.classed('collapsable-open'),
+            );
         });
 
-        const scrollables = substacks.select(".scrollable");
-        const lines = scrollables.selectAll(".line").data(d => d.lines ? d.lines : []).join("div");
-        lines.attr("class", "line");
-        renderFromProto(lines, "line", this);
+        const scrollables = substacks.select('.scrollable');
+        const lines = scrollables
+            .selectAll('.line')
+            .data((d) => (d.lines ? d.lines : []))
+            .join('div');
+        lines.attr('class', 'line');
+        renderFromProto(lines, 'line', this);
     }
 
     remove() {
@@ -442,13 +506,13 @@ class Stack {
             const geojson = data[indices[i].index || 0];
             const source = new VectorSource({
                 features: [],
-             })
-             const layer = new VectorLayer({
-                 source: source,
-                 style: this.ui.getGeoJSONStyle(),
-             })
+            });
+            const layer = new VectorLayer({
+                source: source,
+                style: this.ui.getGeoJSONStyle(),
+            });
             const features = new GeoJSONFormat().readFeatures(geojson, {
-                dataProjection: "EPSG:4326",
+                dataProjection: 'EPSG:4326',
                 featureProjection: this.ui.getProjection(),
             });
             source.addFeatures(features);
@@ -456,7 +520,7 @@ class Stack {
 
             // TODO: We could potentially be creating multiple links
             const blob = new Blob([JSON.stringify(geojson, null, 2)], {
-                type: "application/json",
+                type: 'application/json',
             });
             this.blobURL = URL.createObjectURL(blob);
         }
@@ -492,7 +556,7 @@ class Stack {
                     const namespace = buckets[j].namespaces[k];
                     const values = buckets[j].ids[k].ids;
                     for (const l in values) {
-                        this.ui.addBucketed(namespace + "/" + values[l], j);
+                        this.ui.addBucketed(namespace + '/' + values[l], j);
                     }
                 }
             }
@@ -506,7 +570,7 @@ class Stack {
                 const namespace = highlighted.namespaces[i];
                 const values = highlighted.ids[i].ids;
                 for (const j in values) {
-                    this.ui.addHighlight(namespace + "/" + values[j]);
+                    this.ui.addHighlight(namespace + '/' + values[j]);
                 }
             }
         }
@@ -519,7 +583,7 @@ class Stack {
                 const namespace = highlighted.namespaces[i];
                 const values = highlighted.ids[i].ids;
                 for (const j in values) {
-                    this.ui.removeHighlight(namespace + "/" + values[j])
+                    this.ui.removeHighlight(namespace + '/' + values[j]);
                 }
             }
         }
@@ -553,11 +617,23 @@ class Stack {
 
     evaluateNode(node, logEvent) {
         const position = null;
-        this.ui.evaluateExpressionInNewStack("", node, this.response.proto.locked, position, logEvent);
+        this.ui.evaluateExpressionInNewStack(
+            '',
+            node,
+            this.response.proto.locked,
+            position,
+            logEvent,
+        );
     }
 
     evaluateExpressionInContext(expression, logEvent) {
-        this.ui.evaluateExpression(expression, this.response.proto.node, this.response.proto.locked, logEvent, this.target);
+        this.ui.evaluateExpression(
+            expression,
+            this.response.proto.node,
+            this.response.proto.locked,
+            logEvent,
+            this.target,
+        );
     }
 
     handleDragStart(event, clickAction) {
@@ -566,7 +642,7 @@ class Stack {
 
     handleChipValueChanged() {
         const chipValues = this.chipValues;
-        this.target.selectAll(".atom-chip-clickable").each(function() {
+        this.target.selectAll('.atom-chip-clickable').each(function () {
             while (chipValues.length <= this.__chip_index__) {
                 chipValues.push(0);
             }
@@ -587,7 +663,12 @@ class Stack {
     showMessage(message, position) {
         const rect = this.target.node().getBoundingClientRect();
         const x = rect.x + rect.width + InsetSquishXS;
-        const y = rect.y + (Math.floor((position[1] - rect.y) / (LineHeight + LineBorderWidth)) * LineHeight);
+        const y =
+            rect.y +
+            Math.floor(
+                (position[1] - rect.y) / (LineHeight + LineBorderWidth),
+            ) *
+                LineHeight;
         this.ui.showMessage(message, [x, y]);
     }
 
@@ -598,80 +679,89 @@ class Stack {
 
 class ValueAtomRenderer {
     getCSSClass() {
-        return "atom-value";
+        return 'atom-value';
     }
 
     enter() {}
 
-    update(atom) {        
-        atom.text(d => d.value);
-    }    
+    update(atom) {
+        atom.text((d) => d.value);
+    }
 }
 
 class LabelledIconAtomRenderer {
     getCSSClass() {
-        return "atom-labelled-icon";
+        return 'atom-labelled-icon';
     }
 
     enter(atom) {
-        atom.append("img");
-        atom.append("span");
+        atom.append('img');
+        atom.append('span');
     }
 
     update(atom) {
-        atom.select("img").attr("src", d => `/images/${d.labelledIcon.icon}.svg`);
-        atom.select("img").attr("class", d => `icon-${d.labelledIcon.icon}`);
-        atom.select("span").text(d => d.labelledIcon.label);
-    }    
+        atom.select('img').attr(
+            'src',
+            (d) => `/images/${d.labelledIcon.icon}.svg`,
+        );
+        atom.select('img').attr('class', (d) => `icon-${d.labelledIcon.icon}`);
+        atom.select('span').text((d) => d.labelledIcon.label);
+    }
 }
 
 class DownloadAtomRenderer {
     getCSSClass() {
-        return "atom-download";
+        return 'atom-download';
     }
 
     enter(atom) {
-        atom.append("a");
+        atom.append('a');
     }
 
     update(atom, stack) {
-        const a = atom.select("a");
+        const a = atom.select('a');
         a.node().href = stack.getBlobURL();
-        a.node().download = "b6-result.geojson";
-        a.text(d => d.download);
-    }    
+        a.node().download = 'b6-result.geojson';
+        a.text((d) => d.download);
+    }
 }
 
 class ChipAtomRenderer {
     getCSSClass() {
-        return "atom-chip";
+        return 'atom-chip';
     }
 
     enter(atom) {
-        atom.append("span");
+        atom.append('span');
     }
 
     update(atom, stack) {
-        const chip = atom.select("span").classed("atom-chip-clickable", true);
-        chip.text(d => d.chip.labels[stack.getChipValue(d.chip.index || 0)]);
-        chip.each(function(d) { // Only expects one chip
+        const chip = atom.select('span').classed('atom-chip-clickable', true);
+        chip.text((d) => d.chip.labels[stack.getChipValue(d.chip.index || 0)]);
+        chip.each(function (d) {
+            // Only expects one chip
             this.__chip_index__ = d.chip.index || 0;
             this.__chip_value__ = stack.getChipValue(this.__chip_index__);
         });
-        chip.on("click", function(e, d) {
+        chip.on('click', function (e, d) {
             e.stopPropagation();
-            d3.select(".atom-chip-nav").remove();
-            chip.classed("open", true);
+            d3.select('.atom-chip-nav').remove();
+            chip.classed('open', true);
             const bounds = this.getBoundingClientRect();
-            const nav = d3.select("body").append("nav").classed("atom-chip-nav", true);
+            const nav = d3
+                .select('body')
+                .append('nav')
+                .classed('atom-chip-nav', true);
             nav.node().style.top = `${bounds.y + bounds.height}px`;
             nav.node().style.left = `${bounds.x}px`;
-            const labels = Array.from(d.chip.labels.entries()).map(l => {return {value: l[0], label: l[1]}});
-            const chips = nav.selectAll("span").data(labels).join("div");
-            chips.classed("atom-chip-clickable", true);
-            chips.text(d => d.label);
-            chips.on("click", function(e, d) {
-                chip.classed("open", false);
+            const labels = Array.from(d.chip.labels.entries()).map((l) => {
+                return { value: l[0], label: l[1] };
+            });
+            const chips = nav.selectAll('span').data(labels).join('div');
+            chips.classed('atom-chip-clickable', true);
+            chips.text((d) => d.label);
+            chips.on('click', function (e, d) {
+                chip.classed('open', false);
                 chip.text(d.label);
                 chip.node().__chip_value__ = d.value;
                 nav.remove();
@@ -683,7 +773,7 @@ class ChipAtomRenderer {
 
 class ConditionalAtomRenderer {
     getCSSClass() {
-        return "atom-conditional";
+        return 'atom-conditional';
     }
 
     enter(atom) {}
@@ -692,8 +782,11 @@ class ConditionalAtomRenderer {
         const conditional = atom.datum().conditional;
         for (const i in conditional.conditions) {
             if (stack.stateMatchesCondition(conditional.conditions[i])) {
-                const atoms = atom.selectAll("span").data([conditional.atoms[i]]).join("span");
-                renderFromProto(atoms, "atom", stack);
+                const atoms = atom
+                    .selectAll('span')
+                    .data([conditional.atoms[i]])
+                    .join('span');
+                renderFromProto(atoms, 'atom', stack);
                 return;
             }
         }
@@ -714,39 +807,48 @@ function atomTextToCopy(atom) {
 
 class ValueLineRenderer {
     getCSSClass() {
-        return "line-value";
+        return 'line-value';
     }
 
     enter(line) {}
 
     update(line, stack) {
-        const atoms = line.selectAll("span").data(d => [d.value.atom]).join("span");
-        renderFromProto(atoms, "atom", stack);
-        const clickable = line.filter(d => d.value.clickExpression);
-        clickable.classed("clickable", true);
-        clickable.on("mousedown", (e, d) => {
+        const atoms = line
+            .selectAll('span')
+            .data((d) => [d.value.atom])
+            .join('span');
+        renderFromProto(atoms, 'atom', stack);
+        const clickable = line.filter((d) => d.value.clickExpression);
+        clickable.classed('clickable', true);
+        clickable.on('mousedown', (e, d) => {
             e.stopPropagation();
             const clickHandler = () => {
-                stack.evaluateNode(d.value.clickExpression, EventTypeOutlinerClick);
-            }
+                stack.evaluateNode(
+                    d.value.clickExpression,
+                    EventTypeOutlinerClick,
+                );
+            };
             stack.handleDragStart(e, clickHandler);
         });
-        const notClickable = line.filter(d => !d.value.clickExpression);
-        notClickable.on("mousedown", (e, d) => {
+        const notClickable = line.filter((d) => !d.value.clickExpression);
+        notClickable.on('mousedown', (e, d) => {
             e.stopPropagation();
             const clickHandler = () => {
                 const copy = atomTextToCopy(d.value);
                 navigator.clipboard.writeText(copy);
-                stack.showMessage(`Copied ${copy}`, d3.pointer(e, d3.select("body")));
-            }
+                stack.showMessage(
+                    `Copied ${copy}`,
+                    d3.pointer(e, d3.select('body')),
+                );
+            };
             stack.handleDragStart(e, clickHandler);
         });
-    }    
+    }
 }
 
 class LeftRightValueLineRenderer {
     getCSSClass() {
-        return "line-left-right-value";
+        return 'line-left-right-value';
     }
 
     enter(line) {}
@@ -758,66 +860,90 @@ class LeftRightValueLineRenderer {
         }
         values.push(line.datum().leftRightValue.right);
 
-        let atoms = line.selectAll(".line-leftrightvalue-atom").data(values).join("span").attr("class", "line-leftrightvalue-atom");
-        renderFromProto(atoms.datum(d => d.atom), "atom", stack);
+        let atoms = line
+            .selectAll('.line-leftrightvalue-atom')
+            .data(values)
+            .join('span')
+            .attr('class', 'line-leftrightvalue-atom');
+        renderFromProto(
+            atoms.datum((d) => d.atom),
+            'atom',
+            stack,
+        );
 
-        const clickables = atoms.datum(d => d.clickExpression).filter(d => d);
-        clickables.classed("clickable", true);
-        clickables.on("mousedown", (e, d) => {
+        const clickables = atoms
+            .datum((d) => d.clickExpression)
+            .filter((d) => d);
+        clickables.classed('clickable', true);
+        clickables.on('mousedown', (e, d) => {
             e.stopPropagation();
             if (d) {
                 const clickHandler = () => {
                     stack.evaluateNode(d, EventTypeOutlinerClick);
-                }
+                };
                 stack.handleDragStart(e, clickHandler);
             }
-        })
+        });
     }
 }
 
 class ExpressionLineRenderer {
     getCSSClass() {
-        return "line-expression";
+        return 'line-expression';
     }
 
     enter(line) {}
 
     update(line, stack) {
-        line.text(d => d.expression.expression);
-        line.on("mousedown", (e, d) => {
+        line.text((d) => d.expression.expression);
+        line.on('mousedown', (e, d) => {
             e.stopPropagation();
             const clickHandler = () => {
                 navigator.clipboard.writeText(d.expression.expression);
-            }
+            };
             stack.handleDragStart(e, clickHandler);
-        })
-    }    
+        });
+    }
 }
 
 class TagsLineRenderer {
     getCSSClass() {
-        return "line-tags";
+        return 'line-tags';
     }
 
     enter(line) {
-        line.append("ul");
+        line.append('ul');
     }
 
     update(line, stack) {
-        const formatTags = t => [
-            {class: "prefix", text: t.prefix},
-            {class: "key", text: t.key},
-            {class: "value", text: t.value, clickExpression: t.clickExpression},
+        const formatTags = (t) => [
+            { class: 'prefix', text: t.prefix },
+            { class: 'key', text: t.key },
+            {
+                class: 'value',
+                text: t.value,
+                clickExpression: t.clickExpression,
+            },
         ];
-        const li = line.select("ul").selectAll("li").data(d => d.tags.tags ? d.tags.tags.map(formatTags) : []).join("li");
-        li.selectAll("span").data(d => d).join("span").attr("class", d => d.class).text(d => d.text);
-        const clickable = li.selectAll(".value").filter(d => d.clickExpression);
-        clickable.classed("clickable", true);
-        clickable.on("mousedown", (e, d) => {
+        const li = line
+            .select('ul')
+            .selectAll('li')
+            .data((d) => (d.tags.tags ? d.tags.tags.map(formatTags) : []))
+            .join('li');
+        li.selectAll('span')
+            .data((d) => d)
+            .join('span')
+            .attr('class', (d) => d.class)
+            .text((d) => d.text);
+        const clickable = li
+            .selectAll('.value')
+            .filter((d) => d.clickExpression);
+        clickable.classed('clickable', true);
+        clickable.on('mousedown', (e, d) => {
             e.stopPropagation();
             const clickHandler = () => {
                 stack.evaluateNode(d.clickExpression, EventTypeOutlinerClick);
-            }
+            };
             stack.handleDragStart(e, clickHandler);
         });
     }
@@ -825,93 +951,121 @@ class TagsLineRenderer {
 
 class HistogramBarLineRenderer {
     getCSSClass() {
-        return "line-histogram-bar";
+        return 'line-histogram-bar';
     }
 
     enter(line) {
-        line.append("div").attr("class", "range-icon");
-        line.append("span").attr("class", "range");
-        line.append("span").attr("class", "value");
-        line.append("span").attr("class", "total");
-        const bar = line.append("div").attr("class", "value-bar");
-        bar.append("div").attr("class", "fill");
+        line.append('div').attr('class', 'range-icon');
+        line.append('span').attr('class', 'range');
+        line.append('span').attr('class', 'value');
+        line.append('span').attr('class', 'total');
+        const bar = line.append('div').attr('class', 'value-bar');
+        bar.append('div').attr('class', 'fill');
     }
 
     update(line, stack) {
-        line.select(".range-icon").attr("class", d => `range-icon index-${d.histogramBar.index ? d.histogramBar.index : 0}`);
-        renderFromProto(line.select(".range").datum(d => d.histogramBar.range), "atom", stack);
-        line.select(".value").text(d => d.histogramBar.value || "0");
-        line.select(".total").text(d => `/ ${d.histogramBar.total}`);
-        line.select(".fill").attr("style", d => `width: ${(d.histogramBar.value || 0)/d.histogramBar.total*100.00}%;`);
+        line.select('.range-icon').attr(
+            'class',
+            (d) =>
+                `range-icon index-${d.histogramBar.index ? d.histogramBar.index : 0}`,
+        );
+        renderFromProto(
+            line.select('.range').datum((d) => d.histogramBar.range),
+            'atom',
+            stack,
+        );
+        line.select('.value').text((d) => d.histogramBar.value || '0');
+        line.select('.total').text((d) => `/ ${d.histogramBar.total}`);
+        line.select('.fill').attr(
+            'style',
+            (d) =>
+                `width: ${((d.histogramBar.value || 0) / d.histogramBar.total) * 100.0}%;`,
+        );
     }
 }
 
 class SwatchLineRenderer {
     getCSSClass() {
-        return "line-swatch";
+        return 'line-swatch';
     }
 
     enter(line) {
         const index = line.datum().swatch.index || 0;
         if (index >= 0) {
-            line.append("div").attr("class", "range-icon");
+            line.append('div').attr('class', 'range-icon');
         }
-        line.append("span").attr("class", "label");
+        line.append('span').attr('class', 'label');
     }
 
     update(line, stack) {
         const index = line.datum().swatch.index || 0;
         if (index >= 0) {
-            line.select(".range-icon").attr("class", d => `range-icon index-${d.swatch.index ? d.swatch.index : 0}`);
-            line.on("click", function(e) {
+            line.select('.range-icon').attr(
+                'class',
+                (d) =>
+                    `range-icon index-${d.swatch.index ? d.swatch.index : 0}`,
+            );
+            line.on('click', function (e) {
                 e.stopPropagation();
                 stack.toggleShowBucket(index);
             });
         }
-        renderFromProto(line.select(".label").datum(d => d.swatch.label), "atom", stack);
+        renderFromProto(
+            line.select('.label').datum((d) => d.swatch.label),
+            'atom',
+            stack,
+        );
     }
 }
 
-
 class ShellLineRenderer {
     getCSSClass() {
-        return "line-shell";
+        return 'line-shell';
     }
 
     enter(line) {
-        const form = line.append("form");
-        form.append("div").attr("class", "prompt").text("b6");
-        form.append("input").attr("type", "text");
-        return form
+        const form = line.append('form');
+        form.append('div').attr('class', 'prompt').text('b6');
+        form.append('input').attr('type', 'text');
+        return form;
     }
 
     update(line, stack) {
-        const state = {suggestions: line.datum().shell.functions ? line.datum().shell.functions.toSorted() : [], highlighted: 0};
-        const form = line.select("form");
-        form.select("input").on("focusin", e => {
-            form.select("ul").classed("focussed", true);
+        const state = {
+            suggestions: line.datum().shell.functions
+                ? line.datum().shell.functions.toSorted()
+                : [],
+            highlighted: 0,
+        };
+        const form = line.select('form');
+        form.select('input').on('focusin', (e) => {
+            form.select('ul').classed('focussed', true);
         });
-        form.select("input").on("focusout", e => {
-            form.select("ul").classed("focussed", false);
+        form.select('input').on('focusout', (e) => {
+            form.select('ul').classed('focussed', false);
         });
-        form.on("keydown", e => {
+        form.on('keydown', (e) => {
             switch (e.key) {
-                case "Tab":
-                    const node = form.select("input").node();
-                    if (state.highlighted >= 0 && state.filtered[state.highlighted].length > node.value.length) {
-                        node.value = state.filtered[state.highlighted] + " ";
+                case 'Tab':
+                    const node = form.select('input').node();
+                    if (
+                        state.highlighted >= 0 &&
+                        state.filtered[state.highlighted].length >
+                            node.value.length
+                    ) {
+                        node.value = state.filtered[state.highlighted] + ' ';
                     }
                     e.preventDefault();
                     break;
             }
         });
-        form.on("keyup", e => {
+        form.on('keyup', (e) => {
             switch (e.key) {
-                case "ArrowUp":
+                case 'ArrowUp':
                     state.highlighted--;
                     e.preventDefault();
                     break;
-                case "ArrowDown":
+                case 'ArrowDown':
                     state.highlighted++;
                     e.preventDefault();
                     break;
@@ -921,49 +1075,63 @@ class ShellLineRenderer {
             }
             this.updateShellSuggestions(line, state);
         });
-        form.on("submit", e => {
+        form.on('submit', (e) => {
             e.preventDefault();
-            var expression = line.select("input").node().value;
-            if (state.highlighted >= 0 && state.filtered[state.highlighted].length > expression.length) {
+            var expression = line.select('input').node().value;
+            if (
+                state.highlighted >= 0 &&
+                state.filtered[state.highlighted].length > expression.length
+            ) {
                 expression = state.filtered[state.highlighted];
             }
-            stack.evaluateExpressionInContext(expression, EventTypeOutlinerShell);
+            stack.evaluateExpressionInContext(
+                expression,
+                EventTypeOutlinerShell,
+            );
             return;
-        });    
+        });
     }
 
     updateShellSuggestions(line, state) {
-        const entered = line.select("input").node().value;
-        const filtered = state.suggestions.filter(s => s.startsWith(entered));
+        const entered = line.select('input').node().value;
+        const filtered = state.suggestions.filter((s) => s.startsWith(entered));
         state.filtered = filtered;
 
-        const suggestions = filtered.slice(0, ShellMaxSuggestions).map(s => {return {text: s, highlighted: false}});
+        const suggestions = filtered.slice(0, ShellMaxSuggestions).map((s) => {
+            return { text: s, highlighted: false };
+        });
         if (state.highlighted < 0) {
-            state.highlighted = 0
+            state.highlighted = 0;
         } else if (state.highlighted >= filtered.length) {
             state.highlighted = filtered.length - 1;
         }
         if (state.highlighted >= 0) {
             suggestions[state.highlighted].highlighted = true;
         }
-    
+
         const substack = d3.select(line.node().parentNode);
-        const lines = substack.selectAll(".line-suggestion").data(suggestions).join("div");
-        lines.attr("class", "line line-suggestion");
-        lines.text(d => d.text).classed("highlighted", d => d.highlighted);
+        const lines = substack
+            .selectAll('.line-suggestion')
+            .data(suggestions)
+            .join('div');
+        lines.attr('class', 'line line-suggestion');
+        lines.text((d) => d.text).classed('highlighted', (d) => d.highlighted);
     }
 }
 
 class ChoiceLineRenderer {
     getCSSClass() {
-        return "line-choice";
+        return 'line-choice';
     }
 
     enter(line) {}
 
     update(line, stack) {
-        const atoms = line.selectAll("span").data(d => this._mergeAtoms(d)).join("span");
-        renderFromProto(atoms, "atom", stack);
+        const atoms = line
+            .selectAll('span')
+            .data((d) => this._mergeAtoms(d))
+            .join('span');
+        renderFromProto(atoms, 'atom', stack);
     }
 
     _mergeAtoms(d) {
@@ -976,78 +1144,84 @@ class ChoiceLineRenderer {
 
 class HeaderLineRenderer {
     getCSSClass() {
-        return "line-header";
+        return 'line-header';
     }
 
     enter(line, stack) {
-        line.append("span");
+        line.append('span');
         if (line.datum().header.close) {
-            const close = line.append("img");
-            close.attr("class", "line-header-close");
-            close.attr("src", "/images/close.svg");
-            close.on("click", function(e) {
+            const close = line.append('img');
+            close.attr('class', 'line-header-close');
+            close.attr('src', '/images/close.svg');
+            close.on('click', function (e) {
                 e.stopPropagation();
                 stack.remove();
             });
         }
         if (line.datum().header.share) {
-            const close = line.append("img");
-            close.attr("class", "line-header-share");
-            close.attr("src", "/images/share.svg");
-            close.on("click", function(e) {
+            const close = line.append('img');
+            close.attr('class', 'line-header-share');
+            close.attr('src', '/images/share.svg');
+            close.on('click', function (e) {
                 e.stopPropagation();
                 navigator.clipboard.writeText(window.location.href);
-                stack.showMessage("Copied link to clipboard", d3.pointer(e, d3.select("body")));
+                stack.showMessage(
+                    'Copied link to clipboard',
+                    d3.pointer(e, d3.select('body')),
+                );
             });
         }
-        line.on("mousedown", (e) => {
+        line.on('mousedown', (e) => {
             e.stopPropagation();
             stack.handleDragStart(e);
         });
     }
 
     update(line, stack) {
-        renderFromProto(line.select("span").datum(d => d.header.title), "atom", stack);
+        renderFromProto(
+            line.select('span').datum((d) => d.header.title),
+            'atom',
+            stack,
+        );
     }
 }
 
-
 class ErrorLineRenderer {
     getCSSClass() {
-        return "line-error";
+        return 'line-error';
     }
 
     enter(line) {}
 
     update(line) {
-        line.text(d => d.error.error);
-    }    
-}
-
-const Renderers = {
-    "atom": {
-        "value": new ValueAtomRenderer(),
-        "labelledIcon": new LabelledIconAtomRenderer(),
-        "download": new DownloadAtomRenderer(),
-        "chip": new ChipAtomRenderer(),
-        "conditional": new ConditionalAtomRenderer(),
-    },
-    "line": {
-        "value": new ValueLineRenderer(),
-        "leftRightValue": new LeftRightValueLineRenderer(),
-        "expression": new ExpressionLineRenderer(),
-        "tags": new TagsLineRenderer(),
-        "histogramBar": new HistogramBarLineRenderer(),
-        "swatch": new SwatchLineRenderer(),
-        "shell": new ShellLineRenderer(),
-        "choice": new ChoiceLineRenderer(),
-        "header": new HeaderLineRenderer(),
-        "error": new ErrorLineRenderer(),
+        line.text((d) => d.error.error);
     }
 }
 
+const Renderers = {
+    atom: {
+        value: new ValueAtomRenderer(),
+        labelledIcon: new LabelledIconAtomRenderer(),
+        download: new DownloadAtomRenderer(),
+        chip: new ChipAtomRenderer(),
+        conditional: new ConditionalAtomRenderer(),
+    },
+    line: {
+        value: new ValueLineRenderer(),
+        leftRightValue: new LeftRightValueLineRenderer(),
+        expression: new ExpressionLineRenderer(),
+        tags: new TagsLineRenderer(),
+        histogramBar: new HistogramBarLineRenderer(),
+        swatch: new SwatchLineRenderer(),
+        shell: new ShellLineRenderer(),
+        choice: new ChoiceLineRenderer(),
+        header: new HeaderLineRenderer(),
+        error: new ErrorLineRenderer(),
+    },
+};
+
 function renderFromProto(targets, uiElement, stack) {
-    const f = function(d) {
+    const f = function (d) {
         // If the CSS class of the line's div matches the data bound to it, update() it,
         // otherwise remove all child nodes and enter() the line beforehand.
         const renderers = Renderers[uiElement];
@@ -1057,7 +1231,9 @@ function renderFromProto(targets, uiElement, stack) {
         const uiElementType = Object.getOwnPropertyNames(d)[0];
         const renderer = renderers[uiElementType];
         if (!renderer) {
-            throw new Error(`Can't render ${uiElement} of type ${uiElementType}`);
+            throw new Error(
+                `Can't render ${uiElement} of type ${uiElementType}`,
+            );
         }
 
         const target = d3.select(this);
@@ -1068,20 +1244,28 @@ function renderFromProto(targets, uiElement, stack) {
             target.classed(uiElement, true);
             target.classed(renderer.getCSSClass(), true);
             renderer.enter(target, stack);
-       }
-       renderer.update(target, stack);
-    }
-    for (const e of ["click", "mousedown", "focusin", "focusout"]) {
+        }
+        renderer.update(target, stack);
+    };
+    for (const e of ['click', 'mousedown', 'focusin', 'focusout']) {
         targets.on(e, null);
     }
     targets.each(f);
 }
 
 class UI {
-    constructor(map, dockTarget, state, queryStyle, geojsonStyle, highlightChanged, session, logger) {
+    constructor(
+        map,
+        dockTarget,
+        state,
+        queryStyle,
+        geojsonStyle,
+        highlightChanged,
+        session,
+        logger,
+    ) {
         this.map = map;
-        this.dockTarget = dockTarget,
-        this.state = state;
+        (this.dockTarget = dockTarget), (this.state = state);
         this.queryStyle = queryStyle;
         this.geojsonStyle = geojsonStyle;
         this.basemapHighlightChanged = highlightChanged;
@@ -1090,15 +1274,15 @@ class UI {
         this.uiContext = null;
         this.dragging = null;
         this.shellHistory = [];
-        this.html = d3.select("html");
-        this.dragPointerOrigin = [0,0];
-        this.dragElementOrigin = [0,0];
+        this.html = d3.select('html');
+        this.dragPointerOrigin = [0, 0];
+        this.dragElementOrigin = [0, 0];
         this.stacks = [];
         this.needHighlightRedraw = false;
         this.docked = [];
         this.openDockIndex = -1;
 
-        this.map.on("moveend", (e) => {
+        this.map.on('moveend', (e) => {
             this._updateBrowserState();
         });
     }
@@ -1118,21 +1302,30 @@ class UI {
         if (response.expression) {
             const locked = this.uiContext !== undefined;
             const position = null;
-            this.evaluateExpressionInNewStack(response.expression, null, locked, position, EventTypeStartup);
+            this.evaluateExpressionInNewStack(
+                response.expression,
+                null,
+                locked,
+                position,
+                EventTypeStartup,
+            );
         }
     }
 
     _renderDock(docked) {
-        const target = this.dockTarget.selectAll(".stack").data(docked).join("div");
-        target.attr("class", "stack closed");
+        const target = this.dockTarget
+            .selectAll('.stack')
+            .data(docked)
+            .join('div');
+        target.attr('class', 'stack closed');
         const ui = this;
-        target.each(function(response, i) {
+        target.each(function (response, i) {
             this.__dock_index__ = i;
             ui.docked.push(this);
             ui._renderStack(response, d3.select(this), false, false);
         });
 
-        target.on("click", function(e) {
+        target.on('click', function (e) {
             e.preventDefault();
             ui.toggleDockedAtIndex(this.__dock_index__);
         });
@@ -1143,12 +1336,12 @@ class UI {
             return;
         }
         const docked = this.docked[index];
-        const logOptions = {ld: docked.__stack__.getLogDetail()};
+        const logOptions = { ld: docked.__stack__.getLogDetail() };
         this._logEvent(EventTypeDockOpen, logOptions);
-        if (d3.select(docked).classed("closed")) {
+        if (d3.select(docked).classed('closed')) {
             this.closeAllDocked();
             this.removeFeaturedStack();
-            d3.select(docked).classed("closed", false);
+            d3.select(docked).classed('closed', false);
             this.openDockIndex = index;
             if (docked.__stack__) {
                 this.state.bucketed = {};
@@ -1161,47 +1354,60 @@ class UI {
     }
 
     closeAllDocked() {
-        const docked = this.dockTarget.selectAll(".stack");
+        const docked = this.dockTarget.selectAll('.stack');
         const ui = this;
-        docked.each(function() {
+        docked.each(function () {
             if (this.__stack__) {
                 this.__stack__.removeFromMap();
             }
         });
-        docked.classed("closed", true);
+        docked.classed('closed', true);
         this.openDockIndex = -1;
     }
 
     _updateBrowserState() {
         const ll = toLonLat(this.map.getView().getCenter());
         const params = new URLSearchParams({
-            "ll": `${Number(ll[1].toFixed(7))},${Number(ll[0].toFixed(7))}`,
-            "z": `${Number(this.map.getView().getZoom().toFixed(2))}`,
+            ll: `${Number(ll[1].toFixed(7))},${Number(ll[0].toFixed(7))}`,
+            z: `${Number(this.map.getView().getZoom().toFixed(2))}`,
         });
         if (this.uiContext) {
-            params.set("r", idTokenFromProto(this.uiContext));
+            params.set('r', idTokenFromProto(this.uiContext));
         }
         if (this.openDockIndex >= 0) {
-            params.set("d", this.openDockIndex);
+            params.set('d', this.openDockIndex);
         }
         if (this.lastExpression) {
-            params.set("e", this.lastExpression);
+            params.set('e', this.lastExpression);
         }
-        const query = params.toString().replaceAll("%2C", ",").replaceAll("%2F", "/");
-        history.replaceState(null, "", "/?" + query);
+        const query = params
+            .toString()
+            .replaceAll('%2C', ',')
+            .replaceAll('%2F', '/');
+        history.replaceState(null, '', '/?' + query);
     }
 
-    evaluateExpressionInNewStack(expression, context, locked, position, logEvent) {
+    evaluateExpressionInNewStack(
+        expression,
+        context,
+        locked,
+        position,
+        logEvent,
+    ) {
         const ui = this;
-        this._sendRequest(expression, context, locked, logEvent).then(response => {
-            ui._renderNewStack(response, position);
-        });
+        this._sendRequest(expression, context, locked, logEvent).then(
+            (response) => {
+                ui._renderNewStack(response, position);
+            },
+        );
     }
 
     evaluateExpression(expression, context, locked, logEvent, target) {
-        this._sendRequest(expression, context, locked, logEvent).then(response => {
-            this._renderStack(response, target, true, false);
-        });
+        this._sendRequest(expression, context, locked, logEvent).then(
+            (response) => {
+                this._renderStack(response, target, true, false);
+            },
+        );
     }
 
     _sendRequest(expression, context, locked, logEvent) {
@@ -1217,22 +1423,22 @@ class UI {
             },
             logMapZoom: this.map.getView().getZoom(),
             session: this.session,
-        }
+        };
         if (this.uiContext) {
             request.context = this.uiContext;
         }
         const body = JSON.stringify(request);
         const post = {
-            method: "POST",
+            method: 'POST',
             body: body,
             headers: {
-                "Content-type": "application/json; charset=UTF-8"
-            }
-        }
-        const promise = d3.json("/stack", post);
+                'Content-type': 'application/json; charset=UTF-8',
+            },
+        };
+        const promise = d3.json('/stack', post);
         promise.catch((error) => {
             showMessage(error.message);
-            this._logEvent(EventTypeError, {ld: error.message});
+            this._logEvent(EventTypeError, { ld: error.message });
         });
         return promise;
     }
@@ -1243,30 +1449,34 @@ class UI {
         // Remove the existing featured stack from the UI if response is
         // null.
         const ui = this;
-        const target = d3.select("body").selectAll(".stack-featured").data(response ? [response] : []).join(
-            enter => {
-                return enter.append("div");
-            },
-            update => update,
-            exit => {
-                exit.each(function() {
-                    if (this.__stack__) {
-                        ui.removeStack(this.__stack__, true);
-                    }
-                });
-                return exit.remove();
-            },
-        );
+        const target = d3
+            .select('body')
+            .selectAll('.stack-featured')
+            .data(response ? [response] : [])
+            .join(
+                (enter) => {
+                    return enter.append('div');
+                },
+                (update) => update,
+                (exit) => {
+                    exit.each(function () {
+                        if (this.__stack__) {
+                            ui.removeStack(this.__stack__, true);
+                        }
+                    });
+                    return exit.remove();
+                },
+            );
         const dockRect = this.dockTarget.node().getBoundingClientRect();
-        target.attr("class", "stack stack-featured");
+        target.attr('class', 'stack stack-featured');
         if (position) {
-            target.style("left",  `${StackOffset[0] + position[0]}px`);
-            target.style("top", `${StackOffset[1] + position[1]}px`);
+            target.style('left', `${StackOffset[0] + position[0]}px`);
+            target.style('top', `${StackOffset[1] + position[1]}px`);
         } else {
-            target.style("left",  `${dockRect.left}px`);
-            target.style("top", `${StackOffset[1] + dockRect.bottom}px`);
+            target.style('left', `${dockRect.left}px`);
+            target.style('top', `${StackOffset[1] + dockRect.bottom}px`);
         }
-        target.each(function(response) {
+        target.each(function (response) {
             ui.closeAllDocked();
             ui._renderStack(response, d3.select(this), true, !position);
         });
@@ -1297,7 +1507,10 @@ class UI {
             const center = response.proto.mapCenter;
             if (center && center.latE7 && center.lngE7) {
                 this.map.getView().animate({
-                    center: fromLonLat([center.lngE7 / 1e7, center.latE7 / 1e7]),
+                    center: fromLonLat([
+                        center.lngE7 / 1e7,
+                        center.latE7 / 1e7,
+                    ]),
                     duration: 500,
                 });
             }
@@ -1347,25 +1560,25 @@ class UI {
     }
 
     createQueryLayer(query, before) {
-        const params = new URLSearchParams({"q": query});
+        const params = new URLSearchParams({ q: query });
         const source = new VectorTileSource({
             format: new MVT(),
-            url: "/tiles/query/{z}/{x}/{y}.mvt?" + params.toString(),
+            url: '/tiles/query/{z}/{x}/{y}.mvt?' + params.toString(),
             minZoom: 14,
         });
         const layer = new VectorTileLayer({
             source: source,
             style: this.queryStyle,
         });
-        layer.set("clickable", true);
+        layer.set('clickable', true);
         if (before) {
-            layer.set("before", before);
+            layer.set('before', before);
         }
         return layer;
     }
 
     getGeoJSONStyle() {
-        return this.geojsonStyle
+        return this.geojsonStyle;
     }
 
     getProjection() {
@@ -1373,10 +1586,10 @@ class UI {
     }
 
     addLayer(layer) {
-        if (layer.get("before")) {
+        if (layer.get('before')) {
             const layers = this.map.getLayers();
             for (let i = 0; i < layers.getLength(); i++) {
-                if (layers.item(i).get("position") == layer.get("before")) {
+                if (layers.item(i).get('position') == layer.get('before')) {
                     layers.insertAt(i, layer);
                     return;
                 }
@@ -1391,20 +1604,35 @@ class UI {
 
     removeStack(stack, keepElement) {
         stack.removeFromMap();
-        this.stacks = this.stacks.filter(r => r != stack);
+        this.stacks = this.stacks.filter((r) => r != stack);
         if (!keepElement) {
             stack.getElement().remove();
         }
     }
 
     handleMapClick(event) {
-        const position = d3.pointer(event.originalEvent, d3.select("html"));
+        const position = d3.pointer(event.originalEvent, d3.select('html'));
         if (event.originalEvent.shiftKey) {
-            showFeatureAtPixel(event.pixel, false, position, this.map, this, EventTypeMapFeatureClick);
+            showFeatureAtPixel(
+                event.pixel,
+                false,
+                position,
+                this.map,
+                this,
+                EventTypeMapFeatureClick,
+            );
             event.stopPropagation();
         } else {
-            const ll = lonLatToLiteral(toLonLat(this.map.getCoordinateFromPixel(event.pixel)));
-            this.evaluateExpressionInNewStack(ll, null, true, position, EventTypeMapLatLngClick);
+            const ll = lonLatToLiteral(
+                toLonLat(this.map.getCoordinateFromPixel(event.pixel)),
+            );
+            this.evaluateExpressionInNewStack(
+                ll,
+                null,
+                true,
+                position,
+                EventTypeMapLatLngClick,
+            );
             event.stopPropagation();
         }
     }
@@ -1414,7 +1642,7 @@ class UI {
     handleDragStart(event, root, clickHandler) {
         event.preventDefault();
         this.dragging = root;
-        this.dragging.classed("dragging", true);
+        this.dragging.classed('dragging', true);
         this.dragClickHandler = clickHandler;
         this.dragPointerOrigin = d3.pointer(event, this.html);
         this.dragElementOrigin = elementPosition(root);
@@ -1424,16 +1652,19 @@ class UI {
         if (this.dragging) {
             event.preventDefault();
             const pointer = d3.pointer(event, this.html);
-            const delta = [pointer[0]-this.dragPointerOrigin[0], pointer[1]-this.dragPointerOrigin[1]];
+            const delta = [
+                pointer[0] - this.dragPointerOrigin[0],
+                pointer[1] - this.dragPointerOrigin[1],
+            ];
             if (delta[0] != 0 || delta[1] != 0) {
-                if (this.dragging.classed("stack-featured")) {
-                    this.dragging.attr("class", "stack stack-floating");
+                if (this.dragging.classed('stack-featured')) {
+                    this.dragging.attr('class', 'stack stack-floating');
                 }
             }
-            const left = Math.round(this.dragElementOrigin[0]+delta[0]);
-            const top = Math.round(this.dragElementOrigin[1]+delta[1]);
-            this.dragging.style("left", `${left}px`);
-            this.dragging.style("top", `${top}px`);
+            const left = Math.round(this.dragElementOrigin[0] + delta[0]);
+            const top = Math.round(this.dragElementOrigin[1] + delta[1]);
+            this.dragging.style('left', `${left}px`);
+            this.dragging.style('top', `${top}px`);
         }
     }
 
@@ -1441,9 +1672,12 @@ class UI {
         if (this.dragging) {
             event.preventDefault();
             const pointer = d3.pointer(event, this.html);
-            const delta = [pointer[0]-this.dragPointerOrigin[0], pointer[1]-this.dragPointerOrigin[1]];
-            this.dragging.classed("dragging", false);
-            if (delta[0] == 0 && delta[1] ==  0 && this.dragClickHandler) {
+            const delta = [
+                pointer[0] - this.dragPointerOrigin[0],
+                pointer[1] - this.dragPointerOrigin[1],
+            ];
+            this.dragging.classed('dragging', false);
+            if (delta[0] == 0 && delta[1] == 0 && this.dragClickHandler) {
                 this.dragClickHandler();
             }
             this.dragging = null;
@@ -1469,22 +1703,22 @@ class UI {
         }
         const ll = toLonLat(this.map.getView().getCenter());
         options.lc = `${Number(ll[1].toFixed(7))},${Number(ll[0].toFixed(7))}`;
-        options.lz = d3.format(".3f")(this.map.getView().getZoom());
+        options.lz = d3.format('.3f')(this.map.getView().getZoom());
         options.ls = this.session;
         this.logger.logEvent(event, options);
     }
 }
 
 function showMessage(message, position) {
-    d3.select(".message").remove();
-    const div = d3.select("body").append("div").classed("message", true);
+    d3.select('.message').remove();
+    const div = d3.select('body').append('div').classed('message', true);
     if (position) {
         div.node().style.top = `${position[1]}px`;
         div.node().style.left = `${position[0]}px`;
     }
     div.text(message);
     const exit = () => {
-        div.classed("exiting", true);
+        div.classed('exiting', true);
         setTimeout(() => div.remove(), 700);
     };
     setTimeout(exit, 700);
@@ -1497,11 +1731,11 @@ function showFeatureAtPixel(pixel, locked, position, map, ui, logEvent) {
     const search = (i, found) => {
         if (i >= 0) {
             const layer = layers.item(i);
-            if (layer.getVisible() && layer.get("clickable")) {
-                layer.getFeatures(pixel).then(features => {
+            if (layer.getVisible() && layer.get('clickable')) {
+                layer.getFeatures(pixel).then((features) => {
                     if (features.length > 0) {
                         found(features[0]);
-                        return
+                        return;
                     } else {
                         search(i - 1, found);
                     }
@@ -1510,11 +1744,21 @@ function showFeatureAtPixel(pixel, locked, position, map, ui, logEvent) {
                 search(i - 1, found);
             }
         } else {
-            const ll = lonLatToLiteral(toLonLat(map.getCoordinateFromPixel(pixel)));
-            ui.evaluateExpressionInNewStack(ll, null, locked, position, logEvent);
+            const ll = lonLatToLiteral(
+                toLonLat(map.getCoordinateFromPixel(pixel)),
+            );
+            ui.evaluateExpressionInNewStack(
+                ll,
+                null,
+                locked,
+                position,
+                logEvent,
+            );
         }
     };
-    search(layers.getLength() - 1, f => showFeature(f, locked, position, ui, logEvent));
+    search(layers.getLength() - 1, (f) =>
+        showFeature(f, locked, position, ui, logEvent),
+    );
 }
 
 function idKey(id) {
@@ -1522,179 +1766,196 @@ function idKey(id) {
 }
 
 const idGeometryTypes = {
-    "Point": "point",
-    "LineString": "path",
-    "Polygon": "area",
-    "MultiPolygon": "area",
-}
+    Point: 'point',
+    LineString: 'path',
+    Polygon: 'area',
+    MultiPolygon: 'area',
+};
 
 function idKeyFromFeature(feature) {
-    const type = idGeometryTypes[feature.getGeometry().getType()] || "invalid";
-    return `/${type}/${feature.get("ns")}/${parseInt(feature.get("id"), 16)}`
+    const type = idGeometryTypes[feature.getGeometry().getType()] || 'invalid';
+    return `/${type}/${feature.get('ns')}/${parseInt(feature.get('id'), 16)}`;
 }
 
 const featureTypes = {
-    "FeatureTypePoint": "point",
-    "FeatureTypePath": "path",
-    "FeatureTypeArea": "area",
-    "FeatureTypeRelation": "relation",
-    "FeatureTypeCollection": "collection",
-    "FeatureTypeExpression": "expression",
-}
+    FeatureTypePoint: 'point',
+    FeatureTypePath: 'path',
+    FeatureTypeArea: 'area',
+    FeatureTypeRelation: 'relation',
+    FeatureTypeCollection: 'collection',
+    FeatureTypeExpression: 'expression',
+};
 
 function idTokenFromProto(p) {
-    const type = featureTypes[p.type]
+    const type = featureTypes[p.type];
     return `/${type}/${p.namespace}/${p.value || 0}`;
 }
 
 function setupShell(target, ui) {
-    target.selectAll("form").data([1]).join(
-        enter => {
-            const form = enter.append("form").attr("class", "shell-form");
-            form.append("div").attr("class", "prompt").text("b6");
-            form.append("input").attr("type", "text");
-            return form;
-        },
-        update => {
-            return update;
-        },
-    );
-    const state = {index: 0};
-    d3.select("body").on("keydown", (e) => {
+    target
+        .selectAll('form')
+        .data([1])
+        .join(
+            (enter) => {
+                const form = enter.append('form').attr('class', 'shell-form');
+                form.append('div').attr('class', 'prompt').text('b6');
+                form.append('input').attr('type', 'text');
+                return form;
+            },
+            (update) => {
+                return update;
+            },
+        );
+    const state = { index: 0 };
+    d3.select('body').on('keydown', (e) => {
         const history = ui.getShellHistory();
-        if (e.key == "`" || e.key == "~") {
+        if (e.key == '`' || e.key == '~') {
             e.preventDefault();
-            target.classed("closed", !target.classed("closed"));
-            target.select("input").node().focus();
-        } else if (e.key == "ArrowUp") {
+            target.classed('closed', !target.classed('closed'));
+            target.select('input').node().focus();
+        } else if (e.key == 'ArrowUp') {
             e.preventDefault();
             if (state.index < history.length) {
                 state.index++;
-                target.select("input").node().value = history[history.length - state.index];
+                target.select('input').node().value =
+                    history[history.length - state.index];
             }
-        } else if (e.key == "ArrowDown") {
+        } else if (e.key == 'ArrowDown') {
             e.preventDefault();
             if (state.index > 0) {
                 state.index--;
                 if (state.index == 0) {
-                    target.select("input").node().value = "";
+                    target.select('input').node().value = '';
                 } else {
-                    target.select("input").node().value = history[history.length - state.index];
+                    target.select('input').node().value =
+                        history[history.length - state.index];
                 }
             }
         }
     });
-    target.select("form").on("submit", (e) => {
+    target.select('form').on('submit', (e) => {
         e.preventDefault();
-        target.classed("closed", true);
-        const expression = target.select("input").node().value;
+        target.classed('closed', true);
+        const expression = target.select('input').node().value;
         state.index = 0;
         const locked = false;
         const position = null;
-        ui.evaluateExpressionInNewStack(expression, null, locked, position, EventTypeWorldShell);
-        target.select("input").node().value = "";
-    })
+        ui.evaluateExpressionInNewStack(
+            expression,
+            null,
+            locked,
+            position,
+            EventTypeWorldShell,
+        );
+        target.select('input').node().value = '';
+    });
 }
 
 function newQueryStyle(state, styles) {
-    const point = styles.lookupCircle("query-point");
-    const highlightedPoint = styles.lookupCircle("highlighted-point");
-    const path = styles.lookupStyle("query-path");
-    const highlightedPath = styles.lookupStyle("highlighted-path");
-    const area = styles.lookupStyle("query-area");
-    const highlightedArea = styles.lookupStyle("highlighted-area");
-    const boundary = styles.lookupStyle("query-boundary");
-    const highlightedBoundary = styles.lookupStyle("highlighted-boundary");
+    const point = styles.lookupCircle('query-point');
+    const highlightedPoint = styles.lookupCircle('highlighted-point');
+    const path = styles.lookupStyle('query-path');
+    const highlightedPath = styles.lookupStyle('highlighted-path');
+    const area = styles.lookupStyle('query-area');
+    const highlightedArea = styles.lookupStyle('highlighted-area');
+    const boundary = styles.lookupStyle('query-boundary');
+    const highlightedBoundary = styles.lookupStyle('highlighted-boundary');
 
-    const bucketedArea = Array.from(Array(6).keys()).map(b => {
+    const bucketedArea = Array.from(Array(6).keys()).map((b) => {
         return styles.lookupStyle(`bucketed-${b}`);
     });
 
-    return function(feature, resolution) {
-        if (feature.get("layer") != "background") {
+    return function (feature, resolution) {
+        if (feature.get('layer') != 'background') {
             const id = idKeyFromFeature(feature);
             const highlighted = state.highlighted[id];
             switch (feature.getGeometry().getType()) {
-                case "Point":
+                case 'Point':
                     return highlighted ? highlightedPoint : point;
-                case "LineString":
+                case 'LineString':
                     return highlighted ? highlightedPath : path;
-                case "MultiLineString":
+                case 'MultiLineString':
                     return highlighted ? highlightedPath : path;
-                case "Polygon":
+                case 'Polygon':
                     if (state.bucketed[id]) {
                         return bucketedArea[state.bucketed[id]];
                     }
-                    if (feature.get("boundary")) {
+                    if (feature.get('boundary')) {
                         return highlighted ? highlightedBoundary : boundary;
                     } else {
                         return highlighted ? highlightedArea : area;
                     }
-                case "MultiPolygon":
+                case 'MultiPolygon':
                     if (state.bucketed[id]) {
                         return bucketedArea[state.bucketed[id]];
                     }
-                    if (feature.get("boundary")) {
+                    if (feature.get('boundary')) {
                         return highlighted ? highlightedBoundary : boundary;
                     } else {
                         return highlighted ? highlightedArea : area;
                     }
             }
         }
-    }
+    };
 }
 
 const StyleClasses = [
-    "bucketed-0",
-    "bucketed-1",
-    "bucketed-2",
-    "bucketed-3",
-    "bucketed-4",
-    "bucketed-5",
-    "geojson-area",
-    "geojson-path",
-    "geojson-point",
-    "highlighted-area",
-    "highlighted-path",
-    "highlighted-point",
-    "highlighted-rail",
-    "highlighted-road-fill",
-    "highlighted-boundary",
-    "outliner-blue",
-    "outliner-emerald",
-    "outliner-rose",
-    "outliner-teal",
-    "outliner-stone",
-    "outliner-cyan",
-    "outliner-violet",
-    "outliner-yellow",
-    "query-area",
-    "query-path",
-    "query-point",
-    "query-boundary",
-    "rail",
-    "road-fill",
-    "road-outline",
-    "road-label",
-    "landuse-urban", // #landuse=commercial, #landuse=residential etc
-    "landuse-greenspace", // #landuse=park etc
-    "landuse-nature", // #natural=heath, #landuse=meadow etc
-    "landuse-forest", // #landuse=forest etc
-    "contour",
-    "water-area",
-    "water-line",
-    "coastline",
+    'bucketed-0',
+    'bucketed-1',
+    'bucketed-2',
+    'bucketed-3',
+    'bucketed-4',
+    'bucketed-5',
+    'geojson-area',
+    'geojson-path',
+    'geojson-point',
+    'highlighted-area',
+    'highlighted-path',
+    'highlighted-point',
+    'highlighted-rail',
+    'highlighted-road-fill',
+    'highlighted-boundary',
+    'outliner-blue',
+    'outliner-emerald',
+    'outliner-rose',
+    'outliner-teal',
+    'outliner-stone',
+    'outliner-cyan',
+    'outliner-violet',
+    'outliner-yellow',
+    'query-area',
+    'query-path',
+    'query-point',
+    'query-boundary',
+    'rail',
+    'road-fill',
+    'road-outline',
+    'road-label',
+    'landuse-urban', // #landuse=commercial, #landuse=residential etc
+    'landuse-greenspace', // #landuse=park etc
+    'landuse-nature', // #natural=heath, #landuse=meadow etc
+    'landuse-forest', // #landuse=forest etc
+    'contour',
+    'water-area',
+    'water-line',
+    'coastline',
 ];
 
 class Styles {
     constructor(classes) {
-        const palette = d3.select("body").selectAll(".palette").data([1]).join("g");
-        palette.classed("palette", true);
-        const items = palette.selectAll("g").data(classes).join("g");
-        items.attr("class", d => d);
+        const palette = d3
+            .select('body')
+            .selectAll('.palette')
+            .data([1])
+            .join('g');
+        palette.classed('palette', true);
+        const items = palette.selectAll('g').data(classes).join('g');
+        items.attr('class', (d) => d);
         this.css = {};
         for (const i in classes) {
-            this.css[classes[i]] = getComputedStyle(palette.select("." + classes[i]).node());
+            this.css[classes[i]] = getComputedStyle(
+                palette.select('.' + classes[i]).node(),
+            );
         }
         this.styles = {};
         this.strokes = {};
@@ -1703,8 +1964,8 @@ class Styles {
         this.icons = {};
         this.texts = {};
 
-        this.missingStroke = new Stroke({color: "#ff0000", width: 1});
-        this.missingFill = new Fill({color: "#ff0000"});
+        this.missingStroke = new Stroke({ color: '#ff0000', width: 1 });
+        this.missingFill = new Fill({ color: '#ff0000' });
     }
 
     lookupStyle(name) {
@@ -1712,11 +1973,11 @@ class Styles {
             const options = {};
             const stroke = this.lookupStroke(name);
             if (stroke) {
-                options["stroke"] = stroke;
+                options['stroke'] = stroke;
             }
             const fill = this.lookupFill(name);
             if (fill) {
-                options["fill"] = fill;
+                options['fill'] = fill;
             }
             this.styles[name] = new Style(options);
         }
@@ -1736,10 +1997,13 @@ class Styles {
     lookupStroke(name) {
         if (!this.strokes[name]) {
             if (this.css[name]) {
-                if (this.css[name]["stroke"] != "none") {
+                if (this.css[name]['stroke'] != 'none') {
                     this.strokes[name] = new Stroke({
-                        color: this.css[name]["stroke"],
-                        width: +this.css[name]["stroke-width"].replace("px", ""),
+                        color: this.css[name]['stroke'],
+                        width: +this.css[name]['stroke-width'].replace(
+                            'px',
+                            '',
+                        ),
                     });
                 } else {
                     this.strokes[name] = null;
@@ -1754,9 +2018,9 @@ class Styles {
     lookupFill(name) {
         if (!this.fills[name]) {
             if (this.css[name]) {
-                if (this.css[name]["fill-opacity"] != 0) {
+                if (this.css[name]['fill-opacity'] != 0) {
                     this.fills[name] = new Fill({
-                        color: this.css[name]["fill"],
+                        color: this.css[name]['fill'],
                     });
                 } else {
                     this.fills[name] = null;
@@ -1786,8 +2050,8 @@ class Styles {
             this.icons[name] = new Style({
                 image: new Icon({
                     src: `/images/${name}.svg`,
-                })
-            })
+                }),
+            });
         }
         return this.icons[name];
     }
@@ -1795,8 +2059,8 @@ class Styles {
     lookupLineTextWithText(name, text) {
         if (!this.texts[name]) {
             const options = {
-                font: "11px sans-serif",
-                placement: "line",
+                font: '11px sans-serif',
+                placement: 'line',
             };
             if (this.css[name]) {
                 if (this.css[name].font) {
@@ -1819,48 +2083,66 @@ class Styles {
     }
 }
 
-const EventTypeStartup = "s"
-const EventTypeDockOpen = "do";
-const EventTypeMapLatLngClick = "mlc";
-const EventTypeMapFeatureClick = "mfc";
-const EventTypeOutlinerClick  = "oc";
-const EventTypeOutlinerShell = "os";
-const EventTypeWorldShell = "ws";
-const EventTypeError = "err";
+const EventTypeStartup = 's';
+const EventTypeDockOpen = 'do';
+const EventTypeMapLatLngClick = 'mlc';
+const EventTypeMapFeatureClick = 'mfc';
+const EventTypeOutlinerClick = 'oc';
+const EventTypeOutlinerShell = 'os';
+const EventTypeWorldShell = 'ws';
+const EventTypeError = 'err';
 
 class NullEventLogger {
     logEvent(type, options) {}
 }
 
 function setup(selector, startupResponse, logger) {
-    const target = d3.select(selector).classed("b6", true);
-    const mapTarget = target.append("div").classed("map", true);
-    const shellTarget = target.append("div").classed("shell", true).classed("closed", true);
-    const dockTarget = target.append("div").classed("dock", true);
+    const target = d3.select(selector).classed('b6', true);
+    const mapTarget = target.append('div').classed('map', true);
+    const shellTarget = target
+        .append('div')
+        .classed('shell', true)
+        .classed('closed', true);
+    const dockTarget = target.append('div').classed('dock', true);
     if (startupResponse.error) {
         showMessage(startupResponse.error);
         return;
     }
-    const state = {highlighted: {}, bucketed: {}, showBucket: -1};
+    const state = { highlighted: {}, bucketed: {}, showBucket: -1 };
     const styles = new Styles(StyleClasses);
     const mapCenter = startupResponse.mapCenter || InitialCenter;
     const mapZoom = startupResponse.mapZoom || InitalZoom;
-    const [map, highlightChanged] = setupMap(mapTarget, state, styles, mapCenter, mapZoom);
+    const [map, highlightChanged] = setupMap(
+        mapTarget,
+        state,
+        styles,
+        mapCenter,
+        mapZoom,
+    );
     const queryStyle = newQueryStyle(state, styles);
     const geojsonStyle = newGeoJSONStyle(state, styles);
-    const ui = new UI(map, dockTarget, state, queryStyle, geojsonStyle, highlightChanged, startupResponse.session, logger);
-    const html = d3.select("html");
-    html.on("pointermove", e => {
+    const ui = new UI(
+        map,
+        dockTarget,
+        state,
+        queryStyle,
+        geojsonStyle,
+        highlightChanged,
+        startupResponse.session,
+        logger,
+    );
+    const html = d3.select('html');
+    html.on('pointermove', (e) => {
         ui.handlePointerMove(e);
     });
-    html.on("mouseup", e => {
+    html.on('mouseup', (e) => {
         ui.handleDragEnd(e);
     });
 
     setupShell(shellTarget, ui);
     ui.handleStartupResponse(startupResponse);
 
-    map.on("singleclick", e => {
+    map.on('singleclick', (e) => {
         ui.handleMapClick(e);
     });
 }
@@ -1870,7 +2152,9 @@ function main(selector, logger) {
         logger = new NullEventLogger();
     }
     const params = new URLSearchParams(window.location.search);
-    d3.json("/startup?" + params.toString()).then(response => setup(selector, response, logger));
+    d3.json('/startup?' + params.toString()).then((response) =>
+        setup(selector, response, logger),
+    );
 }
 
 export default main;

--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -38,7 +38,6 @@ const RoadWidths = {
     footway: 8.0,
     path: 8.0,
 };
-const GeoJSONFillColour = '#364153';
 
 function scaleWidth(width, resolution) {
     return width * (0.3 / resolution);
@@ -60,12 +59,13 @@ function newGeoJSONStyle(state, styles) {
     const path = styles.lookupStyle('geojson-path');
     const area = styles.lookupStyle('geojson-area');
 
-    return function (feature, resolution) {
+    return function (feature) {
         var s = point;
         switch (feature.getGeometry().getType()) {
             case 'LineString':
             case 'MultiLineString':
                 s = path;
+                break;
             case 'Polygon':
             case 'MultiPolygon':
                 s = area;
@@ -113,7 +113,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const background = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'background') {
                 return backgroundFill;
             }
@@ -122,7 +122,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const boundaries = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'boundary') {
                 if (state.featureColours) {
                     const colour =
@@ -166,7 +166,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const landuse = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             const landuse = feature.get('landuse');
             const leisure = feature.get('leisure');
             const natural = feature.get('natural');
@@ -242,7 +242,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
     const roadLabels = new VectorTileLayer({
         source: baseSource,
         declutter: true,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'road') {
                 if (feature.get('name')) {
                     return styles.lookupLineTextWithText(
@@ -256,7 +256,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const rails = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'road' && feature.get('railway')) {
                 const id = idKeyFromFeature(feature);
                 if (state.highlighted[id]) {
@@ -285,7 +285,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const buildings = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'building') {
                 const id = idKeyFromFeature(feature);
                 const bucket = state.bucketed[id];
@@ -307,7 +307,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const points = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'point') {
                 const id = idKeyFromFeature(feature);
                 const bucket = state.bucketed[id];
@@ -327,7 +327,7 @@ function setupMap(target, state, styles, mapCenter, mapZoom) {
 
     const labels = new VectorTileLayer({
         source: baseSource,
-        style: function (feature, resolution) {
+        style: function (feature) {
             if (feature.get('layer') == 'label') {
                 return new Style({
                     text: new Text({
@@ -776,7 +776,7 @@ class ConditionalAtomRenderer {
         return 'atom-conditional';
     }
 
-    enter(atom) {}
+    enter() {}
 
     update(atom, stack) {
         const conditional = atom.datum().conditional;
@@ -810,7 +810,7 @@ class ValueLineRenderer {
         return 'line-value';
     }
 
-    enter(line) {}
+    enter() {}
 
     update(line, stack) {
         const atoms = line
@@ -851,7 +851,7 @@ class LeftRightValueLineRenderer {
         return 'line-left-right-value';
     }
 
-    enter(line) {}
+    enter() {}
 
     update(line, stack) {
         const values = [];
@@ -892,7 +892,7 @@ class ExpressionLineRenderer {
         return 'line-expression';
     }
 
-    enter(line) {}
+    enter() {}
 
     update(line, stack) {
         line.text((d) => d.expression.expression);
@@ -1038,15 +1038,15 @@ class ShellLineRenderer {
             highlighted: 0,
         };
         const form = line.select('form');
-        form.select('input').on('focusin', (e) => {
+        form.select('input').on('focusin', () => {
             form.select('ul').classed('focussed', true);
         });
-        form.select('input').on('focusout', (e) => {
+        form.select('input').on('focusout', () => {
             form.select('ul').classed('focussed', false);
         });
         form.on('keydown', (e) => {
             switch (e.key) {
-                case 'Tab':
+                case 'Tab': {
                     const node = form.select('input').node();
                     if (
                         state.highlighted >= 0 &&
@@ -1057,6 +1057,7 @@ class ShellLineRenderer {
                     }
                     e.preventDefault();
                     break;
+                }
             }
         });
         form.on('keyup', (e) => {
@@ -1124,7 +1125,7 @@ class ChoiceLineRenderer {
         return 'line-choice';
     }
 
-    enter(line) {}
+    enter() {}
 
     update(line, stack) {
         const atoms = line
@@ -1191,7 +1192,7 @@ class ErrorLineRenderer {
         return 'line-error';
     }
 
-    enter(line) {}
+    enter() {}
 
     update(line) {
         line.text((d) => d.error.error);
@@ -1282,7 +1283,7 @@ class UI {
         this.docked = [];
         this.openDockIndex = -1;
 
-        this.map.on('moveend', (e) => {
+        this.map.on('moveend', () => {
             this._updateBrowserState();
         });
     }
@@ -1355,7 +1356,7 @@ class UI {
 
     closeAllDocked() {
         const docked = this.dockTarget.selectAll('.stack');
-        const ui = this;
+
         docked.each(function () {
             if (this.__stack__) {
                 this.__stack__.removeFromMap();
@@ -1761,10 +1762,6 @@ function showFeatureAtPixel(pixel, locked, position, map, ui, logEvent) {
     );
 }
 
-function idKey(id) {
-    return `/${id[0]}/${id[1]}/${id[2]}`;
-}
-
 const idGeometryTypes = {
     Point: 'point',
     LineString: 'path',
@@ -1865,7 +1862,7 @@ function newQueryStyle(state, styles) {
         return styles.lookupStyle(`bucketed-${b}`);
     });
 
-    return function (feature, resolution) {
+    return function (feature) {
         if (feature.get('layer') != 'background') {
             const id = idKeyFromFeature(feature);
             const highlighted = state.highlighted[id];
@@ -2093,7 +2090,7 @@ const EventTypeWorldShell = 'ws';
 const EventTypeError = 'err';
 
 class NullEventLogger {
-    logEvent(type, options) {}
+    logEvent() {}
 }
 
 function setup(selector, startupResponse, logger) {

--- a/src/diagonal.works/b6/cmd/b6/js/main.js
+++ b/src/diagonal.works/b6/cmd/b6/js/main.js
@@ -1,3 +1,3 @@
-import main from "./b6.js";
+import main from './b6.js';
 
-main("#b6");
+main('#b6');

--- a/src/diagonal.works/b6/cmd/b6/js/package.json
+++ b/src/diagonal.works/b6/cmd/b6/js/package.json
@@ -4,7 +4,9 @@
         "build": "rollup -c",
         "start": "rollup -c --watch"
     },
-    "files": ["b6.js"],
+    "files": [
+        "b6.js"
+    ],
     "main": "b6.js",
     "module": "b6.js",
     "dependencies": {
@@ -15,5 +17,11 @@
         "ol": "^7.0.0",
         "pbf": "^3.2.1",
         "rollup-plugin-terser": "^7.0.2"
+    },
+    "devDependencies": {
+        "eslint": "^8.56.0",
+        "eslint-config-prettier": "^9.1.0",
+        "prettier": "3.2.5",
+        "prettier-plugin-organize-imports": "^3.2.4"
     }
 }

--- a/src/diagonal.works/b6/cmd/b6/js/rollup.config.js
+++ b/src/diagonal.works/b6/cmd/b6/js/rollup.config.js
@@ -1,14 +1,11 @@
-import resolve from "@rollup/plugin-node-resolve";
-import cjs from "@rollup/plugin-commonjs";
+import cjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 
 export default {
-    input: "main.js",
+    input: 'main.js',
     output: {
-        file: "bundle.js",
-        format: "iife",
+        file: 'bundle.js',
+        format: 'iife',
     },
-	plugins: [
-        resolve(),
-        cjs()
-    ]
+    plugins: [resolve(), cjs()],
 };

--- a/src/diagonal.works/b6/cmd/b6/js/static/b6.css
+++ b/src/diagonal.works/b6/cmd/b6/js/static/b6.css
@@ -1,54 +1,56 @@
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 300;
-    src: url("https://diagonal.works/fonts/unica77-light.woff") format("woff");
+    src: url('https://diagonal.works/fonts/unica77-light.woff') format('woff');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 300;
-    src: url("https://diagonal.works/fonts/unica77-light.woff2") format("woff2");
+    src: url('https://diagonal.works/fonts/unica77-light.woff2') format('woff2');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 400;
-    src: url("https://diagonal.works/fonts/unica77-regular.woff") format("woff");
+    src: url('https://diagonal.works/fonts/unica77-regular.woff') format('woff');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 400;
-    src: url("https://diagonal.works/fonts/unica77-regular.woff2") format("woff2");
+    src: url('https://diagonal.works/fonts/unica77-regular.woff2')
+        format('woff2');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 500;
-    src: url("https://diagonal.works/fonts/unica77-medium.woff") format("woff");
+    src: url('https://diagonal.works/fonts/unica77-medium.woff') format('woff');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 500;
-    src: url("https://diagonal.works/fonts/unica77-medium.woff2") format("woff2");
+    src: url('https://diagonal.works/fonts/unica77-medium.woff2')
+        format('woff2');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 700;
-    src: url("https://diagonal.works/fonts/unica77-bold.woff") format("woff");
+    src: url('https://diagonal.works/fonts/unica77-bold.woff') format('woff');
 }
 
 @font-face {
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-weight: 700;
-    src: url("https://diagonal.works/fonts/unica77-bold.woff2") format("woff2");
+    src: url('https://diagonal.works/fonts/unica77-bold.woff2') format('woff2');
 }
 
 html {
     background: white;
-    font-family: "Unica 77", sans-serif;
+    font-family: 'Unica 77', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -webkit-text-size-adjust: 100%;
@@ -89,7 +91,7 @@ a:hover {
 
 .ol-zoom-in {
     background-color: white;
-    background-image: url("/images/zoom-in.svg");
+    background-image: url('/images/zoom-in.svg');
     background-size: contain;
     background-repeat: no-repeat;
     border: 0px;
@@ -102,7 +104,7 @@ a:hover {
 
 .ol-zoom-out {
     background-color: white;
-    background-image: url("/images/zoom-out.svg");
+    background-image: url('/images/zoom-out.svg');
     background-size: contain;
     background-repeat: no-repeat;
     border: 0px;
@@ -185,7 +187,7 @@ form.shell-form > input {
     stroke: #ffffff;
     stroke-width: 2px;
     fill: #192939;
-    font-family: "Unica 77", sans-serif;
+    font-family: 'Unica 77', sans-serif;
     font-size: 11px;
 }
 
@@ -302,7 +304,7 @@ form.shell-form > input {
 
 .palette > .contour {
     stroke: #e1e1ed;
-    stroke-width: 1.0;
+    stroke-width: 1;
 }
 
 .palette > .outliner-rose {
@@ -437,7 +439,7 @@ form.shell-form > input {
     border: 1px solid #dbdeec; /* Graphite 30 */
     color: #20263b; /* Graphite 100 */
     background: #ffffff;
-    font-family: "Unica 77";
+    font-family: 'Unica 77';
     font-size: 16px;
     font-style: normal;
     font-weight: 400;
@@ -556,32 +558,32 @@ form.shell-form > input {
 
 .range-icon.index-0 {
     background-color: #ffffff;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .range-icon.index-1 {
     background-color: #a9aec5;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .range-icon.index-2 {
     background-color: #9ccdeb;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .range-icon.index-3 {
     background-color: #bce6ee;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .range-icon.index-4 {
     background-color: #d6f5e6;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .range-icon.index-5 {
     background-color: #f4fde5;
-    border: 1px solid #dbdeec; /* Graphite 30 */;
+    border: 1px solid #dbdeec; /* Graphite 30 */
 }
 
 .line-histogram-bar .range-icon {
@@ -604,12 +606,12 @@ form.shell-form > input {
     flex: 0 1 auto;
     padding-right: 5px;
     padding-left: 5px;
-    color: #528DFF;
+    color: #528dff;
 }
 
 .line-histogram-bar .total {
     flex: 0 1 auto;
-    color: #8990AC;
+    color: #8990ac;
 }
 
 .line-histogram-bar .value-bar {
@@ -623,7 +625,7 @@ form.shell-form > input {
 }
 
 .line-histogram-bar .value-bar > .fill {
-    background-color: #4F5A7D;
+    background-color: #4f5a7d;
     border-radius: 2px;
     width: 100%;
 }
@@ -689,7 +691,7 @@ form.shell-form > input {
 }
 
 .line-error {
-    background: #ed968a;   
+    background: #ed968a;
 }
 
 .stack {
@@ -784,7 +786,7 @@ form.shell-form > input {
 }
 
 .dock > .stack.closed .line-question:hover {
-    background: #f8f9fc /* Graphite 10 */
+    background: #f8f9fc; /* Graphite 10 */
 }
 
 .dock > .stack > .substack > .scrollable {
@@ -816,4 +818,3 @@ form.shell-form > input {
     border: 1px solid #528dff00;
     transition: all 0.7s;
 }
-

--- a/src/diagonal.works/b6/cmd/b6/js/static/index.html
+++ b/src/diagonal.works/b6/cmd/b6/js/static/index.html
@@ -1,11 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
     <head>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;1,300"/>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300"/>
-        <link href="/b6.css" rel="stylesheet"/>
-        <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png"/>
-        <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png"/>
+        <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;1,300"
+        />
+        <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300"
+        />
+        <link href="/b6.css" rel="stylesheet" />
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/images/favicon-32x32.png"
+        />
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/images/favicon-16x16.png"
+        />
     </head>
     <body>
         <div id="b6"></div>

--- a/src/diagonal.works/b6/cmd/b6/js/static/palette.html
+++ b/src/diagonal.works/b6/cmd/b6/js/static/palette.html
@@ -1,1097 +1,1758 @@
 <html>
+    <head>
+        <link href="/b6.css" rel="stylesheet" />
+        <style type="text/css">
+            .blocks {
+                position: relative;
+                margin-bottom: 12px;
+            }
+        </style>
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/images/favicon-32x32.png"
+        />
+        <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/images/favicon-16x16.png"
+        />
+    </head>
 
-<head>
-    <link href="/b6.css" rel="stylesheet">
-    <style type="text/css">
-        .blocks {position: relative; margin-bottom: 12px;}        
-    </style>
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
-</head>
-
-<body>
-    <div class="blocks">
-        <div class="block">
-            <div class="block-container placeholder">literal:{queryValue:{tagged:{key:"#amenity" value:"pub"}}} Begin:1
-                End:15</div>
-        </div>
-        <div class="block">
-            <div class="block-container call">find</div>
-        </div>
-        <div class="block">
-            <div class="block-container collection">
-                <h3 class="collection-title">Collection</h3>
-                <ul>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">21593236</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">21593238</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">25475914</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">25501630</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">25534171</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">25744507</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">25831194</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">26610587</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">26610590</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">29039088</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">49314952</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">49319602</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">166967411</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">192399971</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">192399976</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">192399980</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">192399984</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">245437382</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">248453431</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">250367687</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">257422550</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">257937397</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">265649310</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">280145696</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">281455014</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">287326420</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">287326425</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">292183282</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">293390260</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">293754855</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">294599679</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">294659404</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">294765140</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">296889741</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">296891969</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">298347049</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">298347050</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">300500863</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">311188199</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">311877348</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">332118048</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">338463555</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">338504993</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">344084670</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">362501621</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">362582983</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">380568360</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">383932467</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">383970848</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">388116718</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">405268933</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">411096510</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">430432974</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">452433527</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">552169434</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">596791858</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">596791860</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">630503145</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">646585258</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">647873586</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">676853367</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">831456411</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">833772427</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">851223228</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">881370103</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1116251530</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1215861506</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1643783925</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1656086534</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1849624956</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1974309855</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">1975855516</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">2316821043</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">2624195137</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">2636979676</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">3485070520</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">3730997811</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">4020316989</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">4285984291</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">4665750869</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">6052873806</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">6381240591</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">6384330787</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">6561669265</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">7549942987</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">7550093574</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">7550117864</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">7590593053</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">7929807779</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-point"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">8830280452</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">40917016</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">65272901</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">67827145</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">70298958</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">75422589</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">79504992</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">79813535</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">81459093</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">House</span><span class="namespace">OSM</span><span
-                                class="id">85258717</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">93710879</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">93710880</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">97237916</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">98515735</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">98535850</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">98535852</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">98612270</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">99475943</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">100264369</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">100267362</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">House</span><span class="namespace">OSM</span><span
-                                class="id">104112035</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">107530526</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">107755382</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">108251970</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">109187435</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">110467983</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">110512372</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">112564610</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">117607358</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">117861610</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">118806519</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">119297891</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">123092742</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">123701971</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">131196049</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">131925577</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">132202715</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">132319674</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">135117838</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">135117851</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">138339524</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">148519551</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">153690421</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">155724665</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">155731385</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">157757561</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">172055438</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">175155068</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">183366008</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">185312889</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">188549801</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">191317959</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">199398431</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">199398466</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">205275925</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">224892755</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">225302691</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">225442612</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">225442626</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">225465143</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">225465195</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">225785469</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">226909129</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">232592409</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">239482111</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">246222657</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">251068938</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">257148829</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">275292695</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">277929202</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">277929211</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">277929217</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">277929219</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">278118730</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">281133713</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">290457617</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">291687162</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">294646443</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">294886275</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">294886276</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">300898455</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">334243397</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">337127150</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">339202679</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">347393523</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">368797311</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">373710205</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">380853128</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">408113140</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">409316355</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">416068944</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">416601731</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">420411288</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">421566584</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">421882353</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">421882356</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">422540678</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">422540681</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">427341994</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">427900370</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">439073012</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Commercial</span><span class="namespace">OSM</span><span
-                                class="id">449266220</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">451480071</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Pub</span><span class="namespace">OSM</span><span
-                                class="id">451564160</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">451645113</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">451762775</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">452786932</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Retail</span><span class="namespace">OSM</span><span
-                                class="id">452856397</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">House</span><span class="namespace">OSM</span><span
-                                class="id">474249421</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">514560030</span></div>
-                    </li>
-                    <li>
-                        <div class="block-container collection-feature"><span class="icon icon-area"></span><span
-                                class="label">Building</span><span class="namespace">OSM</span><span
-                                class="id">516754454</span></div>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <div class="block">
-            <div class="block-container toolbox">
-                <div class="input">
-                    <div class="button fx">fx</div>
-                    <div class="button move">⇲</div><input type="text">
+    <body>
+        <div class="blocks">
+            <div class="block">
+                <div class="block-container placeholder">
+                    literal:{queryValue:{tagged:{key:"#amenity" value:"pub"}}}
+                    Begin:1 End:15
                 </div>
-                <ul>
-                    <li class="highlighted">add-tags</li>
-                    <li>building-access</li>
-                    <li>collection</li>
-                    <li>containing-areas</li>
-                    <li>count</li>
-                    <li>count-values</li>
-                </ul>
             </div>
-        </div>
-    </div>
-    <div class="blocks">
-        <div class="block">
-            <div class="block-container call">find-feature /a/427900370</div>
-        </div>
-        <div class="block">
-            <div class="block-container feature">
-                <ul class="tags">
-                    <li><span class="prefix"></span><span class="key">addr:city</span><span class="value">London</span>
-                    </li>
-                    <li><span class="prefix"></span><span class="key">addr:housenumber</span><span
-                            class="value">3</span></li>
-                    <li><span class="prefix"></span><span class="key">addr:postcode</span><span class="value">N1C
-                            4BH</span></li>
-                    <li><span class="prefix"></span><span class="key">addr:street</span><span class="value">Granary
-                            Square</span></li>
-                    <li><span class="prefix">#</span><span class="key">amenity</span><span class="value">pub</span></li>
-                    <li><span class="prefix">#</span><span class="key">building</span><span class="value">yes</span>
-                    </li>
-                    <li><span class="prefix"></span><span class="key">building:levels</span><span class="value">3</span>
-                    </li>
-                    <li><span class="prefix"></span><span class="key">email</span><span
-                            class="value">reservations@thelighterman.co.uk</span></li>
-                    <li><span class="prefix"></span><span class="key">name</span><span class="value">The
-                            Lighterman</span></li>
-                    <li><span class="prefix"></span><span class="key">opening_hours</span><span class="value">Mo-Th
-                            08:00-23:30; Fr 08:00-24:00; Sa 09:00-24:00; Su 09:00-22:30</span></li>
-                    <li><span class="prefix"></span><span class="key">phone</span><span class="value">+44 20 3846
-                            3400</span></li>
-                    <li><span class="prefix"></span><span class="key">website</span><span
-                            class="value">https://thelighterman.co.uk/</span></li>
-                </ul>
+            <div class="block">
+                <div class="block-container call">find</div>
             </div>
-        </div>
-        <div class="block">
-            <div class="block-container toolbox">
-                <div class="input">
-                    <div class="button fx">fx</div>
-                    <div class="button move">⇲</div><input type="text">
+            <div class="block">
+                <div class="block-container collection">
+                    <h3 class="collection-title">Collection</h3>
+                    <ul>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">21593236</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">21593238</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">25475914</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">25501630</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">25534171</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">25744507</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">25831194</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">26610587</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">26610590</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">29039088</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">49314952</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">49319602</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">166967411</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">192399971</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">192399976</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">192399980</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">192399984</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">245437382</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">248453431</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">250367687</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">257422550</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">257937397</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">265649310</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">280145696</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">281455014</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">287326420</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">287326425</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">292183282</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">293390260</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">293754855</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294599679</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294659404</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294765140</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">296889741</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">296891969</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">298347049</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">298347050</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">300500863</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">311188199</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">311877348</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">332118048</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">338463555</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">338504993</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">344084670</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">362501621</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">362582983</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">380568360</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">383932467</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">383970848</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">388116718</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">405268933</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">411096510</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">430432974</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">452433527</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">552169434</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">596791858</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">596791860</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">630503145</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">646585258</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">647873586</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">676853367</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">831456411</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">833772427</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">851223228</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">881370103</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1116251530</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1215861506</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1643783925</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1656086534</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1849624956</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1974309855</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">1975855516</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">2316821043</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">2624195137</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">2636979676</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">3485070520</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">3730997811</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">4020316989</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">4285984291</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">4665750869</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">6052873806</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">6381240591</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">6384330787</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">6561669265</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">7549942987</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">7550093574</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">7550117864</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">7590593053</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">7929807779</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-point"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">8830280452</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">40917016</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">65272901</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">67827145</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">70298958</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">75422589</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">79504992</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">79813535</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">81459093</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">House</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">85258717</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">93710879</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">93710880</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">97237916</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">98515735</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">98535850</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">98535852</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">98612270</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">99475943</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">100264369</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">100267362</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">House</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">104112035</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">107530526</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">107755382</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">108251970</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">109187435</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">110467983</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">110512372</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">112564610</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">117607358</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">117861610</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">118806519</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">119297891</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">123092742</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">123701971</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">131196049</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">131925577</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">132202715</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">132319674</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">135117838</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">135117851</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">138339524</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">148519551</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">153690421</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">155724665</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">155731385</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">157757561</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">172055438</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">175155068</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">183366008</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">185312889</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">188549801</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">191317959</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">199398431</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">199398466</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">205275925</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">224892755</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225302691</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225442612</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225442626</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225465143</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225465195</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">225785469</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">226909129</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">232592409</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">239482111</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">246222657</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">251068938</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">257148829</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">275292695</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">277929202</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">277929211</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">277929217</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">277929219</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">278118730</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">281133713</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">290457617</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">291687162</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294646443</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294886275</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">294886276</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">300898455</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">334243397</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">337127150</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">339202679</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">347393523</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">368797311</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">373710205</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">380853128</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">408113140</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">409316355</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">416068944</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">416601731</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">420411288</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">421566584</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">421882353</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">421882356</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">422540678</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">422540681</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">427341994</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">427900370</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">439073012</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Commercial</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">449266220</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">451480071</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Pub</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">451564160</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">451645113</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">451762775</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">452786932</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Retail</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">452856397</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">House</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">474249421</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">514560030</span>
+                            </div>
+                        </li>
+                        <li>
+                            <div class="block-container collection-feature">
+                                <span class="icon icon-area"></span
+                                ><span class="label">Building</span
+                                ><span class="namespace">OSM</span
+                                ><span class="id">516754454</span>
+                            </div>
+                        </li>
+                    </ul>
                 </div>
-                <ul>
-                    <li class="highlighted">add-tag</li>
-                    <li>all-tags</li>
-                    <li>area</li>
-                    <li>centroid</li>
-                    <li>closest</li>
-                    <li>closest-distance</li>
-                </ul>
+            </div>
+            <div class="block">
+                <div class="block-container toolbox">
+                    <div class="input">
+                        <div class="button fx">fx</div>
+                        <div class="button move">⇲</div>
+                        <input type="text" />
+                    </div>
+                    <ul>
+                        <li class="highlighted">add-tags</li>
+                        <li>building-access</li>
+                        <li>collection</li>
+                        <li>containing-areas</li>
+                        <li>count</li>
+                        <li>count-values</li>
+                    </ul>
+                </div>
             </div>
         </div>
-    </div>
-</body>
-
+        <div class="blocks">
+            <div class="block">
+                <div class="block-container call">
+                    find-feature /a/427900370
+                </div>
+            </div>
+            <div class="block">
+                <div class="block-container feature">
+                    <ul class="tags">
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">addr:city</span
+                            ><span class="value">London</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">addr:housenumber</span
+                            ><span class="value">3</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">addr:postcode</span
+                            ><span class="value">N1C 4BH</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">addr:street</span
+                            ><span class="value">Granary Square</span>
+                        </li>
+                        <li>
+                            <span class="prefix">#</span
+                            ><span class="key">amenity</span
+                            ><span class="value">pub</span>
+                        </li>
+                        <li>
+                            <span class="prefix">#</span
+                            ><span class="key">building</span
+                            ><span class="value">yes</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">building:levels</span
+                            ><span class="value">3</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">email</span
+                            ><span class="value"
+                                >reservations@thelighterman.co.uk</span
+                            >
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">name</span
+                            ><span class="value">The Lighterman</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">opening_hours</span
+                            ><span class="value"
+                                >Mo-Th 08:00-23:30; Fr 08:00-24:00; Sa
+                                09:00-24:00; Su 09:00-22:30</span
+                            >
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">phone</span
+                            ><span class="value">+44 20 3846 3400</span>
+                        </li>
+                        <li>
+                            <span class="prefix"></span
+                            ><span class="key">website</span
+                            ><span class="value"
+                                >https://thelighterman.co.uk/</span
+                            >
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="block">
+                <div class="block-container toolbox">
+                    <div class="input">
+                        <div class="button fx">fx</div>
+                        <div class="button move">⇲</div>
+                        <input type="text" />
+                    </div>
+                    <ul>
+                        <li class="highlighted">add-tag</li>
+                        <li>all-tags</li>
+                        <li>area</li>
+                        <li>centroid</li>
+                        <li>closest</li>
+                        <li>closest-distance</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
### Goal

This PR adds [ESlint](https://eslint.org/) for linting and [Prettier](https://prettier.io/) for formatting.

### Comments

We add explicit prettier configuration so that we don't run into mismatches if we have different workspace formatting preferences in our code editor