### PR TITLE
Correctly infer value type

### DIFF
--- a/src/diagonal.works/b6/ingest/compact/build.go
+++ b/src/diagonal.works/b6/ingest/compact/build.go
@@ -196,7 +196,7 @@ func emitPoints(source ingest.FeatureSource, o *Options, s *encoding.StringTable
 					end--
 				}
 				// Note that ways that reference a path may be dropped from the index at a
-				// later stage (becuause, for example, they're missing points), so we need
+				// later stage (because, for example, they're missing points), so we need
 				// to handle this at query time.
 				for i := 0; i < end; i++ {
 					if id := feature.Reference(i).Source(); id.IsValid() {

--- a/src/diagonal.works/b6/ingest/compact/world_test.go
+++ b/src/diagonal.works/b6/ingest/compact/world_test.go
@@ -41,6 +41,46 @@ func TestValidateWorld(t *testing.T) {
 	ingest.ValidateWorld("Compact", build, t)
 }
 
+func TestPointPathValueTypesCorrectlyInferred(t *testing.T) {
+	nodes := []osm.Node{
+		{
+			ID:       9663680708,
+			Location: osm.LatLng{Lat: 58.2859244, Lng: -6.7920486},
+			Tags:     []osm.Tag{},
+		},
+		{
+			ID:       9663680707,
+			Location: osm.LatLng{Lat: 58.2856653, Lng: -6.7915911},
+			Tags:     []osm.Tag{},
+		},
+	}
+
+	ways := [1][]osm.Way{
+		{
+			osm.Way{
+				ID:    1051579980,
+				Nodes: []osm.NodeID{9663680708, 9663680707},
+				Tags:  []osm.Tag{{Key: "highway", Value: "path"}},
+			},
+		},
+	}
+
+	w := NewWorld()
+	if err := mergeOSM(nodes, ways[0], []osm.Relation{}, nil, w, &ingest.BuildOptions{Cores: 2}); err != nil {
+		t.Fatalf("Expected no error, found: %s", err)
+	}
+
+	point := w.FindFeatureByID(ingest.FromOSMNodeID(9663680708))
+	if point == nil {
+		t.Fatalf("Expected to find point feature")
+	}
+
+	tags := point.AllTags()
+	if len(tags) != 1 {
+		t.Fatalf("Expected one tag got %d", len(tags))
+	}
+}
+
 func TestPathSegmentsWithSameNamespaceInMultipleBlocks(t *testing.T) {
 	nodes := []osm.Node{
 		{


### PR DESCRIPTION
Check read value and type are not zero when attempting to extract a uint64 from the buffer which happens when a read error occurs, and if so backtrack to reading a uint32