### PR TITLE
Allow functions to access the Expression that called them.

### DIFF
--- a/src/diagonal.works/b6/api/collections.go
+++ b/src/diagonal.works/b6/api/collections.go
@@ -20,10 +20,12 @@ func (h *HistogramCollection) Begin() b6.Iterator[any, any] {
 	return &HistogramCollection{UntypedCollection: h.UntypedCollection, i: h.UntypedCollection.BeginUntyped()}
 }
 
-func (h *HistogramCollection) Next() (bool, error) { return h.i.Next() }
-func (h *HistogramCollection) Key() interface{}    { return h.i.Key() }
-func (h *HistogramCollection) Value() interface{}  { return h.i.Value() }
-func (h *HistogramCollection) Count() (int, bool)  { return h.UntypedCollection.Count() }
+func (h *HistogramCollection) Next() (bool, error)            { return h.i.Next() }
+func (h *HistogramCollection) KeyExpression() b6.Expression   { return h.i.KeyExpression() }
+func (h *HistogramCollection) ValueExpression() b6.Expression { return h.i.ValueExpression() }
+func (h *HistogramCollection) Key() interface{}               { return h.i.Key() }
+func (h *HistogramCollection) Value() interface{}             { return h.i.Value() }
+func (h *HistogramCollection) Count() (int, bool)             { return h.UntypedCollection.Count() }
 
 var _ b6.UntypedCollection = &HistogramCollection{}
 

