### PR TITLE
Support the exist tag serialisation format for tags with string values.

### DIFF
--- a/src/diagonal.works/b6/expression.go
+++ b/src/diagonal.works/b6/expression.go
@@ -292,6 +292,11 @@ func FromLiteral(l interface{}) (Literal, error) {
 	case Feature:
 		f := FeatureExpression{Feature: l}
 		return Literal{AnyLiteral: &f}, nil
+	case LatLng:
+		// TODO: Remove and only use Geo(metry). Needed because
+		// tag values can current be LatLng.
+		ll := PointExpression(l)
+		return Literal{AnyLiteral: &ll}, nil
 	case Geo:
 		ll := PointExpression(l.Location())
 		return Literal{AnyLiteral: &ll}, nil

--- a/src/diagonal.works/b6/ingest/yaml_test.go
+++ b/src/diagonal.works/b6/ingest/yaml_test.go
@@ -3,11 +3,13 @@ package ingest
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"testing"
 
 	"diagonal.works/b6"
 	"diagonal.works/b6/osm"
 	"diagonal.works/b6/test"
+	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -224,6 +226,9 @@ func DiffFeatures(expected b6.Feature, actual b6.Feature) string {
 		// TODO: implement a cmp.Diff transformer for expressions
 		diffs += cmp.Diff(ee, ae, protocmp.Transform())
 	}
-	diffs += cmp.Diff(expected.AllTags(), actual.AllTags())
+	approxAngles := cmp.Comparer(func(a s1.Angle, b s1.Angle) bool {
+		return math.Abs(float64(a-b)) < 0.001
+	})
+	diffs += cmp.Diff(expected.AllTags(), actual.AllTags(), approxAngles)
 	return diffs
 }

--- a/src/diagonal.works/b6/world_test.go
+++ b/src/diagonal.works/b6/world_test.go
@@ -37,7 +37,7 @@ func TestTagToAndFromStringHappyPath(t *testing.T) {
 			t.Errorf("Expected %s, found %s", c.s, s)
 		}
 		var tag Tag
-		tag.FromString(c.s, ValueTypeString)
+		tag.FromString(c.s)
 		if tag.Key != c.tag.Key {
 			t.Errorf("Expected key %s, found %s", c.tag.Key, tag.Key)
 		}
@@ -58,7 +58,7 @@ func TestTagToAndFromStringBrokenStrings(t *testing.T) {
 	}
 	for _, c := range cases {
 		var tag Tag
-		tag.FromString(c.s, ValueTypeString)
+		tag.FromString(c.s)
 		if tag.Key != c.tag.Key {
 			t.Errorf("Expected key %s, found %s", c.tag.Key, tag.Key)
 		}


### PR DESCRIPTION
We currently use tags with string values in configuration files for, eg, the basemap rendering rules. Support the old way of serialising them to YAML (as, eg, #highway=pedestrian), while also supporting the serialisation of more complex tag values via the existing YAML serialisation code for literals in expressions (which are the same thing - so b6.Literal and b6.Value should merge).