### PR TITLE
Adapt gdal import for generic features.

### DIFF
--- a/src/diagonal.works/b6/ingest/gdal/source.go
+++ b/src/diagonal.works/b6/ingest/gdal/source.go
@@ -219,7 +219,9 @@ func (b *batchTransformer) Flush(ctx context.Context) error {
 			}
 			f := newFeatureFromS2Region(region)
 			f.SetFeatureID(b.b6IDs[i])
-			f.SetTags(b.tags[i])
+			for _, tag := range b.tags[i] {
+				f.AddTag(tag)
+			}
 			for _, tag := range b.AddTags {
 				f.AddTag(tag)
 			}


### PR DESCRIPTION
Adapt gdal import for generic features - don't replace all the tags, as there are now point and path tags added on feature creation.