### PR TITLE
Upgrade the build environment to ubuntu mantic.

### DIFF
--- a/docker/Dockerfile.b6-build.inc
+++ b/docker/Dockerfile.b6-build.inc
@@ -1,14 +1,16 @@
 # Build a docker image containing the tools and dependencies necessary to
 # build b6 from source
-FROM ubuntu:jammy AS b6-build
+FROM ubuntu:mantic AS b6-build
 ARG TARGETOS
 ARG TARGETARCH
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yq install git make ca-certificates curl npm protobuf-compiler gdal-bin libgdal-dev python3-pip python3.10-venv
-RUN curl -L -O https://go.dev/dl/go1.20.3.$TARGETOS-$TARGETARCH.tar.gz
-RUN tar -C /usr/local -xzf go1.20.3.$TARGETOS-$TARGETARCH.tar.gz && rm go1.20.3.$TARGETOS-$TARGETARCH.tar.gz
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yq install git make ca-certificates curl npm protobuf-compiler gdal-bin libgdal-dev python3-full
+RUN curl -L -O https://go.dev/dl/go1.21.6.$TARGETOS-$TARGETARCH.tar.gz
+RUN tar -C /usr/local -xzf go1.21.6.$TARGETOS-$TARGETARCH.tar.gz && rm go1.21.6.$TARGETOS-$TARGETARCH.tar.gz
 RUN mkdir /go-cache
 ENV GOBIN=/usr/local/go/bin
 ENV GOCACHE=/go-cache
 ENV PATH=/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest && GOBIN=/usr/local/go/bin go install golang.org/x/tools/cmd/goyacc@latest
-RUN python3 -m pip install build grpcio grpcio-tools s2sphere
+RUN python3 -m venv /build
+RUN /build/bin/pip install build grpcio grpcio-tools s2sphere
+ENV PATH="/build/bin:$PATH"

--- a/docker/Dockerfile.b6.inc
+++ b/docker/Dockerfile.b6.inc
@@ -16,7 +16,7 @@ RUN TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH make -C /build python-test
 RUN cd /build/python; python3 -m build
 RUN /build/bin/$TARGETOS/$TARGETARCH/b6-ingest-osm --input=/build/data/tests/camden.osm.pbf --output=/build/data/camden.index
 RUN /build/bin/$TARGETOS/$TARGETARCH/b6-connect --input=/build/data/camden.index --output=/build/data/camden.connected.index
-FROM ubuntu:jammy
+FROM ubuntu:mantic
 ARG TARGETOS
 ARG TARGETARCH
 COPY --from=b6-build /build/bin/$TARGETOS/$TARGETARCH/* /diagonal/bin/

--- a/src/diagonal.works/b6/go.mod
+++ b/src/diagonal.works/b6/go.mod
@@ -1,17 +1,12 @@
 module diagonal.works/b6
 
-go 1.20
-
-// Use Diagonal's fork of gdal, which supports linux/arm64 for Docker
-// running on Apple silicon.
-replace github.com/lukeroth/gdal v0.0.0-20220614134811-3c605a05e283 => github.com/diagonalworks/gdal v0.0.0-20230425060405-b7726afc0d73
+go 1.21
 
 require (
 	github.com/apache/beam v2.32.0+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/go-cmp v0.5.9
-	github.com/lukeroth/gdal v0.0.0-20220614134811-3c605a05e283
 	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
 	golang.org/x/mod v0.10.0
 	golang.org/x/sync v0.1.0
@@ -32,6 +27,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
+	github.com/lukeroth/gdal v0.0.0-20230818145556-62d5095a1cda // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.9.0 // indirect

--- a/src/diagonal.works/b6/go.sum
+++ b/src/diagonal.works/b6/go.sum
@@ -79,6 +79,10 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5
 github.com/googleapis/gax-go/v2 v2.8.0 h1:UBtEZqx1bjXtOQ5BVTkuYghXrr3N4V123VKJK67vJZc=
 github.com/googleapis/gax-go/v2 v2.8.0/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/lukeroth/gdal v0.0.0-20230817233842-b938af96a129 h1:QCZOLtmFjADRWl+cFwdCabIp0e9YnbFQDmTJu7ZsWhs=
+github.com/lukeroth/gdal v0.0.0-20230817233842-b938af96a129/go.mod h1:u/R3dIULVNb+dWMOvaoa5GxHgN1rJi+TUKUlTOqU/MY=
+github.com/lukeroth/gdal v0.0.0-20230818145556-62d5095a1cda h1:k/GMO3p7c586UHhr1hxGNQfBBtBfYuaI+acah/CwaPA=
+github.com/lukeroth/gdal v0.0.0-20230818145556-62d5095a1cda/go.mod h1:u/R3dIULVNb+dWMOvaoa5GxHgN1rJi+TUKUlTOqU/MY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Upgrade the build environment to ubuntu mantic, for GDAL 3.6, which is the only version for which the wrapper works with go 1.21.