### PR TITLE
FindAreasByPoint should check all feature blocks.

### DIFF
--- a/src/diagonal.works/b6/ingest/compact/world.go
+++ b/src/diagonal.works/b6/ingest/compact/world.go
@@ -512,8 +512,7 @@ func (m *marshalledArea) Location() s2.LatLng {
 }
 
 func (f *FeaturesByID) newArea(fb *featureBlock, id uint64) b6.AreaFeature {
-	b := fb.Map.FindFirstWithTag(id, encoding.NoTag)
-	if b != nil {
+	if b := fb.Map.FindFirstWithTag(id, encoding.NoTag); len(b) > 0 {
 		return f.newAreaFromBuffer(fb, id, b)
 	}
 	return nil
@@ -740,20 +739,23 @@ func (f *FeaturesByID) FindAreasByPoint(id b6.FeatureID) b6.AreaFeatures {
 			for _, path := range paths {
 				for _, pm := range f.features[b6.FeatureTypePath] {
 					if pm.Namespaces[b6.FeatureTypePath] == path.Namespace {
-						b := pm.Map.FindFirstWithTag(path.Value, encoding.NoTag)
-						p.Unmarshal(&pm.Namespaces, b)
-						for _, area := range p.Areas {
-							areas[area] = struct{}{}
+						if b := pm.Map.FindFirstWithTag(path.Value, encoding.NoTag); len(b) > 0 {
+							p.Unmarshal(&pm.Namespaces, b)
+							for _, area := range p.Areas {
+								areas[area] = struct{}{}
+							}
+							break
 						}
-						break
 					}
 				}
 			}
 			for area := range areas {
 				for _, am := range f.features[b6.FeatureTypeArea] {
 					if am.Namespaces[b6.FeatureTypeArea] == area.Namespace {
-						features = append(features, f.newArea(am, area.Value))
-						break
+						if a := f.newArea(am, area.Value); a != nil {
+							features = append(features, a)
+							break
+						}
 					}
 				}
 			}

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -2,6 +2,7 @@ package compact
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"diagonal.works/b6"
@@ -97,6 +98,80 @@ func TestPathSegmentsWithSameNamespaceInMultipleBlocks(t *testing.T) {
 				t.Errorf("Expected to find way %d", w.ID)
 			}
 		}
+	}
+}
+
+func TestAreasForPointWithSameNamespaceInMultipleBlocks(t *testing.T) {
+	londonNodes := []osm.Node{
+		{
+			ID:       4270651271,
+			Location: osm.LatLng{Lat: 51.5354065, Lng: -0.1243874},
+		},
+		{
+			ID:       1715968760,
+			Location: osm.LatLng{Lat: 51.5353655, Lng: -0.1244049},
+		},
+		{
+			ID:       2309943806,
+			Location: osm.LatLng{Lat: 51.5352053, Lng: -0.1245396},
+		},
+	}
+
+	londonWays := []osm.Way{
+		{
+			ID:    427900370,
+			Nodes: []osm.NodeID{4270651271, 1715968760, 2309943806, 4270651271},
+			Tags:  []osm.Tag{{Key: "building", Value: "yes"}, {Key: "name", Value: "The Lighterman"}},
+		},
+	}
+
+	manchesterNodes := []osm.Node{
+		{
+			ID:       1492899494,
+			Location: osm.LatLng{Lat: 53.4792602, Lng: -2.2316735},
+		},
+		{
+			ID:       1492899361,
+			Location: osm.LatLng{Lat: 53.4788548, Lng: -2.2312303},
+		},
+		{
+			ID:       1492899446,
+			Location: osm.LatLng{Lat: 53.4791165, Lng: -2.2305658},
+		},
+	}
+
+	manchesterWays := []osm.Way{
+		{
+			ID:    136038212,
+			Nodes: []osm.NodeID{1492899494, 1492899361, 1492899446, 1492899494},
+			Tags:  []osm.Tag{{Key: "building", Value: "yes"}, {Key: "name", Value: "Ducie Street Warehouse"}},
+		},
+	}
+
+	w := NewWorld()
+	if err := mergeOSM(londonNodes, londonWays, []osm.Relation{}, nil, w, &ingest.BuildOptions{Cores: 2}); err != nil {
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+	if err := mergeOSM(manchesterNodes, manchesterWays, []osm.Relation{}, nil, w, &ingest.BuildOptions{Cores: 2}); err != nil {
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+
+	areas := w.FindAreasByPoint(ingest.FromOSMNodeID(londonNodes[0].ID))
+	ids := make([]b6.FeatureID, 0)
+	for areas.Next() {
+		ids = append(ids, areas.FeatureID())
+	}
+	if !slices.Equal(ids, []b6.FeatureID{ingest.AreaIDFromOSMWayID(londonWays[0].ID).FeatureID()}) {
+		t.Errorf("Expected to find London area")
+	}
+
+	areas = w.FindAreasByPoint(ingest.FromOSMNodeID(manchesterNodes[0].ID))
+	ids = ids[0:0]
+	for areas.Next() {
+		ids = append(ids, areas.FeatureID())
+	}
+	if !slices.Equal(ids, []b6.FeatureID{ingest.AreaIDFromOSMWayID(manchesterWays[0].ID).FeatureID()}) {
+		t.Errorf("Expected to find Manchester area")
 	}
 }
 


### PR DESCRIPTION
FindAreasByPoint should check all feature blocks, as a single namespace can be split across multiple blocks, for example, when OSM data for multiple areas is loaded from separate index files.