### PR TITLE
Support writing to cloud from b6-ingest-osm and b6-connect.

### DIFF
--- a/src/diagonal.works/b6/api/functions/export.go
+++ b/src/diagonal.works/b6/api/functions/export.go
@@ -20,10 +20,10 @@ func exportWorld(c *api.Context, filename string) (int, error) {
 
 	source := ingest.WorldFeatureSource{World: c.World}
 	options := compact.Options{
-		OutputFilename:       filename,
-		Goroutines:           c.Cores,
-		WorkDirectory:        "",
-		PointsWorkOutputType: compact.OutputTypeMemory,
+		OutputFilename:          filename,
+		Goroutines:              c.Cores,
+		ScratchDirectory:        "",
+		PointsScratchOutputType: compact.OutputTypeMemory,
 	}
 	return 0, compact.Build(source, &options)
 }

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-codepoint/b6-ingest-gb-codepoint.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-codepoint/b6-ingest-gb-codepoint.go
@@ -174,10 +174,10 @@ func main() {
 		var postcodes Postcodes
 		if postcodes, err = readCodepointOpen(*inputFlag); err == nil {
 			config := compact.Options{
-				OutputFilename:       *outputFlag,
-				Goroutines:           *coresFlag,
-				WorkDirectory:        "",
-				PointsWorkOutputType: compact.OutputTypeMemory,
+				OutputFilename:          *outputFlag,
+				Goroutines:              *coresFlag,
+				ScratchDirectory:        "",
+				PointsScratchOutputType: compact.OutputTypeMemory,
 			}
 			err = compact.Build(&postcodes, &config)
 		}

--- a/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gb-uprn/b6-ingest-gb-uprn.go
@@ -84,10 +84,10 @@ func main() {
 	}
 
 	config := compact.Options{
-		OutputFilename:       *outputFlag,
-		Goroutines:           *cores,
-		WorkDirectory:        "",
-		PointsWorkOutputType: compact.OutputTypeMemory,
+		OutputFilename:          *outputFlag,
+		Goroutines:              *cores,
+		ScratchDirectory:        "",
+		PointsScratchOutputType: compact.OutputTypeMemory,
 	}
 	if err := compact.Build(toIndex, &config); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-gdal/b6-ingest-gdal.go
@@ -127,10 +127,10 @@ func main() {
 	}
 
 	options := compact.Options{
-		OutputFilename:       *outputFlag,
-		Goroutines:           *coresFlag,
-		WorkDirectory:        "",
-		PointsWorkOutputType: compact.OutputTypeMemory,
+		OutputFilename:          *outputFlag,
+		Goroutines:              *coresFlag,
+		ScratchDirectory:        "",
+		PointsScratchOutputType: compact.OutputTypeMemory,
 	}
 
 	if err := compact.Build(source, &options); err != nil {

--- a/src/diagonal.works/b6/cmd/b6-ingest-terrain/b6-ingest-terrain.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-terrain/b6-ingest-terrain.go
@@ -234,10 +234,10 @@ func main() {
 	}
 
 	options := compact.Options{
-		OutputFilename:       *outputFlag,
-		Goroutines:           *coresFlag,
-		WorkDirectory:        "",
-		PointsWorkOutputType: compact.OutputTypeMemory,
+		OutputFilename:          *outputFlag,
+		Goroutines:              *coresFlag,
+		ScratchDirectory:        "",
+		PointsScratchOutputType: compact.OutputTypeMemory,
 	}
 	source := elevationSource{World: w, Elevations: elevations}
 	if compact.Build(&source, &options); err != nil {

--- a/src/diagonal.works/b6/ingest/compact/overlay_test.go
+++ b/src/diagonal.works/b6/ingest/compact/overlay_test.go
@@ -19,7 +19,7 @@ func TestOverlayPathOnExistingWorld(t *testing.T) {
 
 	osmSource := ingest.MemoryOSMSource{Nodes: nodes, Ways: ways, Relations: relations}
 	source, err := ingest.NewFeatureSourceFromPBF(&osmSource, &ingest.BuildOptions{Cores: 2}, context.Background())
-	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsScratchOutputType: OutputTypeMemory}
 	index, err := BuildInMemory(source, &options)
 	if err != nil {
 		t.Fatalf("Failed to build base index: %s", err)

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -18,7 +18,7 @@ func mergeOSM(nodes []osm.Node, ways []osm.Way, relations []osm.Relation, base b
 	if err != nil {
 		return err
 	}
-	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsScratchOutputType: OutputTypeMemory}
 	var index []byte
 	if base == nil {
 		if index, err = BuildInMemory(source, &options); err != nil {
@@ -110,7 +110,7 @@ func mustBuildCamdenForBenchmarks() b6.World {
 		panic(err)
 	}
 
-	options := Options{Goroutines: 2, PointsWorkOutputType: OutputTypeMemory}
+	options := Options{Goroutines: 2, PointsScratchOutputType: OutputTypeMemory}
 	var index []byte
 	if index, err = BuildInMemory(source, &options); err != nil {
 		panic(err)


### PR DESCRIPTION
Writing a compact world requires an IO layer that supports writing at a specific byte position, so writing directly to gcs (or s3) isn't possible. Write to a temporary file local file instead, then copy that to gcs, deleting the local file.