### PR TITLE
Correct map rendering rules loaded from YAML

### DIFF
--- a/src/diagonal.works/b6/cmd/b6/js/b6.js
+++ b/src/diagonal.works/b6/cmd/b6/js/b6.js
@@ -1685,16 +1685,6 @@ class UI {
     handleMapClick(event) {
         const position = d3.pointer(event.originalEvent, d3.select('html'));
         if (event.originalEvent.shiftKey) {
-            showFeatureAtPixel(
-                event.pixel,
-                false,
-                position,
-                this.map,
-                this,
-                EventTypeMapFeatureClick,
-            );
-            event.stopPropagation();
-        } else {
             const ll = lonLatToLiteral(
                 toLonLat(this.map.getCoordinateFromPixel(event.pixel)),
             );
@@ -1705,8 +1695,17 @@ class UI {
                 position,
                 EventTypeMapLatLngClick,
             );
-            event.stopPropagation();
+        } else {
+            showFeatureAtPixel(
+                event.pixel,
+                false,
+                position,
+                this.map,
+                this,
+                EventTypeMapFeatureClick,
+            );
         }
+        event.stopPropagation();
     }
 
     // Start dragging root. If the mouse button is raised without the

--- a/src/diagonal.works/b6/ingest/compact/encoding.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding.go
@@ -577,6 +577,14 @@ func (m MarshalledTags) Get(key string) b6.Tag {
 	return b6.InvalidTag()
 }
 
+func (m MarshalledTags) GetString(key string) string {
+	tag := m.Get(key)
+	if s, ok := tag.Value.(b6.String); ok {
+		return string(s)
+	}
+	return ""
+}
+
 func (m MarshalledTags) Length() int {
 	l, i := binary.Uvarint(m.Tags)
 	return i + int(l)

--- a/src/diagonal.works/b6/ingest/compact/world.go
+++ b/src/diagonal.works/b6/ingest/compact/world.go
@@ -288,6 +288,10 @@ func (m *marshalledPath) Get(key string) b6.Tag {
 	return m.path.Tags(m.fb.Strings).Get(key)
 }
 
+func (m *marshalledPath) GetString(key string) string {
+	return m.path.Tags(m.fb.Strings).GetString(key)
+}
+
 func (m *marshalledPath) Len() int {
 	return m.path.Len()
 }
@@ -429,6 +433,10 @@ func (m *marshalledArea) Get(key string) b6.Tag {
 	return m.area.Tags(m.fb.Strings).Get(key)
 }
 
+func (m *marshalledArea) GetString(key string) string {
+	return m.area.Tags(m.fb.Strings).GetString(key)
+}
+
 func (m *marshalledArea) Len() int {
 	return m.area.Len()
 }
@@ -542,6 +550,10 @@ func (m *marshalledRelation) AllTags() []b6.Tag {
 
 func (m *marshalledRelation) Get(key string) b6.Tag {
 	return m.relation.Tags(m.fb.Strings).Get(key)
+}
+
+func (m *marshalledRelation) GetString(key string) string {
+	return m.relation.Tags(m.fb.Strings).GetString(key)
 }
 
 func (m *marshalledRelation) Len() int {

--- a/src/diagonal.works/b6/merged_test.go
+++ b/src/diagonal.works/b6/merged_test.go
@@ -20,6 +20,10 @@ func (t testFeature) Get(string) Tag {
 	return Tag{}
 }
 
+func (t testFeature) GetString(string) string {
+	return ""
+}
+
 func TestMergedFeatures(t *testing.T) {
 	a := []Feature{
 		testFeature(FeatureID{FeatureTypePoint, NamespaceOSMNode, 1447052072}),

--- a/src/diagonal.works/b6/renderer/renderer.go
+++ b/src/diagonal.works/b6/renderer/renderer.go
@@ -116,7 +116,7 @@ func (r *RenderRule) ToQuery(zoom uint) (b6.Query, bool) {
 	if (r.MinZoom > 0 && zoom < r.MinZoom) || (r.MaxZoom > 0 && zoom > r.MaxZoom) {
 		return nil, false
 	}
-	if r.Tag.Value != nil {
+	if r.Tag.StringValue() != "" {
 		return b6.Tagged(r.Tag), true
 	} else {
 		return b6.Keyed{Key: r.Tag.Key}, true
@@ -138,7 +138,7 @@ func (rs RenderRules) ToQuery(zoom uint) b6.Query {
 func (rs RenderRules) IsRendered(tag b6.Tag) bool {
 	for _, r := range rs {
 		if r.Tag.Key == tag.Key {
-			if r.Tag.Value == nil || r.Tag.Value == tag.Value {
+			if r.Tag.StringValue() == "" || r.Tag.StringValue() == tag.StringValue() {
 				return true
 			}
 		}
@@ -211,7 +211,7 @@ func (b *BasemapRenderer) findFeatures(root b6.FeatureID, tile b6.Tile) []b6.Fea
 func (b *BasemapRenderer) renderFeature(f b6.Feature, layers *BasemapLayers, fs []*Feature) []*Feature {
 	var tags [1]b6.Tag
 	for _, rule := range b.RenderRules {
-		if t := f.Get(rule.Tag.Key); t.IsValid() && rule.Tag.Value == nil || t.Value == rule.Tag.Value {
+		if t := f.Get(rule.Tag.Key); t.IsValid() && (rule.Tag.StringValue() == "" || t.StringValue() == rule.Tag.StringValue()) {
 			tags[0] = b6.Tag{Key: rule.Tag.Key[1:], Value: t.Value}
 			fs = FillFeaturesFromFeature(f, tags[0:], fs, &rule)
 			layers[rule.Layer].AddFeatures(fs)

--- a/src/diagonal.works/b6/ui/lines.go
+++ b/src/diagonal.works/b6/ui/lines.go
@@ -451,23 +451,3 @@ func fillSubstacksFromFeature(substacks []*pb.SubstackProto, f b6.Feature, w b6.
 	}
 	return substacks
 }
-
-func fillSubstackFromActions(substack *pb.SubstackProto) {
-	e := b6.NewCallExpression(
-		b6.NewSymbolExpression("sightline"),
-		[]b6.Expression{
-			b6.NewIntExpression(200),
-		},
-	)
-	if p, err := e.ToProto(); err == nil {
-		substack.Lines = append(substack.Lines, &pb.LineProto{
-			Line: &pb.LineProto_Action{
-				Action: &pb.ActionLineProto{
-					Atom:            AtomFromString("Sightline"),
-					ClickExpression: p,
-					InContext:       true,
-				},
-			},
-		})
-	}
-}

--- a/src/diagonal.works/b6/ui/ui.go
+++ b/src/diagonal.works/b6/ui/ui.go
@@ -657,7 +657,6 @@ func (o *OpenSourceUI) fillResponseFromResult(response *UIResponseJSON, result i
 			fillSubstackFromAtom(&substack1, atom)
 			p.Stack.Substacks = append(p.Stack.Substacks, &substack1)
 			var substack2 pb.SubstackProto
-			fillSubstackFromActions(&substack2)
 			p.Stack.Substacks = append(p.Stack.Substacks, &substack2)
 			response.AddGeoJSON(r.ToGeoJSON())
 		} else {

--- a/src/diagonal.works/b6/world.go
+++ b/src/diagonal.works/b6/world.go
@@ -57,6 +57,15 @@ func (t Tag) IsValid() bool {
 	return t.Key != ""
 }
 
+func (t Tag) StringValue() string {
+	if t.Value != nil {
+		if s, ok := t.Value.(String); ok {
+			return string(s)
+		}
+	}
+	return ""
+}
+
 func (t Tag) String() string {
 	return escapeTagPart(t.Key) + "=" + escapeTagPart(t.Value.String())
 }
@@ -76,6 +85,8 @@ type tagYAML struct {
 func (t Tag) MarshalYAML() (interface{}, error) {
 	if s, ok := t.Value.(String); ok {
 		return escapeTagPart(t.Key) + "=" + escapeTagPart(s.String()), nil
+	} else if t.Value == nil {
+		return escapeTagPart(t.Key) + "=\"\"", nil
 	}
 	// TODO: harmonise Value and Literal in expression.go
 	literal, err := FromLiteral(t.Value)
@@ -183,6 +194,7 @@ func InvalidTag() Tag {
 type Taggable interface {
 	AllTags() []Tag
 	Get(key string) Tag
+	GetString(key string) string
 }
 
 type Tags []Tag
@@ -198,6 +210,15 @@ func (t Tags) Get(key string) Tag {
 		}
 	}
 	return InvalidTag()
+}
+
+func (t Tags) GetString(key string) string {
+	for _, tag := range t {
+		if tag.Key == key {
+			return tag.StringValue()
+		}
+	}
+	return ""
 }
 
 func (t Tags) TagOrFallback(key string, fallback string) Tag {


### PR DESCRIPTION
Correct map rendering rules loaded from YAML, since default rules could either be nil, or the empty string. Add a convenience accessor for string values in passing, since b6.String can't easily be compared for equality, since it's an interface.
In passing, swap click/shift click in the UI to match baseline.