--- a/src/diagonal.works/b6/api/functions/collections_test.go
+++ b/src/diagonal.works/b6/api/functions/collections_test.go
@@ -1,6 +1,7 @@
 package functions
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
@@ -127,7 +128,8 @@ func TestFilter(t *testing.T) {
 
 	limit := 0.5
 	f := func(_ *api.Context, v interface{}) (bool, error) { return v.(float64) > limit, nil }
-	filtered, err := filter(&api.Context{}, collection.Collection(), f)
+	c := &api.Context{Cores: 8, Context: context.Background(), VM: &api.VM{}}
+	filtered, err := filter(c, collection.Collection(), api.NewNativeFunction1(f, b6.NewSymbolExpression("x-native")))
 	if err != nil {
 		t.Fatalf("Expected no error, found: %s", err)
 	}

--- a/src/diagonal.works/b6/api/functions/features.go
+++ b/src/diagonal.works/b6/api/functions/features.go
@@ -248,6 +248,14 @@ func (p *pathPointCollection) Value() b6.Geometry {
 	return b6.GeometryFromLatLng(s2.LatLngFromPoint(p.path.PointAt(p.i - 1)))
 }
 
+func (p *pathPointCollection) KeyExpression() b6.Expression {
+	return b6.NewIntExpression(p.Key())
+}
+
+func (p *pathPointCollection) ValueExpression() b6.Expression {
+	return b6.NewPointExpressionFromLatLng(s2.LatLngFromPoint(p.Value().Point()))
+}
+
 var _ b6.AnyCollection[int, b6.Geometry] = &pathPointCollection{}
 
 type areaPointCollection struct {
@@ -314,6 +322,14 @@ func (a *areaPointCollection) Key() int {
 
 func (a *areaPointCollection) Value() b6.Geometry {
 	return b6.GeometryFromLatLng(s2.LatLngFromPoint(a.loop.Vertex(a.k - 1)))
+}
+
+func (a *areaPointCollection) KeyExpression() b6.Expression {
+	return b6.NewIntExpression(a.Key())
+}
+
+func (a *areaPointCollection) ValueExpression() b6.Expression {
+	return b6.NewPointExpressionFromLatLng(s2.LatLngFromPoint(a.Value().Point()))
 }
 
 var _ b6.AnyCollection[int, b6.Geometry] = &areaPointCollection{}

--- a/src/diagonal.works/b6/api/functions/graph.go
+++ b/src/diagonal.works/b6/api/functions/graph.go
@@ -134,6 +134,14 @@ func (o *odCollection) Next() (bool, error) {
 	return o.i <= len(o.origins), nil
 }
 
+func (o *odCollection) KeyExpression() b6.Expression {
+	return b6.NewFeatureIDExpression(o.Key())
+}
+
+func (o *odCollection) ValueExpression() b6.Expression {
+	return b6.NewFeatureIDExpression(o.Value())
+}
+
 func (o *odCollection) Flip() {
 	flipped := make(map[b6.FeatureID][]b6.FeatureID)
 	for i, origin := range o.origins {

--- a/src/diagonal.works/b6/api/functions/search.go
+++ b/src/diagonal.works/b6/api/functions/search.go
@@ -36,6 +36,19 @@ func (s *searchFeatureCollection) Next() (bool, error) {
 	return s.i.Next(), nil
 }
 
+func (s *searchFeatureCollection) KeyExpression() b6.Expression {
+	return b6.NewFeatureIDExpression(s.i.FeatureID())
+}
+
+func (s *searchFeatureCollection) ValueExpression() b6.Expression {
+	return b6.NewCallExpression(
+		b6.NewSymbolExpression("find-feature"),
+		[]b6.Expression{
+			s.KeyExpression(),
+		},
+	)
+}
+
 func (s *searchFeatureCollection) Count() (int, bool) {
 	n := 0
 	i := s.w.FindFeatures(s.query)

--- a/src/diagonal.works/b6/api/vm.go
+++ b/src/diagonal.works/b6/api/vm.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"time"
 
@@ -55,6 +56,7 @@ type Op uint8
 const (
 	OpPushValue Op = iota
 	OpStore
+	OpDiscard
 	OpLoad
 	OpJump
 	OpCallValue
@@ -68,6 +70,8 @@ func (o Op) String() string {
 		return "PushValue"
 	case OpStore:
 		return "Store"
+	case OpDiscard:
+		return "Discard"
 	case OpLoad:
 		return "Load"
 	case OpJump:
@@ -96,9 +100,9 @@ type Callable interface {
 	// Call a function using arguments passed to the method. Scratch is a temporary
 	// buffer used to avoid allocations. Execution happens in the VM specified by
 	// the context, and the stack is left unmodified.
-	CallWithArgs(context *Context, args []interface{}, scratch []reflect.Value) (interface{}, []reflect.Value, error)
+	//CallWithArgs(context *Context, args []interface{}, scratch []reflect.Value) (interface{}, []reflect.Value, error)
 	ToFunctionValue(t reflect.Type, context *Context) reflect.Value
-	Expression() (b6.Expression, bool)
+	Expression() b6.Expression
 }
 
 type Adaptors struct {
@@ -107,28 +111,23 @@ type Adaptors struct {
 }
 
 func Call0(context *Context, c Callable) (interface{}, error) {
-	var scratch [MaxArgs]reflect.Value
-	result, _, err := c.CallWithArgs(context, []interface{}{}, scratch[0:])
-	return result, err
+	return context.VM.CallWithArgs(context, c, []interface{}{})
 }
 
 func Call1(context *Context, arg0 interface{}, c Callable) (interface{}, error) {
-	var scratch [MaxArgs]reflect.Value
-	result, _, err := c.CallWithArgs(context, []interface{}{arg0}, scratch[0:])
-	return result, err
+	return context.VM.CallWithArgs(context, c, []interface{}{arg0})
 }
 
 func Call2(context *Context, arg0 interface{}, arg1 interface{}, c Callable) (interface{}, error) {
-	var scratch [MaxArgs]reflect.Value
-	result, _, err := c.CallWithArgs(context, []interface{}{arg0, arg1}, scratch[0:])
-	return result, err
+	return context.VM.CallWithArgs(context, c, []interface{}{arg0, arg1})
 }
 
 type Instruction struct {
-	Op       Op
-	Args     [2]int16
-	Value    reflect.Value
-	Callable Callable
+	Op         Op
+	Args       [2]int16
+	Value      reflect.Value
+	Callable   Callable
+	Expression b6.Expression
 }
 
 func (i Instruction) String() string {
@@ -197,7 +196,7 @@ func EvaluateAndFill(expression b6.Expression, context *Context, toFill interfac
 	}
 	v := reflect.ValueOf(toFill)
 	if v.Kind() != reflect.Ptr {
-		return fmt.Errorf("Expected a pointer, found %T", toFill)
+		return fmt.Errorf("expected a pointer, found %T", toFill)
 	}
 	r, err := vm.Execute(context)
 	if err != nil {
@@ -228,27 +227,31 @@ func newVM(expression b6.Expression, fs FunctionSymbols) (*VM, error) {
 	c := compilation{
 		Globals: fs,
 		Targets: []target{{Expression: expression, Done: func(int) {}}},
+		Instructions: []Instruction{{
+			Op:         OpPushValue,
+			Value:      reflect.ValueOf(0),
+			Expression: expression,
+		}},
 	}
 	for i := 0; i < len(c.Targets); i++ {
 		entrypoint := len(c.Instructions)
 		c.Args = c.Targets[i].Args
 		if c.Args != nil {
-			for i := len(c.Args.Symbols) - 1; i >= 0; i-- {
-				c.Append(Instruction{Op: OpStore, Args: [2]int16{int16(c.Args.Args[i])}})
-			}
+			c.Append(Instruction{Op: OpStore})
 		}
 		if err := compile(c.Targets[i].Expression, &c); err != nil {
 			return nil, err
 		}
+		c.Append(Instruction{Op: OpDiscard})
 		c.Append(Instruction{Op: OpReturn})
 		c.Targets[i].Done(entrypoint)
 	}
 	return &VM{Instructions: c.Instructions}, nil
 }
 
-func compile(expression b6.Expression, c *compilation) error {
+func compile(e b6.Expression, c *compilation) error {
 	var err error
-	switch e := expression.AnyExpression.(type) {
+	switch e.AnyExpression.(type) {
 	case *b6.CallExpression:
 		err = compileCall(e, c)
 	case *b6.SymbolExpression:
@@ -260,14 +263,15 @@ func compile(expression b6.Expression, c *compilation) error {
 			c.Append(Instruction{Op: OpPushValue, Value: reflect.ValueOf(l)})
 		}
 	case b6.AnyLiteral:
-		err = compileLiteral(b6.Literal{AnyLiteral: e}, c)
+		err = compileLiteral(e, c)
 	default:
 		err = fmt.Errorf("Don't know how to compile %T", e)
 	}
 	return err
 }
 
-func compileCall(call *b6.CallExpression, c *compilation) error {
+func compileCall(e b6.Expression, c *compilation) error {
+	call := e.AnyExpression.(*b6.CallExpression)
 	for _, a := range call.Args {
 		if err := compile(a, c); err != nil {
 			return err
@@ -275,44 +279,46 @@ func compileCall(call *b6.CallExpression, c *compilation) error {
 	}
 	var args [2]int16
 	args[ArgsNumArgs] = int16(len(call.Args))
-	// XXX TODO: use a type switch?
-	if symbol, ok := call.Function.AnyExpression.(*b6.SymbolExpression); ok {
-		if f, ok := c.Globals.Function(*symbol); ok {
-			callable := goCall{f: f, name: symbol.String(), expression: call.Function}
-			c.Append(Instruction{Op: OpCallValue, Callable: callable, Args: args})
+	switch f := call.Function.AnyExpression.(type) {
+	case *b6.SymbolExpression:
+		if ff, ok := c.Globals.Function(*f); ok {
+			callable := goCall{f: ff, expression: call.Function}
+			c.Append(Instruction{Op: OpCallValue, Callable: callable, Args: args, Expression: e})
 		} else {
-			return fmt.Errorf("Undefined symbol %q", symbol)
+			return fmt.Errorf("undefined symbol %q", *f)
 		}
-	} else if f, ok := call.Function.AnyExpression.(*b6.LambdaExpression); ok {
-		if l, err := compileLambda(f, c); err == nil {
-			c.Append(Instruction{Op: OpCallValue, Callable: l, Args: args})
+	case *b6.LambdaExpression:
+		if l, err := compileLambda(e, c); err == nil {
+			c.Append(Instruction{Op: OpCallValue, Callable: l, Args: args, Expression: e})
 		} else {
 			return err
 		}
-	} else if _, ok := call.Function.AnyExpression.(*b6.CallExpression); ok {
+	case *b6.CallExpression:
 		if err := compile(call.Function, c); err != nil {
 			return err
 		}
-		c.Append(Instruction{Op: OpCallStack, Args: [2]int16{int16(len(call.Args)), 0}})
-	} else {
-		return fmt.Errorf("Can't call %T", call.Function.AnyExpression)
+		c.Append(Instruction{Op: OpCallStack, Args: [2]int16{int16(len(call.Args)), 0}, Expression: e})
+	default:
+		return fmt.Errorf("can't call %T", call.Function.AnyExpression)
 	}
 	return nil
 }
 
-func compileSymbol(symbol *b6.SymbolExpression, c *compilation) error {
+func compileSymbol(e b6.Expression, c *compilation) error {
+	symbol := e.AnyExpression.(*b6.SymbolExpression)
 	if a, ok := c.Args.Lookup(*symbol); ok {
-		c.Append(Instruction{Op: OpLoad, Args: [2]int16{int16(a)}})
+		c.Append(Instruction{Op: OpLoad, Args: [2]int16{int16(a)}, Expression: e})
 	} else if f, ok := c.Globals.Function(*symbol); ok {
-		c.Append(Instruction{Op: OpPushValue, Value: reflect.ValueOf(&goCall{f: f, name: symbol.String()})})
+		c.Append(Instruction{Op: OpPushValue, Value: reflect.ValueOf(&goCall{f: f, expression: e}), Expression: e})
 	} else {
-		return fmt.Errorf("Undefined symbol %q", symbol)
+		return fmt.Errorf("undefined symbol %q", symbol)
 	}
 	return nil
 }
 
-func compileLambda(lambda *b6.LambdaExpression, c *compilation) (*lambdaCall, error) {
-	l := &lambdaCall{args: len(lambda.Args), expression: b6.Expression{AnyExpression: lambda}}
+func compileLambda(e b6.Expression, c *compilation) (*lambdaCall, error) {
+	lambda := e.AnyExpression.(*b6.LambdaExpression)
+	l := &lambdaCall{args: len(lambda.Args), expression: e}
 	f := &frame{Previous: c.Args}
 	for _, s := range lambda.Args {
 		if c.NumArgs > MaxArgs {
@@ -329,18 +335,24 @@ func compileLambda(lambda *b6.LambdaExpression, c *compilation) (*lambdaCall, er
 	return l, nil
 }
 
-func compileLiteral(l b6.Literal, c *compilation) error {
-	c.Append(Instruction{Op: OpPushValue, Value: reflect.ValueOf(l.Literal())})
+func compileLiteral(e b6.Expression, c *compilation) error {
+	l := e.AnyExpression.(b6.AnyLiteral)
+	c.Append(Instruction{Op: OpPushValue, Value: reflect.ValueOf(l.Literal()), Expression: e})
 	return nil
 }
 
 const MaxArgs = 32
 
+type StackFrame struct {
+	Value      reflect.Value
+	Expression b6.Expression
+}
+
 type VM struct {
 	Instructions []Instruction
 	PC           int
-	Args         [MaxArgs]reflect.Value
-	Stack        []reflect.Value
+	Args         [MaxArgs]StackFrame
+	Stack        []StackFrame
 }
 
 const (
@@ -356,7 +368,7 @@ func (v *VM) Fork(n int) []VM {
 	vms := make([]VM, n)
 	for i := range vms {
 		vms[i] = *v
-		vms[i].Stack = make([]reflect.Value, len(v.Stack))
+		vms[i].Stack = make([]StackFrame, len(v.Stack))
 		copy(vms[i].Stack, v.Stack)
 	}
 	return vms
@@ -366,7 +378,7 @@ func (v *VM) Execute(context *Context) (interface{}, error) {
 	if err := v.execute(context); err != nil {
 		return nil, err
 	}
-	result := v.Stack[len(v.Stack)-1].Interface()
+	result := v.Stack[len(v.Stack)-1].Value.Interface()
 	v.Stack = v.Stack[0 : len(v.Stack)-1]
 	return result, nil
 }
@@ -381,37 +393,143 @@ func (v *VM) execute(context *Context) error {
 		case OpJump:
 			v.PC = int(v.Instructions[v.PC].Args[ArgsJumpDestination]) - 1 // Incremented below
 		case OpPushValue:
-			v.Stack = append(v.Stack, v.Instructions[v.PC].Value)
+			v.Stack = append(v.Stack, StackFrame{
+				Value:      v.Instructions[v.PC].Value,
+				Expression: v.Instructions[v.PC].Expression,
+			})
 		case OpStore:
-			v.Args[v.Instructions[v.PC].Args[0]] = v.Stack[len(v.Stack)-1]
-			v.Stack = v.Stack[0 : len(v.Stack)-1]
+			n := int(v.Stack[len(v.Stack)-1].Value.Int())
+			argsStart := len(v.Stack) - n - 1
+			for i := 0; i < n; i++ {
+				v.Args[i] = v.Stack[argsStart+i]
+			}
+		case OpDiscard:
+			n := int(v.Stack[len(v.Stack)-2].Value.Int())
+			v.Stack[len(v.Stack)-n-2] = v.Stack[len(v.Stack)-1]
+			v.Stack = v.Stack[0 : len(v.Stack)-n-1]
 		case OpLoad:
 			v.Stack = append(v.Stack, v.Args[v.Instructions[v.PC].Args[0]])
 		case OpCallValue:
+			// Before a call, the stack contains the arguments for the
+			// function, followed by the expression representing the
+			// function call. The function is responsible for removing
+			// the arguments and expression from the stack, and leaving
+			// the result.
 			n := int(v.Instructions[v.PC].Args[ArgsNumArgs])
+			v.Stack = append(v.Stack, StackFrame{
+				Value:      reflect.ValueOf(n),
+				Expression: v.Instructions[v.PC].Expression,
+			})
 			if args, err = v.Instructions[v.PC].Callable.CallFromStack(context, n, args); err != nil {
 				return err
 			}
 		case OpCallStack:
 			n := int(v.Instructions[v.PC].Args[ArgsNumArgs])
-			f := v.Stack[len(v.Stack)-1].Interface().(Callable)
-			v.Stack = v.Stack[0 : len(v.Stack)-1]
+			f := v.Stack[len(v.Stack)-1].Value.Interface().(Callable)
+			v.Stack[len(v.Stack)-1].Value = reflect.ValueOf(n)
 			if args, err = f.CallFromStack(context, n, args); err != nil {
 				return err
 			}
 		case OpReturn:
 			done = true
 		default:
-			return fmt.Errorf("Can't execute instruction %+v", v.Instructions[v.PC])
+			return fmt.Errorf("can't execute instruction %+v", v.Instructions[v.PC])
 		}
 		v.PC++
 	}
 	return nil
 }
 
+func (v *VM) CallWithArgsAndExpressions(context *Context, c Callable, args []StackFrame) (interface{}, error) {
+	l := len(v.Stack)
+	v.Stack = append(v.Stack, args...)
+
+	var aes [MaxArgs]b6.Expression
+	for i, arg := range args {
+		aes[i] = arg.Expression
+	}
+	e := b6.NewCallExpression(c.Expression(), aes[0:len(args)])
+
+	v.Stack = append(v.Stack, StackFrame{Value: reflect.ValueOf(len(args)), Expression: e})
+	var scratch [MaxArgs]reflect.Value
+	_, err := c.CallFromStack(context, len(args), scratch[0:])
+	var result interface{}
+	if err == nil {
+		result = v.Stack[len(v.Stack)-1].Value.Interface()
+	}
+	v.Stack = v.Stack[0:l]
+	return result, err
+}
+
+func (v *VM) CallWithArgs(context *Context, c Callable, args []interface{}) (interface{}, error) {
+	var frames [MaxArgs]StackFrame
+	for i, arg := range args {
+		literal, err := b6.FromLiteral(arg)
+		if err != nil {
+			return nil, err
+		}
+		frames[i].Value = reflect.ValueOf(arg)
+		frames[i].Expression = b6.Expression{AnyExpression: literal.AnyLiteral}
+	}
+	return v.CallWithArgsAndExpressions(context, c, frames[0:len(args)])
+}
+
+func (v *VM) Expression() b6.Expression {
+	if len(v.Stack) == 0 {
+		panic("not in a call, stack empty")
+	}
+	_, ok := v.Stack[len(v.Stack)-1].Expression.AnyExpression.(*b6.CallExpression)
+	if !ok {
+		panic("not in a call")
+	}
+	return v.Stack[len(v.Stack)-1].Expression
+}
+
+func (v *VM) ArgExpressions() []b6.Expression {
+	if len(v.Stack) == 0 {
+		panic("not in a call, stack empty")
+	}
+	_, ok := v.Stack[len(v.Stack)-1].Expression.AnyExpression.(*b6.CallExpression)
+	if !ok {
+		panic("not in a call")
+	}
+	n := int(v.Stack[len(v.Stack)-1].Value.Int())
+	argsStart := len(v.Stack) - n - 1
+	args := make([]b6.Expression, n)
+	for i := range args {
+		args[i] = v.Stack[argsStart+i].Expression
+	}
+	return args
+}
+
+func (v *VM) WriteStackForDebug(w io.Writer) {
+	w.Write([]byte("stack:\n"))
+	for i := range v.Stack {
+		if s, ok := UnparseExpression(v.Stack[i].Expression); ok {
+			w.Write([]byte(fmt.Sprintf("  %d: %v %s\n", i, v.Stack[i].Value, s)))
+		} else {
+			w.Write([]byte(fmt.Sprintf("  %d: %v %T\n", i, v.Stack[i].Value, v.Stack[i].Expression.AnyExpression)))
+		}
+	}
+}
+
+func NewNativeFunction0[Returns any](f func(*Context) (Returns, error), e b6.Expression) Callable {
+	return goCall{
+		f:          reflect.ValueOf(f),
+		expression: e,
+	}
+}
+
+func NewNativeFunction1[Arg0 any, Returns any](f func(*Context, Arg0) (Returns, error), e b6.Expression) Callable {
+	return goCall{
+		f:          reflect.ValueOf(f),
+		expression: e,
+	}
+}
+
+// TODO(andrew): rename to nativeFunction
 type goCall struct {
 	f          reflect.Value
-	name       string
 	expression b6.Expression
 }
 
@@ -419,46 +537,50 @@ func (g goCall) NumArgs() int {
 	return g.f.Type().NumIn() - 1
 }
 
-func (g goCall) Expression() (b6.Expression, bool) {
-	if g.expression.AnyExpression != nil {
-		return g.expression, true
-	} else {
-		return b6.Expression{}, false
-	}
+func (g goCall) Expression() b6.Expression {
+	return g.expression
 }
 
+func (g goCall) String() string {
+	return g.expression.String()
+}
+
+// TODO: use context to store scrach arg []reflect.Value?
 func (g goCall) CallFromStack(context *Context, n int, scratch []reflect.Value) ([]reflect.Value, error) {
 	vm := context.VM
 	t := g.f.Type()
 	scratch = scratch[0:0]
 	expected := g.NumArgs()
 	if t.IsVariadic() {
-		expected-- // handle the last argument separately
+		// handle the last argument separately, as it's turned into a slice
+		expected--
 	} else if n > expected {
-		return nil, fmt.Errorf("%s: expected %d arguments, found %d", g.name, expected, n)
+		return nil, fmt.Errorf("%s: expected %d arguments, found %d", g.String(), expected, n)
 	}
+	argsStart := len(vm.Stack) - n - 1
+	expression := vm.Stack[len(vm.Stack)-1].Expression
 	if n >= expected {
 		scratch = append(scratch, reflect.ValueOf(context))
 		for i := 0; i < expected; i++ {
-			arg := len(vm.Stack) - n + i
-			if v, err := ConvertWithContext(vm.Stack[arg], t.In(i+1), context); err == nil {
+			arg := argsStart + i
+			if v, err := ConvertWithContext(vm.Stack[arg].Value, t.In(i+1), context); err == nil {
 				scratch = append(scratch, v)
 			} else {
-				return nil, fmt.Errorf("%s: %s", g.name, err.Error())
+				return nil, fmt.Errorf("%s: %s", g.String(), err.Error())
 			}
 		}
 		if t.IsVariadic() {
 			for i := expected; i < n; i++ {
-				arg := len(vm.Stack) - n + i
-				if v, err := ConvertWithContext(vm.Stack[arg], t.In(expected+1).Elem(), context); err == nil {
+				arg := argsStart + i
+				if v, err := ConvertWithContext(vm.Stack[arg].Value, t.In(expected+1).Elem(), context); err == nil {
 					scratch = append(scratch, v)
 				} else {
-					return scratch, fmt.Errorf("%s: %s", g.name, err.Error())
+					return scratch, fmt.Errorf("%s: %s", g.String(), err.Error())
 				}
 			}
 		}
 		result := g.f.Call(scratch)
-		vm.Stack = vm.Stack[0 : len(vm.Stack)-n]
+		vm.Stack = vm.Stack[0:argsStart]
 		if len(result) < 1 {
 			// Checked during init() in functions, but not guaranteed if
 			// unvalidated local functions have been registered.
@@ -466,67 +588,34 @@ func (g goCall) CallFromStack(context *Context, n int, scratch []reflect.Value) 
 		}
 		if len(result) > 1 {
 			if err, ok := result[1].Interface().(error); ok && err != nil {
-				vm.Stack = append(vm.Stack, reflect.Value{})
+				vm.Stack = append(vm.Stack, StackFrame{Value: reflect.Value{}, Expression: expression})
 				return nil, err
 			}
 		}
 		if result[0].Kind() == reflect.Func {
-			vm.Stack = append(vm.Stack, reflect.ValueOf(&goCall{f: result[0], name: "(result)"}))
+			vm.Stack = append(vm.Stack, StackFrame{
+				Value:      reflect.ValueOf(&goCall{f: result[0], expression: expression}),
+				Expression: expression,
+			})
 		} else {
-			vm.Stack = append(vm.Stack, result[0])
+			vm.Stack = append(vm.Stack, StackFrame{
+				Value:      result[0],
+				Expression: expression,
+			})
 		}
 	} else {
-		p := &partialCall{c: g, vmArgs: vm.Args}
+		p := &partialCall{c: g, e: expression, vmArgs: vm.Args}
 		p.n = n
 		for i := 0; i < n; i++ {
-			p.args[i] = vm.Stack[len(vm.Stack)-n+i]
+			p.args[i] = vm.Stack[argsStart+i]
 		}
-		vm.Stack = vm.Stack[0 : len(vm.Stack)-n]
-		vm.Stack = append(vm.Stack, reflect.ValueOf(p))
+		vm.Stack = vm.Stack[0:argsStart]
+		vm.Stack = append(vm.Stack, StackFrame{
+			Value:      reflect.ValueOf(p),
+			Expression: expression,
+		})
 	}
 	return scratch, nil
-}
-
-func (g goCall) CallWithArgs(context *Context, args []interface{}, scratch []reflect.Value) (interface{}, []reflect.Value, error) {
-	t := g.f.Type()
-	expected := g.NumArgs()
-	if t.IsVariadic() {
-		expected-- // handle the last argument separately
-	} else if len(args) > expected {
-		return nil, scratch, fmt.Errorf("%s: expected %d arguments, found %d", g.name, expected, len(args))
-	}
-	if len(args) >= expected {
-		scratch = scratch[0:0]
-		scratch = append(scratch, reflect.ValueOf(context))
-		for i := 0; i < expected; i++ {
-			if v, err := ConvertWithContext(reflect.ValueOf(args[i]), t.In(i+1), context); err == nil {
-				scratch = append(scratch, v)
-			} else {
-				return nil, scratch, fmt.Errorf("%s: %s", g.name, err.Error())
-			}
-		}
-		if t.IsVariadic() {
-			for i := expected; i < len(args); i++ {
-				if v, err := ConvertWithContext(reflect.ValueOf(args[i]), t.In(expected+1).Elem(), context); err == nil {
-					scratch = append(scratch, v)
-				} else {
-					return nil, scratch, fmt.Errorf("%s: %s", g.name, err.Error())
-				}
-			}
-		}
-		result := g.f.Call(scratch)
-		if err, ok := result[1].Interface().(error); ok && err != nil {
-			return nil, scratch, err
-		}
-		return result[0].Interface(), scratch, nil
-	} else {
-		p := &partialCall{c: g, vmArgs: context.VM.Args}
-		p.n = len(args)
-		for i, arg := range args {
-			p.args[i] = reflect.ValueOf(arg)
-		}
-		return p.ToFunction(), scratch, nil
-	}
 }
 
 func (g goCall) ToFunctionValue(t reflect.Type, context *Context) reflect.Value {
@@ -555,8 +644,8 @@ func (l *lambdaCall) NumArgs() int {
 	return l.args
 }
 
-func (l *lambdaCall) Expression() (b6.Expression, bool) {
-	return l.expression, true
+func (l *lambdaCall) Expression() b6.Expression {
+	return l.expression
 }
 
 func (l *lambdaCall) String() string {
@@ -566,37 +655,28 @@ func (l *lambdaCall) String() string {
 func (l *lambdaCall) CallFromStack(context *Context, n int, scratch []reflect.Value) ([]reflect.Value, error) {
 	var err error
 	vm := context.VM
+	argsStart := len(vm.Stack) - n - 1
+	expression := vm.Stack[len(vm.Stack)-1].Expression
 	if n >= l.args {
 		opc := vm.PC
 		vm.PC = l.pc
 		err = vm.execute(context)
 		vm.PC = opc
 	} else if n < l.args {
-		p := &partialCall{c: l, vmArgs: vm.Args}
+		p := &partialCall{c: l, e: expression, vmArgs: vm.Args}
 		p.n = n
 		for i := 0; i < n; i++ {
-			p.args[i] = vm.Stack[len(vm.Stack)-n+i]
+			p.args[i] = vm.Stack[argsStart+i]
 		}
-		vm.Stack = vm.Stack[0 : len(vm.Stack)-n]
-		vm.Stack = append(vm.Stack, reflect.ValueOf(p))
+		vm.Stack = vm.Stack[0:argsStart]
+		vm.Stack = append(vm.Stack, StackFrame{
+			Value:      reflect.ValueOf(p),
+			Expression: expression,
+		})
 	} else {
 		err = fmt.Errorf("lambda: expected at most %d args, found %d", l.args, n)
 	}
 	return scratch, err
-}
-
-func (l *lambdaCall) CallWithArgs(context *Context, args []interface{}, scratch []reflect.Value) (interface{}, []reflect.Value, error) {
-	vm := context.VM
-	for _, arg := range args {
-		vm.Stack = append(vm.Stack, reflect.ValueOf(arg))
-	}
-	scratch, err := l.CallFromStack(context, len(args), scratch)
-	var result interface{}
-	if err == nil {
-		result = vm.Stack[len(vm.Stack)-1].Interface()
-	}
-	vm.Stack = vm.Stack[0 : len(vm.Stack)-1]
-	return result, scratch, err
 }
 
 func (l *lambdaCall) ToFunctionValue(t reflect.Type, context *Context) reflect.Value {
@@ -608,9 +688,10 @@ func (l *lambdaCall) ToFunctionValue(t reflect.Type, context *Context) reflect.V
 
 type partialCall struct {
 	c      Callable
+	e      b6.Expression
 	n      int
-	args   [MaxArgs]reflect.Value
-	vmArgs [MaxArgs]reflect.Value
+	args   [MaxArgs]StackFrame
+	vmArgs [MaxArgs]StackFrame
 }
 
 func (p *partialCall) NumArgs() int {
@@ -619,47 +700,34 @@ func (p *partialCall) NumArgs() int {
 
 func (p *partialCall) CallFromStack(context *Context, n int, scratch []reflect.Value) ([]reflect.Value, error) {
 	vm := context.VM
+	argsStart := len(vm.Args) - n - 1
+	expression := vm.Stack[len(vm.Stack)-1].Expression
 	if n+p.n == p.c.NumArgs() {
+		vm.Stack = vm.Stack[0 : len(vm.Stack)-1]
 		vm.Stack = append(vm.Stack, p.args[0:p.n]...)
+		vm.Stack = append(vm.Stack, StackFrame{Value: reflect.ValueOf(n + p.n), Expression: expression})
 		oargs := vm.Args
 		vm.Args = p.vmArgs
 		scratch, err := p.c.CallFromStack(context, n+p.n, scratch)
 		vm.Args = oargs
 		return scratch, err
 	} else if n+p.n < p.c.NumArgs() {
-		pp := &partialCall{c: p, vmArgs: vm.Args}
+		es := make([]b6.Expression, 0, n)
+		pp := &partialCall{c: p, e: expression, vmArgs: vm.Args}
 		pp.n = n
 		for i := 0; i < n; i++ {
-			pp.args[i] = vm.Stack[len(vm.Stack)-n+i]
+			pp.args[i] = vm.Stack[argsStart+i]
+			es[i] = vm.Stack[argsStart+i].Expression
 		}
-		vm.Stack = vm.Stack[0 : len(vm.Stack)-n]
-		vm.Stack = append(vm.Stack, reflect.ValueOf(pp))
+		vm.Stack = vm.Stack[0:argsStart]
+		vm.Stack = append(vm.Stack, StackFrame{
+			Value:      reflect.ValueOf(pp),
+			Expression: expression,
+		})
 	} else {
 		return scratch, fmt.Errorf("(partial): expected at most %d args, found %d", p.c.NumArgs()-p.n, n)
 	}
 	return scratch, nil
-}
-
-func (p *partialCall) CallWithArgs(context *Context, args []interface{}, scratch []reflect.Value) (interface{}, []reflect.Value, error) {
-	if len(args)+p.n == p.c.NumArgs() {
-		added := make([]interface{}, len(args)+p.n)
-		for i, arg := range args {
-			added[i] = arg
-		}
-		for i := 0; i < p.n; i++ {
-			added[i+len(args)] = p.args[i].Interface()
-		}
-		return p.c.CallWithArgs(context, added, scratch)
-	} else if len(args)+p.n < p.c.NumArgs() {
-		pp := &partialCall{c: p.c, vmArgs: context.VM.Args}
-		pp.n = len(args)
-		for i, arg := range args {
-			pp.args[i] = reflect.ValueOf(arg)
-		}
-		return p.ToFunction(), scratch, nil
-	} else {
-		return nil, scratch, fmt.Errorf("(partial): expected at most %d args, found %d", p.c.NumArgs()-p.n, len(args))
-	}
 }
 
 func (p *partialCall) ToFunctionValue(t reflect.Type, context *Context) reflect.Value {
@@ -669,41 +737,6 @@ func (p *partialCall) ToFunctionValue(t reflect.Type, context *Context) reflect.
 	panic(fmt.Sprintf("Can't convert values of type %s", t)) // Checked in init()
 }
 
-func (p *partialCall) ToFunction() interface{} {
-	switch p.c.NumArgs() - p.n {
-	case 0:
-		return func(context *Context) (interface{}, error) {
-			return Call0(context, p.c)
-		}
-	case 1:
-		return func(arg0 interface{}, context *Context) (interface{}, error) {
-			return Call1(context, arg0, p.c)
-		}
-	case 2:
-		return func(arg0 interface{}, arg1 interface{}, context *Context) (interface{}, error) {
-			return Call2(context, arg0, arg1, p.c)
-		}
-	default:
-		panic(fmt.Sprintf("can't wrap partial with %d args", p.c.NumArgs()-p.n))
-	}
-}
-
-func (p *partialCall) Expression() (b6.Expression, bool) {
-	if expression, ok := p.c.Expression(); ok {
-		args := make([]b6.Expression, p.n)
-		for i := 0; i < p.n; i++ {
-			if literal, err := b6.FromLiteral(p.args[i].Interface()); err == nil {
-				args[i] = b6.Expression{AnyExpression: literal.AnyLiteral}
-			} else {
-				return b6.Expression{}, false
-			}
-		}
-		return b6.Expression{
-			AnyExpression: &b6.CallExpression{
-				Function: expression,
-				Args:     args,
-			},
-		}, true
-	}
-	return b6.Expression{}, false
+func (p *partialCall) Expression() b6.Expression {
+	return p.e
 }

--- a/src/diagonal.works/b6/expression.go
+++ b/src/diagonal.works/b6/expression.go
@@ -32,6 +32,7 @@ type AnyExpression interface {
 	FromProto(node *pb.NodeProto) error
 	Equal(other AnyExpression) bool
 	Clone() Expression
+	String() string
 }
 
 type Expression struct {
@@ -201,6 +202,9 @@ func (e Expression) Clone() Expression {
 }
 
 func (e Expression) Equal(other Expression) bool {
+	if e.AnyExpression == nil {
+		return other.AnyExpression == nil
+	}
 	return e.AnyExpression.Equal(other.AnyExpression)
 }
 
@@ -294,6 +298,8 @@ func FromLiteral(l interface{}) (Literal, error) {
 		// TODO(mari): Remove and only use Geo(metry). Needed because tag values can current be LatLng.
 		ll := PointExpression(l)
 		return Literal{AnyLiteral: &ll}, nil
+	case Area:
+		return Literal{AnyLiteral: &AreaExpression{Area: l}}, nil
 	case Geometry:
 		switch l.GeometryType() {
 		case GeometryTypePoint:
@@ -305,8 +311,6 @@ func FromLiteral(l interface{}) (Literal, error) {
 	case s2.LatLng:
 		ll := PointExpression(l)
 		return Literal{AnyLiteral: &ll}, nil
-	case Area:
-		return Literal{AnyLiteral: &AreaExpression{Area: l}}, nil
 	case geojson.GeoJSON:
 		return Literal{AnyLiteral: &GeoJSONExpression{GeoJSON: l}}, nil
 	case Route:
@@ -391,6 +395,10 @@ func (i IntExpression) Literal() interface{} {
 	return int(i)
 }
 
+func (i IntExpression) String() string {
+	return fmt.Sprintf("%d", i)
+}
+
 func (i IntExpression) Equal(other AnyExpression) bool {
 	if ii, ok := other.(*IntExpression); ok {
 		return i == *ii
@@ -429,6 +437,10 @@ func (f *FloatExpression) Clone() Expression {
 
 func (f FloatExpression) Literal() interface{} {
 	return float64(f)
+}
+
+func (f FloatExpression) String() string {
+	return fmt.Sprintf("%f", f)
 }
 
 func (f FloatExpression) Equal(other AnyExpression) bool {
@@ -478,6 +490,13 @@ func (b BoolExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (b BoolExpression) String() string {
+	if bool(b) {
+		return "true"
+	}
+	return "false"
+}
+
 type StringExpression string
 
 func (s *StringExpression) ToProto() (*pb.NodeProto, error) {
@@ -511,6 +530,10 @@ func (s StringExpression) Equal(other AnyExpression) bool {
 		return s == *ss
 	}
 	return false
+}
+
+func (s StringExpression) String() string {
+	return string(s)
 }
 
 func NewStringExpression(s string) Expression {
@@ -559,6 +582,10 @@ func (f FeatureIDExpression) Equal(other AnyExpression) bool {
 		return f == *ff
 	}
 	return false
+}
+
+func (f FeatureIDExpression) String() string {
+	return "/" + FeatureID(f).String()
 }
 
 func NewFeatureIDExpression(id FeatureID) Expression {
@@ -667,6 +694,10 @@ func (q QueryExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (q QueryExpression) String() string {
+	return q.Query.String()
+}
+
 func NewQueryExpression(query Query) Expression {
 	return Expression{AnyExpression: &QueryExpression{
 		Query: query,
@@ -726,6 +757,10 @@ func (g GeoJSONExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (g GeoJSONExpression) String() string {
+	return "x-geojson"
+}
+
 type RouteExpression Route
 
 func (r *RouteExpression) ToProto() (*pb.NodeProto, error) {
@@ -769,6 +804,10 @@ func (r *RouteExpression) Equal(other AnyExpression) bool {
 		}
 	}
 	return true
+}
+
+func (r *RouteExpression) String() string {
+	return "x-route"
 }
 
 type FeatureExpression struct {
@@ -825,6 +864,10 @@ func (f FeatureExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (f FeatureExpression) String() string {
+	return "x-feature"
+}
+
 type PointExpression s2.LatLng
 
 func (p *PointExpression) ToProto() (*pb.NodeProto, error) {
@@ -876,6 +919,10 @@ func (p PointExpression) Equal(other AnyExpression) bool {
 		return p == *pp
 	}
 	return false
+}
+
+func (p PointExpression) String() string {
+	return LatLngToString(s2.LatLng(p))
 }
 
 func NewPointExpressionFromLatLng(ll s2.LatLng) Expression {
@@ -942,6 +989,10 @@ func (p PathExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (p PathExpression) String() string {
+	return "x-path"
+}
+
 type AreaExpression struct {
 	Area Area
 }
@@ -984,6 +1035,10 @@ func (a AreaExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (a AreaExpression) String() string {
+	return "x-area"
+}
+
 type NilExpression struct{}
 
 func (_ NilExpression) ToProto() (*pb.NodeProto, error) {
@@ -1011,6 +1066,10 @@ func (n NilExpression) Literal() interface{} {
 func (n NilExpression) Equal(other AnyExpression) bool {
 	_, ok := other.(NilExpression)
 	return ok
+}
+
+func (n NilExpression) String() string {
+	return "x-nil"
 }
 
 type CollectionExpression struct {
@@ -1123,6 +1182,24 @@ func (c CollectionExpression) Equal(other AnyExpression) bool {
 		return true
 	}
 	return false
+}
+
+func (c CollectionExpression) String() string {
+	s := "{"
+	i := c.UntypedCollection.BeginUntyped()
+	for {
+		ok, err := i.Next()
+		if err != nil {
+			return "x-broken-collection"
+		} else if !ok {
+			break
+		}
+		if len(s) > 1 {
+			s += ", "
+		}
+		s += i.KeyExpression().String() + ": " + i.ValueExpression().String()
+	}
+	return s + "}"
 }
 
 func NewCollectionExpression(c UntypedCollection) Expression {
@@ -1255,6 +1332,23 @@ func (c *CallExpression) Equal(other AnyExpression) bool {
 	return false
 }
 
+func (c *CallExpression) String() string {
+	s := ""
+	if _, ok := c.Function.AnyExpression.(*CallExpression); ok {
+		s += "(" + c.Function.String() + ")"
+	} else {
+		s += c.String()
+	}
+	for _, arg := range c.Args {
+		if _, ok := arg.AnyExpression.(*CallExpression); ok {
+			s += "(" + arg.String() + ")"
+		} else {
+			s += arg.String()
+		}
+	}
+	return s
+}
+
 func NewCallExpression(function Expression, args []Expression) Expression {
 	return Expression{AnyExpression: &CallExpression{Function: function, Args: args}}
 }
@@ -1312,6 +1406,18 @@ func (l *LambdaExpression) Equal(other AnyExpression) bool {
 		return true
 	}
 	return false
+}
+
+func (l *LambdaExpression) String() string {
+	s := "{"
+	for i := range l.Args {
+		if i > 0 {
+			s += ", "
+		}
+		s += l.Args[i]
+	}
+	return " -> " + l.Expression.String() + "}"
+
 }
 
 func NewLambdaExpression(args []string, e Expression) Expression {

--- a/src/diagonal.works/b6/ingest/basic.go
+++ b/src/diagonal.works/b6/ingest/basic.go
@@ -192,6 +192,22 @@ func (c collectionFeatureIterator) Value() interface{} {
 	return c.c.Values[c.i-1]
 }
 
+func (c *collectionFeatureIterator) KeyExpression() b6.Expression {
+	if l, err := b6.FromLiteral(c.Key()); err == nil {
+		return b6.Expression{AnyExpression: l.AnyLiteral}
+	} else {
+		panic(err.Error())
+	}
+}
+
+func (c collectionFeatureIterator) ValueExpression() b6.Expression {
+	if l, err := b6.FromLiteral(c.Value()); err == nil {
+		return b6.Expression{AnyExpression: l.AnyLiteral}
+	} else {
+		panic(err.Error())
+	}
+}
+
 type expressionFeature struct {
 	*ExpressionFeature
 }

--- a/src/diagonal.works/b6/world.go
+++ b/src/diagonal.works/b6/world.go
@@ -1259,6 +1259,8 @@ func (a area) ToGeoJSON() geojson.GeoJSON {
 	return AreaToGeoJSON(a)
 }
 
+var _ Area = area{}
+
 func AreaFromS2Loop(l *s2.Loop) Area {
 	return AreaFromS2Polygon(s2.PolygonFromLoops([]*s2.Loop{l}))
 }


### PR DESCRIPTION
Allow functions to access the Expression that called them, to support persisting expressions for rerunning later.