### PR TITLE
Provide a basic implementation of FindReferences for compact worlds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ python/pyproject.toml: python/pyproject.toml.template python/VERSION
 python/VERSION:
 	bin/${TARGETPLATFORM}/b6-api --pip-version > $@
 
-python-test: python b6-backend
+python-test: python b6-backend b6-ingest-osm
+	bin/${TARGETPLATFORM}/b6-ingest-osm --input=data/tests/granary-square.osm.pbf --output=data/tests/granary-square.index
 	PYTHONPATH=python TARGETPLATFORM=${TARGETPLATFORM} python3 python/diagonal_b6/b6_test.py
 
 test: proto-go src/diagonal.works/b6/api/y.go

--- a/data/tests/.gitignore
+++ b/data/tests/.gitignore
@@ -1,0 +1,1 @@
+granary-square.index

--- a/python/diagonal_b6/b6_test.py
+++ b/python/diagonal_b6/b6_test.py
@@ -622,7 +622,7 @@ def main():
         "bin/%s/b6" % platform,
         "--http=%s" % http_address,
         "--grpc=%s" % grpc_address,
-        "--world=osm:data/tests/granary-square.osm.pbf"
+        "--world=data/tests/granary-square.index"
     ])
 
     ready, response = wait_until_ready(p, http_address)


### PR DESCRIPTION
Build and use a compact index of Granary Square for the Python unit tests. Fix the resulting test failures by providing a basic implementation of FindReferences, which should ultimately be replaced when we implement a unified way of storing references in the compact world encoding.