### PR TITLE
Support rendering histograms directly from accessibility results.

### DIFF
--- a/src/diagonal.works/b6/ingest/features.go
+++ b/src/diagonal.works/b6/ingest/features.go
@@ -558,6 +558,30 @@ func (c *CollectionFeature) FindValue(key any) (any, bool) {
 	return nil, false
 }
 
+func (c *CollectionFeature) FindValues(key any, values []any) []any {
+	if c.sorted {
+		i := sort.Search(len(c.Keys), func(i int) bool {
+			greater, _ := b6.Less(c.Keys[i], key)
+			return !greater
+		})
+		for i < len(c.Keys) {
+			if equal, _ := b6.Equal(c.Keys[i], key); equal {
+				values = append(values, c.Values[i])
+			} else {
+				break
+			}
+			i++
+		}
+	} else {
+		for i := range c.Keys {
+			if equal, _ := b6.Equal(c.Keys[i], key); equal {
+				values = append(values, c.Values[i])
+			}
+		}
+	}
+	return values
+}
+
 func (c *CollectionFeature) Sort() {
 	sort.Sort(byCollectionFeatureKey(*c))
 	c.sorted = true

--- a/src/diagonal.works/b6/renderer/histogram.go
+++ b/src/diagonal.works/b6/renderer/histogram.go
@@ -27,9 +27,36 @@ func (r *HistogramRenderer) Render(tile b6.Tile, args *TileArgs) (*Tile, error) 
 	if id == b6.FeatureIDInvalid || id.Type != b6.FeatureTypeCollection {
 		return nil, fmt.Errorf("expected a collection ID for arg q, found %s", args.Q)
 	}
-
 	histogram := b6.FindCollectionByID(id.ToCollectionID(), w)
-	if histogram == nil || !b6.CanAdaptCollection[b6.FeatureID, int](histogram) {
+
+	var findBucket func(id b6.FeatureID, values []any) (int, bool)
+	if histogram != nil {
+		// TODO: Use types when collections have types
+		if b6.CanAdaptCollection[b6.FeatureID, b6.FeatureID](histogram) {
+			findBucket = func(id b6.FeatureID, values []any) (int, bool) {
+				bucket := 0
+				present := false
+				for _, v := range histogram.FindValues(id, values[0:0]) {
+					present = true
+					if id, ok := v.(b6.FeatureID); ok && id != b6.FeatureIDInvalid {
+						bucket++
+					}
+				}
+				return bucket, present
+			}
+		} else if b6.CanAdaptCollection[b6.FeatureID, int](histogram) {
+			findBucket = func(id b6.FeatureID, _ []any) (int, bool) {
+				var bucket int
+				var ok bool
+				var v any
+				if v, ok = histogram.FindValue(id); ok {
+					bucket, ok = v.(int)
+				}
+				return bucket, ok
+			}
+		}
+	}
+	if findBucket == nil {
 		return &Tile{
 			Layers: []*Layer{{Name: "histogram"}},
 		}, nil
@@ -38,20 +65,19 @@ func (r *HistogramRenderer) Render(tile b6.Tile, args *TileArgs) (*Tile, error) 
 	features := w.FindFeatures(b6.MightIntersect{Region: tile.RectBound()})
 	rendered := make([]*Feature, 0, 4)
 	tags := make([]b6.Tag, 0, 4)
+	values := make([]any, 0, 4)
 	for features.Next() {
-		if value, ok := histogram.FindValue(features.FeatureID()); ok {
-			if bucket, ok := value.(int); ok {
-				f := features.Feature()
-				tags = tags[0:0]
-				for _, rule := range r.rules {
-					if t := f.Get(rule.Tag.Key); t.IsValid() && t.Value == rule.Tag.Value {
-						tags = append(tags, b6.Tag{Key: rule.Tag.Key[1:], Value: t.Value})
-						break
-					}
+		if value, ok := findBucket(features.FeatureID(), values); ok {
+			f := features.Feature()
+			tags = tags[0:0]
+			for _, rule := range r.rules {
+				if t := f.Get(rule.Tag.Key); t.IsValid() && t.Value == rule.Tag.Value {
+					tags = append(tags, b6.Tag{Key: rule.Tag.Key[1:], Value: t.Value})
+					break
 				}
-				tags = append(tags, b6.Tag{Key: "bucket", Value: b6.String(strconv.Itoa(bucket))})
-				rendered = FillFeaturesFromFeature(features.Feature(), tags, rendered, &RenderRule{Label: true})
 			}
+			tags = append(tags, b6.Tag{Key: "bucket", Value: b6.String(strconv.Itoa(value))})
+			rendered = FillFeaturesFromFeature(features.Feature(), tags, rendered, &RenderRule{Label: true})
 		}
 	}
 	return &Tile{

--- a/src/diagonal.works/b6/ui/histogram.go
+++ b/src/diagonal.works/b6/ui/histogram.go
@@ -29,18 +29,16 @@ func addLabel(response *UIResponseJSON, f b6.Feature) {
 
 func fillResponseFromHistogramFeature(response *UIResponseJSON, c b6.CollectionFeature, w b6.World) error {
 	p := (*pb.UIResponseProto)(response.Proto)
-	labels := api.HistogramBucketLabels(c)
-	counts := api.HistogramBucketCounts(c)
+	counts, total, err := api.HistogramBucketCounts(c)
+	labels := api.HistogramBucketLabels(c, len(counts))
+	if err != nil {
+		return err
+	}
 
 	if len(labels) != len(counts) {
 		p.Stack.Substacks = fillSubstacksFromFeature(p.Stack.Substacks, c, w)
 		highlightInResponse(p, c.FeatureID())
 		return nil
-	}
-
-	total := 0
-	for _, count := range counts {
-		total += count
 	}
 
 	addLabel(response, c)

--- a/src/diagonal.works/b6/world.go
+++ b/src/diagonal.works/b6/world.go
@@ -1306,6 +1306,7 @@ type CollectionFeature interface {
 	CollectionID() CollectionID
 	IsSortedByKey() bool
 	FindValue(key any) (any, bool)
+	FindValues(key any, values []any) []any
 }
 
 type ExpressionFeature interface {


### PR DESCRIPTION
Support rendering histograms directly from accessibility results, by assuming that FeatureID, FeatureID collections represent origin/destinaion pairs, computing the buckets at render-time. This gives us more flexibility in visualisation.