### PR TITLE
Add comparison histograms and show layers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
         "design:colors": "bun src/scripts/figma/colors.ts -f b4AjeD0RMn75NF3tyuPrHx -o src/tokens/colors.json",
         "design:typography": "bun src/scripts/figma/typography.ts -f L3ZBxyipqdj4zs4zjLDoiT -o src/tokens/typography.css -r src/tokens/typography.json",
         "design:icons:transform": "svgr --config-file .svgrrc --icon 18 src/assets/icons/circle/svg -d src/assets/icons/circle && svgr --config-file .svgrrc --icon 20 src/assets/icons/solid/svg -d src/assets/icons/solid",
-        "proto:generate": "protoc --plugin=node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_out=src/types/generated ui.proto --ts_proto_opt=esModuleInterop=true -I ../proto/ "
+        "proto:generate": "protoc --plugin=node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_opt=useOptionals=all --ts_proto_out=src/types/generated ui.proto --ts_proto_opt=esModuleInterop=true -I ../proto/ "
     },
     "dependencies": {
         "@deck.gl/core": "^8.9.35",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,7 +90,7 @@ const Workspace = () => {
                 )}
             </div>
             {activeComparator && (
-                <div className="absolute top-2/3 left-1/2 -translate-x-1/2 bg-white">
+                <div className="absolute top-[60vh] left-1/2 -translate-x-1/2 bg-white">
                     <ComparatorProvider comparator={activeComparator}>
                         <Comparator />
                     </ComparatorProvider>

--- a/frontend/src/atoms/app.tsx
+++ b/frontend/src/atoms/app.tsx
@@ -31,6 +31,7 @@ export type ScenarioSpec = {
 export type Scenario = ScenarioSpec & {
     change?: Change;
     featureId?: FeatureIDProto;
+    worldCreated?: boolean;
 };
 
 export type Scenarios = Record<string, Scenario>;

--- a/frontend/src/atoms/app.tsx
+++ b/frontend/src/atoms/app.tsx
@@ -7,7 +7,7 @@ import { atomWithImmer } from 'jotai-immer';
 import { atomWithStorage } from 'jotai/utils';
 
 export type ChangeFeature = {
-    node: NodeProto;
+    id: FeatureIDProto;
     label?: LabelledIconProto;
     expression: string;
 };
@@ -30,9 +30,7 @@ export type ScenarioSpec = {
 
 export type Scenario = ScenarioSpec & {
     node?: FeatureIDProto;
-    worldCreated?: boolean;
     change?: Change;
-    submitted?: boolean;
 };
 
 export type Scenarios = Record<string, Scenario>;

--- a/frontend/src/atoms/app.tsx
+++ b/frontend/src/atoms/app.tsx
@@ -1,7 +1,7 @@
 import { Comparator } from '@/lib/context/comparator';
 import { OutlinerStore } from '@/lib/context/outliner';
 import { urlSearchParamsStorage } from '@/lib/storage';
-import { FeatureIDProto, NodeProto } from '@/types/generated/api';
+import { FeatureIDProto } from '@/types/generated/api';
 import { LabelledIconProto } from '@/types/generated/ui';
 import { atomWithImmer } from 'jotai-immer';
 import { atomWithStorage } from 'jotai/utils';
@@ -18,7 +18,7 @@ export type ChangeFunction = {
 };
 
 export type Change = {
-    analysis?: NodeProto;
+    analysis?: FeatureIDProto;
     features?: ChangeFeature[];
     changeFunction?: ChangeFunction;
 };
@@ -29,8 +29,8 @@ export type ScenarioSpec = {
 };
 
 export type Scenario = ScenarioSpec & {
-    node?: FeatureIDProto;
     change?: Change;
+    featureId?: FeatureIDProto;
 };
 
 export type Scenarios = Record<string, Scenario>;

--- a/frontend/src/atoms/location.ts
+++ b/frontend/src/atoms/location.ts
@@ -14,7 +14,6 @@ const initialViewParamsFromUrl = () => {
     const params = new URLSearchParams(window.location.search);
     const mapCenter = params.get('ll')?.split(',');
     const zoom = params.get('z');
-    console.log('mapCenter', mapCenter);
 
     const initialViewState = {
         latitude: mapCenter ? parseFloat(mapCenter[0]) : INITIAL_CENTER.lat,

--- a/frontend/src/components/Comparator.tsx
+++ b/frontend/src/components/Comparator.tsx
@@ -1,12 +1,27 @@
+import { useComparatorContext } from '@/lib/context/comparator';
 import { createTeleporter } from 'react-teleporter';
+import { HeaderAdapter } from './adapters/HeaderAdapter';
+import { Line } from './system/Line';
 
 export const LeftComparatorTeleporter = createTeleporter();
 export const RightComparatorTeleporter = createTeleporter();
 
 export function Comparator() {
+    const { analysis } = useComparatorContext();
+
+    const analysisTitle = analysis?.proto.stack?.substacks?.[0]?.lines?.map(
+        (l) => l.header
+    )[0];
     return (
         <div>
-            <div className="flex flex-row">
+            <div className="border-t border-x border-graphite-30">
+                {analysisTitle && (
+                    <Line className="border-b-0">
+                        <HeaderAdapter header={analysisTitle} />
+                    </Line>
+                )}
+            </div>
+            <div className="flex flex-row ">
                 <div className="flex-grow">
                     <LeftComparatorTeleporter.Target />
                 </div>

--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -272,6 +272,7 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
 
     return (
         <MapLibre
+            key={id}
             id={id}
             {...viewState}
             onMove={(evt) => {

--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -40,7 +40,7 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
         getVisibleMarkers,
         queryLayers,
         geoJSON,
-        scenario: { id },
+        scenario: { id, featureId, worldCreated },
         mapStyle,
         tab,
     } = useScenarioContext();
@@ -64,10 +64,17 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
         if (!map) return null;
         return queryLayers.map((ql) => {
             const histogram = ql.histogram;
+
             if (!histogram || !ql.show) return null;
             return new MVTLayer({
                 data: [
-                    `${b6Path}tiles/${ql.layer.path}/{z}/{x}/{y}.mvt?q=${ql.layer.q}`,
+                    `${b6Path}tiles/${ql.layer.path}/{z}/{x}/{y}.mvt?q=${
+                        ql.layer.q
+                    }${
+                        featureId && featureId?.value
+                            ? `&r=collection/${featureId.namespace}/${featureId.value}`
+                            : ''
+                    }`,
                 ],
                 beforeId: 'road-label',
                 id: `${ql.layer.path}+${ql.layer.q}`,
@@ -272,7 +279,7 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
 
     return (
         <MapLibre
-            key={id}
+            key={`${id}-${worldCreated ? '-world' : ''}`}
             id={id}
             {...viewState}
             onMove={(evt) => {

--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -169,7 +169,7 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
         if (!map) return null;
         const markers = getVisibleMarkers(map);
         return markers.map((marker, i) => {
-            if (marker.geometry.type !== 'Point') return null;
+            if (marker.geometry?.type !== 'Point') return null;
 
             const icon = match(marker.properties?.['-b6-icon'])
                 .with('dot', () => {

--- a/frontend/src/components/ScenarioTab.tsx
+++ b/frontend/src/components/ScenarioTab.tsx
@@ -54,7 +54,7 @@ export const ScenarioTab = ({
     });
 
     const showComparator =
-        activeComparator?.request?.scenarios.includes(id as $FixMe) ||
+        activeComparator?.request?.scenarios?.includes(id as $FixMe) ||
         activeComparator?.request?.baseline === (id as $FixMe);
 
     const Teleporter = useMemo(() => {

--- a/frontend/src/components/adapters/AtomAdapter.tsx
+++ b/frontend/src/components/adapters/AtomAdapter.tsx
@@ -1,6 +1,7 @@
 import { Line } from '@/components/system/Line';
 import { useLineContext } from '@/lib/context/line';
 import { AtomProto } from '@/types/generated/ui';
+import { isUndefined } from 'lodash';
 import { ChipAdapter } from './ChipAdapter';
 import { ConditionalAdapter } from './ConditionalAdapter';
 import { LabelledIconAdapter } from './LabelledIconAdapter';
@@ -17,13 +18,18 @@ export const AtomAdapter = ({ atom }: { atom: AtomProto }) => {
     }
 
     if (atom.chip) {
-        const lineChip = line.state.chips[atom.chip.index];
+        const chipIndex = atom.chip.index;
+        if (isUndefined(chipIndex)) {
+            console.warn(`Chip index is undefined`, { line, atom });
+            return null;
+        }
+        const lineChip = line.state.chips[chipIndex];
         if (lineChip) {
             return (
                 <ChipAdapter
                     chip={lineChip}
                     onChange={(value: number) =>
-                        line.setChipValue(lineChip.atom.index, value)
+                        line.setChipValue(lineChip.atom.index ?? 0, value)
                     }
                 />
             );

--- a/frontend/src/components/adapters/ChipAdapter.tsx
+++ b/frontend/src/components/adapters/ChipAdapter.tsx
@@ -11,10 +11,10 @@ export const ChipAdapter = ({
 }) => {
     const options = useMemo(
         () =>
-            chip.atom.labels.map((label, i) => ({
+            chip.atom.labels?.map((label, i) => ({
                 value: i.toString(),
                 label,
-            })),
+            })) ?? [],
         [chip.atom.labels]
     );
 

--- a/frontend/src/components/adapters/ChoiceAdapter.tsx
+++ b/frontend/src/components/adapters/ChoiceAdapter.tsx
@@ -1,16 +1,9 @@
 import { useOutlinerContext } from '@/lib/context/outliner';
-import { AtomProto, ChoiceProto } from '@/types/generated/ui';
+import { ChoiceLineProto } from '@/types/generated/ui';
 import { AtomAdapter } from './AtomAdapter';
 import { ChipAdapter } from './ChipAdapter';
 
-export const ChoiceAdapter = ({
-    choice,
-}: {
-    choice: {
-        chips: AtomProto[];
-        label: ChoiceProto['label'];
-    };
-}) => {
+export const ChoiceAdapter = ({ choice }: { choice: ChoiceLineProto }) => {
     const { choiceChips, setChoiceChipValue } = useOutlinerContext();
     return (
         <>

--- a/frontend/src/components/adapters/ConditionalAdapter.tsx
+++ b/frontend/src/components/adapters/ConditionalAdapter.tsx
@@ -2,26 +2,35 @@ import { Tooltip } from '@/components/system/Tooltip';
 import { useLineContext } from '@/lib/context/line';
 import { ConditionalProto } from '@/types/generated/ui';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { isUndefined } from 'lodash';
 import { AtomAdapter } from './AtomAdapter';
 
 export const ConditionalAdapter = ({ atom }: { atom: ConditionalProto }) => {
     const line = useLineContext();
 
-    const atomIndex = atom.conditions.findIndex((condition) => {
-        const check = condition.indices.map((index, i) => {
+    const atomIndex = atom.conditions?.findIndex((condition) => {
+        const check = condition.indices?.map((index, i) => {
             const chip = line.state.chips[index];
             if (!chip) return false;
-            return chip.value === condition.values[i];
+            return condition.values && chip.value === condition.values[i];
         });
+        if (!check) return false;
         return check.every(Boolean);
     });
 
-    if (atomIndex === -1)
+    if (atomIndex === -1 || isUndefined(atomIndex))
         return (
             <Tooltip content="Value not found">
                 <ExclamationTriangleIcon className="text-graphite-50" />
             </Tooltip>
         );
 
-    return <AtomAdapter atom={atom.atoms[atomIndex]} />;
+    return (
+        <>
+            {atom.atoms?.[atomIndex] && (
+                <AtomAdapter atom={atom.atoms[atomIndex]} />
+            )}
+            ;
+        </>
+    );
 };

--- a/frontend/src/components/adapters/HistogramAdapter.tsx
+++ b/frontend/src/components/adapters/HistogramAdapter.tsx
@@ -8,11 +8,16 @@ import { match } from 'ts-pattern';
 import { Histogram } from '../system/Histogram';
 
 const colorInterpolator = interpolateRgbBasis([
-    '#fff',
     colors.green[20],
     colors.cyan[50],
     colors.violet[80],
 ]);
+
+// default color range uses the colorInterpolator to define a 6 color range
+const defaultColorRange = [
+    '#fff',
+    ...Array.from({ length: 4 }, (_, i) => colorInterpolator(i / 4)),
+];
 
 type HistogramData = {
     index: number;
@@ -73,7 +78,15 @@ export const HistogramAdaptor = ({
     useEffect(() => {
         const scale = scaleOrdinal({
             domain: data.map((d) => `${d.index}`),
-            range: data.map((_, i) => colorInterpolator(i / data.length)),
+            range:
+                data.length <= defaultColorRange.length
+                    ? defaultColorRange
+                    : [
+                          '#fff',
+                          ...data.map((_, i) =>
+                              colorInterpolator(i / data.length)
+                          ),
+                      ],
         });
         setHistogramColorScale(scale);
     }, [data]);

--- a/frontend/src/components/adapters/HistogramAdapter.tsx
+++ b/frontend/src/components/adapters/HistogramAdapter.tsx
@@ -48,7 +48,7 @@ export const HistogramAdaptor = ({
                         return {
                             index: bar.index ?? 0,
                             label: bar.range?.value ?? '',
-                            count: bar.value,
+                            count: bar.value ?? 0,
                             origin: origin?.bars?.[i]?.value ?? null,
                         };
                     }) ?? []

--- a/frontend/src/components/adapters/HistogramAdapter.tsx
+++ b/frontend/src/components/adapters/HistogramAdapter.tsx
@@ -106,8 +106,6 @@ export const HistogramAdaptor = ({
         return data.find((d) => d.index.toString() === selected);
     }, [outliner.histogram?.selected, data]);
 
-    console.log('data', data);
-
     return (
         <Histogram
             type={type}

--- a/frontend/src/components/adapters/HistogramAdapter.tsx
+++ b/frontend/src/components/adapters/HistogramAdapter.tsx
@@ -20,6 +20,7 @@ const defaultColorRange = [
 ];
 
 type HistogramData = {
+    total: number;
     index: number;
     label: string;
     count: number;
@@ -51,10 +52,13 @@ export const HistogramAdaptor = ({
                 () =>
                     bars?.flatMap((bar, i) => {
                         return {
+                            total: bar.total ?? 0,
                             index: bar.index ?? 0,
                             label: bar.range?.value ?? '',
                             count: bar.value ?? 0,
-                            origin: origin?.bars?.[i]?.value ?? null,
+                            origin: origin
+                                ? origin?.bars?.[i]?.value ?? 0
+                                : null,
                         };
                     }) ?? []
             )
@@ -68,6 +72,7 @@ export const HistogramAdaptor = ({
                             /* Swatches do not have a count. Should be null but setting it to 0 
                             for now to avoid type errors. */
                             count: 0,
+                            total: 0,
                             origin: null,
                         };
                     }) ?? []
@@ -101,6 +106,8 @@ export const HistogramAdaptor = ({
         return data.find((d) => d.index.toString() === selected);
     }, [outliner.histogram?.selected, data]);
 
+    console.log('data', data);
+
     return (
         <Histogram
             type={type}
@@ -109,6 +116,7 @@ export const HistogramAdaptor = ({
             bucket={(d) => d.index.toString()}
             value={(d) => d.count}
             origin={(d) => d.origin}
+            total={(d) => d.total}
             color={(d) => (scale ? scale(`${d.index}`) : '#fff')}
             onSelect={handleSelect}
             selected={selected}

--- a/frontend/src/components/adapters/LabelledIconAdapter.tsx
+++ b/frontend/src/components/adapters/LabelledIconAdapter.tsx
@@ -13,6 +13,7 @@ export const LabelledIconAdapter = ({
         .with('area', () => <FrameIcon />)
         .with('point', () => <DotIcon />)
         .otherwise(() => {
+            if (!labelledIcon.icon) return <SquareIcon />;
             const iconComponentName = `${labelledIcon.icon
                 .charAt(0)
                 .toUpperCase()}${labelledIcon.icon.slice(1)}`;

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -30,7 +30,7 @@ export const LineAdapter = ({
         createOutlinerInScenario({
             id: JSON.stringify(clickable),
             properties: {
-                coordinates: { x: 10, y: 60 },
+                coordinates: { x: 4, y: 240 },
                 scenario: outliner.properties.scenario,
                 transient: outliner.properties.transient,
                 docked: outliner.properties.docked,
@@ -74,7 +74,7 @@ export const LineAdapter = ({
                                 )}
                             </div>
                             {line.leftRightValue.right?.atom && (
-                                <div className="flex items-center gap-1">
+                                <div className="flex items-center gap-1 text-ultramarine-50">
                                     <AtomAdapter
                                         atom={line.leftRightValue.right.atom}
                                     />

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -28,6 +28,7 @@ export const LineAdapter = ({
     const handleLineClick = () => {
         if (!clickable) return;
         createOutlinerInScenario({
+            active: true,
             id: JSON.stringify(clickable),
             properties: {
                 coordinates: { x: 4, y: 240 },

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -64,10 +64,14 @@ export const LineAdapter = ({
                     {line.leftRightValue && (
                         <div className="justify-between flex items-center w-full">
                             <div className="flex items-center gap-2 w-11/12 flex-grow-0">
-                                {line.leftRightValue.left.map(({ atom }, i) => {
-                                    if (!atom) return null;
-                                    return <AtomAdapter key={i} atom={atom} />;
-                                })}
+                                {line.leftRightValue.left?.map(
+                                    ({ atom }, i) => {
+                                        if (!atom) return null;
+                                        return (
+                                            <AtomAdapter key={i} atom={atom} />
+                                        );
+                                    }
+                                )}
                             </div>
                             {line.leftRightValue.right?.atom && (
                                 <div className="flex items-center gap-1">
@@ -100,7 +104,7 @@ export const LineAdapter = ({
 const Tags = ({ tagLine }: { tagLine: TagsLineProto }) => {
     return (
         <div className="tag w-full text-sm ">
-            {tagLine.tags.map((tag, i) => {
+            {tagLine.tags?.map((tag, i) => {
                 return (
                     <div
                         key={i}

--- a/frontend/src/components/adapters/ShellAdapter.tsx
+++ b/frontend/src/components/adapters/ShellAdapter.tsx
@@ -23,11 +23,13 @@ export const ShellAdapter = ({ shell }: { shell?: ShellLineProto }) => {
 
     const functions = useMemo(() => {
         if (!shell) return [];
-        return shell.functions.map((func) => {
-            return {
-                id: func,
-            };
-        });
+        return (
+            shell.functions?.map((func) => {
+                return {
+                    id: func,
+                };
+            }) ?? []
+        );
     }, [shell?.functions]);
 
     return <Shell functions={functions} onSubmit={handleSubmit} />;

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -17,10 +17,9 @@ export const StackAdapter = () => {
     } = useAppContext();
     const { outliner } = useOutlinerContext();
     const {
-        scenario: { change },
+        scenario: { change, worldCreated },
         addFeatureToChange,
         removeFeatureFromChange,
-        queryScenario,
     } = useScenarioContext();
     const [open, setOpen] = useState(outliner.properties.docked ? false : true);
 
@@ -64,9 +63,7 @@ export const StackAdapter = () => {
     const isInChange = change?.features?.find((f) => isEqual(f, featureNode));
     const outlierFeatureId = outliner.data.proto.stack?.id;
     const showChangeElements =
-        outlierFeatureId &&
-        !queryScenario?.isSuccess &&
-        outliner.properties.changeable;
+        outlierFeatureId && !worldCreated && outliner.properties.changeable;
 
     const labelledIcon =
         outliner.data.proto.stack?.substacks?.[1]?.lines?.flatMap((l) =>

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -50,21 +50,23 @@ export const StackAdapter = () => {
 
     if (!outliner.data) return null;
 
-    const firstSubstack = outliner.data.proto.stack?.substacks[0];
-    const otherSubstacks = outliner.data.proto.stack?.substacks.slice(1);
+    const firstSubstack = outliner.data.proto.stack?.substacks?.[0];
+    const otherSubstacks = outliner.data.proto.stack?.substacks?.slice(1);
 
-    const originFirstSubstack = originOutliner?.data?.proto.stack?.substacks[0];
+    const originFirstSubstack =
+        originOutliner?.data?.proto.stack?.substacks?.[0];
     const originOtherSubstacks =
-        originOutliner?.data?.proto.stack?.substacks.slice(1);
+        originOutliner?.data?.proto.stack?.substacks?.slice(1);
 
     const featureNode = outliner.data?.proto?.node;
 
     const isInChange = change?.features?.find((f) => isEqual(f, featureNode));
     const showChangeElements = !submitted && outliner.properties.changeable;
 
-    const labelledIcon = outliner.data.proto.stack?.substacks[1]?.lines.flatMap(
-        (l) => findAtoms(l, 'labelledIcon')
-    )?.[0]?.labelledIcon;
+    const labelledIcon =
+        outliner.data.proto.stack?.substacks?.[1]?.lines?.flatMap((l) =>
+            findAtoms(l, 'labelledIcon')
+        )?.[0]?.labelledIcon;
 
     return (
         <>

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -17,9 +17,10 @@ export const StackAdapter = () => {
     } = useAppContext();
     const { outliner } = useOutlinerContext();
     const {
-        scenario: { change, submitted },
+        scenario: { change },
         addFeatureToChange,
         removeFeatureFromChange,
+        queryScenario,
     } = useScenarioContext();
     const [open, setOpen] = useState(outliner.properties.docked ? false : true);
 
@@ -61,7 +62,11 @@ export const StackAdapter = () => {
     const featureNode = outliner.data?.proto?.node;
 
     const isInChange = change?.features?.find((f) => isEqual(f, featureNode));
-    const showChangeElements = !submitted && outliner.properties.changeable;
+    const outlierFeatureId = outliner.data.proto.stack?.id;
+    const showChangeElements =
+        outlierFeatureId &&
+        !queryScenario?.isSuccess &&
+        outliner.properties.changeable;
 
     const labelledIcon =
         outliner.data.proto.stack?.substacks?.[1]?.lines?.flatMap((l) =>
@@ -82,13 +87,13 @@ export const StackAdapter = () => {
                             if (isInChange) {
                                 removeFeatureFromChange({
                                     expression,
-                                    node,
+                                    id: outlierFeatureId,
                                     label: labelledIcon,
                                 });
                             }
                             addFeatureToChange({
                                 expression,
-                                node,
+                                id: outlierFeatureId,
                                 label: labelledIcon,
                             });
                         }}

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -58,9 +58,9 @@ export const StackAdapter = () => {
     const originOtherSubstacks =
         originOutliner?.data?.proto.stack?.substacks?.slice(1);
 
-    const featureNode = outliner.data?.proto?.node;
+    const featureId = outliner.data?.proto?.stack?.id;
 
-    const isInChange = change?.features?.find((f) => isEqual(f, featureNode));
+    const isInChange = change?.features?.find((f) => isEqual(f.id, featureId));
     const outlierFeatureId = outliner.data.proto.stack?.id;
     const showChangeElements =
         outlierFeatureId && !worldCreated && outliner.properties.changeable;

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -1,5 +1,6 @@
 import { SubstackProto } from '@/types/generated/ui';
 import { useMemo, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { Stack } from '../system/Stack';
 import { HistogramAdaptor } from './HistogramAdapter';
 import { LineAdapter } from './LineAdapter';
@@ -22,8 +23,8 @@ export const SubstackAdapter = ({
     }, [substack.lines]);
 
     const contentLines = useMemo(() => {
-        return substack.lines?.slice(header ? 1 : 0) ?? [];
-    }, [substack.lines, header]);
+        return substack.lines?.slice(header || collapsible ? 1 : 0) ?? [];
+    }, [substack.lines, header, collapsible]);
 
     const isHistogram =
         contentLines.length > 1 &&
@@ -58,13 +59,14 @@ export const SubstackAdapter = ({
     if (!substack.lines) return null;
 
     return (
-        <Stack
-            collapsible={substack.collapsable}
-            open={open}
-            onOpenChange={setOpen}
-        >
-            {header && (
-                <Stack.Trigger asChild>
+        <Stack collapsible={collapsible} open={open} onOpenChange={setOpen}>
+            {(header || collapsible) && (
+                <Stack.Trigger
+                    className={twMerge(
+                        'border-b border-graphite-30 cursor-pointer',
+                        open ? 'border-b-0' : ''
+                    )}
+                >
                     <LineAdapter
                         line={substack.lines[0]}
                         //changeable={changeable}

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -38,18 +38,18 @@ export const SubstackAdapter = ({
                     | 'histogram',
                 bars: contentLines.flatMap((l) => l.histogramBar ?? []),
                 swatches: contentLines.flatMap((l) => l.swatch ?? []),
-                origin: {
-                    bars: origin
-                        ? origin.lines
-                              ?.slice(header ? 1 : 0)
-                              ?.flatMap((l) => l.histogramBar ?? [])
-                        : [],
-                    swatches: origin
-                        ? origin.lines
-                              ?.slice(header ? 1 : 0)
-                              ?.flatMap((l) => l.swatch ?? [])
-                        : [],
-                },
+                origin: origin
+                    ? {
+                          bars:
+                              origin.lines
+                                  ?.slice(header ? 1 : 0)
+                                  ?.flatMap((l) => l.histogramBar ?? []) ?? [],
+                          swatches:
+                              origin.lines
+                                  ?.slice(header ? 1 : 0)
+                                  ?.flatMap((l) => l.swatch ?? []) ?? [],
+                      }
+                    : undefined,
             };
         }
         return null;

--- a/frontend/src/components/system/Histogram.stories.tsx
+++ b/frontend/src/components/system/Histogram.stories.tsx
@@ -5,13 +5,13 @@ import { interpolateRgbBasis } from 'd3-interpolate';
 import { Histogram as HistogramComponent } from './Histogram';
 type Story = StoryObj<typeof HistogramComponent>;
 
-const dummyData: { bucket: string; value: number }[] = [
-    { bucket: '0', value: 10 },
-    { bucket: '1', value: 50 },
-    { bucket: '2', value: 30 },
-    { bucket: '3', value: 20 },
-    { bucket: '4', value: 10 },
-    { bucket: '5', value: 8 },
+const dummyData: { bucket: string; value: number; total: number }[] = [
+    { bucket: '0', value: 10, total: 128 },
+    { bucket: '1', value: 50, total: 128 },
+    { bucket: '2', value: 30, total: 128 },
+    { bucket: '3', value: 20, total: 128 },
+    { bucket: '4', value: 10, total: 128 },
+    { bucket: '5', value: 8, total: 128 },
 ];
 
 const colorInterpolator = interpolateRgbBasis([
@@ -31,6 +31,7 @@ export const Default: Story = {
                 data={dummyData}
                 bucket={(d) => d.bucket}
                 value={(d) => d.value}
+                total={(d) => d.total}
                 color={(d) => histogramColorScale(d.bucket)}
                 label={(d) =>
                     d.bucket === '0'
@@ -49,6 +50,7 @@ export const Selectable: Story = {
                 data={dummyData}
                 bucket={(d) => d.bucket}
                 value={(d) => d.value}
+                total={(d) => d.total}
                 color={(d) => histogramColorScale(d.bucket)}
                 label={(d) =>
                     d.bucket === '0'

--- a/frontend/src/components/system/Histogram.tsx
+++ b/frontend/src/components/system/Histogram.tsx
@@ -159,14 +159,7 @@ function HistogramBar<T>({
     const originValue = origin ? origin(d) : null;
     const originBarLength = originValue ? xScale(originValue) : 0;
     const isDecreasing = originValue && lineValue && lineValue < originValue;
-    console.log({
-        d,
-        originValue,
-        lineValue,
-        isDecreasing,
-        originBarLength,
-        barLength,
-    });
+
     const textX = isDecreasing ? originBarLength : barLength;
 
     return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,22 @@
 .loader {
     width: 12px;
     height: 12px;
-    border: 2px solid theme('colors.ultramarine.50');
+    border-color: theme('colors.ultramarine.50');
+    border-width: 2px;
+    border-style: solid;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    box-sizing: border-box;
+    animation: rotation 1s linear infinite;
+}
+
+.loader-scenario {
+    width: 12px;
+    height: 12px;
+    border-color: theme('colors.rose.50');
+    border-width: 2px;
+    border-style: solid;
     border-bottom-color: transparent;
     border-radius: 50%;
     display: inline-block;

--- a/frontend/src/lib/b6.ts
+++ b/frontend/src/lib/b6.ts
@@ -1,6 +1,7 @@
 import { Event } from '@/types/events';
 import { EvaluateRequestProto } from '@/types/generated/api';
-import { UIRequestProto } from '@/types/generated/ui';
+import { ComparisonRequestProto, UIRequestProto } from '@/types/generated/ui';
+import { StartupResponse } from '@/types/startup';
 
 export type b6Route = 'startup' | 'stack';
 
@@ -29,7 +30,11 @@ const stack = async (request: UIRequestProto & { logEvent: Event }) => {
     }).then((res) => formatResponse(res));
 };
 
-const startup = async (urlParams: { z: string; ll: string; r: string }) => {
+const startup = async (urlParams: {
+    z: string;
+    ll: string;
+    r: string;
+}): Promise<StartupResponse> => {
     return fetch(`${b6Path}startup?` + new URLSearchParams(urlParams)).then(
         (res) => formatResponse(res)
     );
@@ -47,8 +52,21 @@ const evaluate = async (request: EvaluateRequestProto) => {
     });
 };
 
+const compare = async (request: ComparisonRequestProto) => {
+    return fetch(`${b6Path}compare`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+    }).then((res) => {
+        return formatResponse(res);
+    });
+};
+
 export const b6 = {
     stack,
     startup,
     evaluate,
+    compare,
 };

--- a/frontend/src/lib/context/app.tsx
+++ b/frontend/src/lib/context/app.tsx
@@ -1,9 +1,9 @@
 import { AppStore, Scenario, appAtom, initialAppStore } from '@/atoms/app';
 import { startupQueryAtom } from '@/atoms/startup';
 import {
-    EvaluateRequestProto,
     EvaluateResponseProto,
     FeatureIDProto,
+    FeatureType,
 } from '@/types/generated/api';
 import { $FixMe } from '@/utils/defs';
 import { useQuery } from '@tanstack/react-query';
@@ -97,7 +97,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
                             {
                                 literal: {
                                     featureIDValue: {
-                                        type: 'FeatureTypeCollection',
+                                        type: 'FeatureTypeCollection' as unknown as FeatureType,
                                         namespace:
                                             'diagonal.works/skyline-demo-05-2024',
                                         value: 1,
@@ -107,7 +107,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
                         ],
                     },
                 },
-            } as unknown as EvaluateRequestProto);
+            });
         },
     });
 

--- a/frontend/src/lib/context/app.tsx
+++ b/frontend/src/lib/context/app.tsx
@@ -114,13 +114,16 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     const changes = useMemo(() => {
         const changes = changesQuery.data?.result?.literal?.collectionValue;
         if (!changes) return [];
-        return changes.values.flatMap((v, i) => {
-            if (!v.featureIDValue || !changes.keys[i].stringValue) return [];
-            return {
-                label: changes.keys[i].stringValue,
-                id: v.featureIDValue,
-            };
-        });
+        return (
+            changes.values?.flatMap((v, i) => {
+                if (!v.featureIDValue || !changes.keys?.[i].stringValue)
+                    return [];
+                return {
+                    label: changes.keys?.[i].stringValue,
+                    id: v.featureIDValue,
+                };
+            }) ?? []
+        );
     }, [changesQuery.data]);
 
     const addComparator = useCallback(
@@ -142,7 +145,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
             !c.request
                 ? false
                 : c.request.baseline === (app.tabs.left as $FixMe) &&
-                  c.request.scenarios.includes(app.tabs?.right as $FixMe)
+                  c.request.scenarios?.includes(app.tabs?.right as $FixMe)
         );
     }, [app.comparators, app.tabs]);
 

--- a/frontend/src/lib/context/comparator.tsx
+++ b/frontend/src/lib/context/comparator.tsx
@@ -111,7 +111,7 @@ export const ComparatorProvider = ({
     useEffect(() => {
         if (!query.data) return;
 
-        query.data.proto.stack?.substacks[0].lines.forEach((line) => {
+        query.data.proto.stack?.substacks?.[0].lines?.forEach((line) => {
             if (line.comparison) {
                 createOutliner({
                     id: `comparison-baseline`,
@@ -130,7 +130,7 @@ export const ComparatorProvider = ({
                                 substacks: [
                                     {
                                         lines:
-                                            line.comparison.baseline?.bars.map(
+                                            line.comparison.baseline?.bars?.map(
                                                 (b) => {
                                                     return {
                                                         histogramBar: b,
@@ -145,8 +145,8 @@ export const ComparatorProvider = ({
                     },
                 });
 
-                line.comparison?.scenarios.forEach((scenario, i) => {
-                    const scenarioId = comparator.request?.scenarios[i];
+                line.comparison?.scenarios?.forEach((scenario, i) => {
+                    const scenarioId = comparator.request?.scenarios?.[i];
 
                     if (scenarioId) {
                         createOutliner({
@@ -167,7 +167,7 @@ export const ComparatorProvider = ({
                                         substacks: [
                                             {
                                                 lines:
-                                                    scenario.bars.map((b) => {
+                                                    scenario?.bars?.map((b) => {
                                                         return {
                                                             histogramBar: b,
                                                         };
@@ -180,9 +180,9 @@ export const ComparatorProvider = ({
                             },
                         });
                     }
-                });
+                }) ?? [];
             }
-        });
+        }) ?? [];
     }, [query.data]);
 
     const value = {

--- a/frontend/src/lib/context/line.tsx
+++ b/frontend/src/lib/context/line.tsx
@@ -35,11 +35,18 @@ export const LineContextProvider = ({
     const chips = useMemo(() => {
         const chipMap: LineStore['chips'] = {};
 
-        findAtoms(line, 'chip').forEach((atom) => {
+        for (const atom of findAtoms(line, 'chip')) {
             if (atom.chip) {
+                if (!atom.chip) {
+                    console.warn(`Chip is undefined`, { line, atom });
+                    continue;
+                }
+
                 if (isUndefined(atom.chip.index)) {
                     console.warn(`Chip index is undefined`, { line, atom });
+                    continue;
                 }
+
                 chipMap[atom.chip.index] = {
                     atom: {
                         labels: atom.chip.labels ?? [],
@@ -49,9 +56,9 @@ export const LineContextProvider = ({
                     value: 0,
                 };
             }
-        });
+        }
 
-        if (line.choice) {
+        if (line.choice && line.choice.chips) {
             line.choice.chips.forEach((atom, i) => {
                 if (isUndefined(atom.chip?.index)) {
                     console.warn(`Chip index is undefined`, { line, atom });

--- a/frontend/src/lib/context/outliner.tsx
+++ b/frontend/src/lib/context/outliner.tsx
@@ -277,10 +277,11 @@ export const OutlinerProvider = ({
     }, [outliner.data?.proto.highlighted]);
 
     useEffect(() => {
+        if (!map) return;
         highlightedFeatures.forEach((f) => {
-            if (!f) return;
+            if (!f || !map) return;
             const { feature, layer } = f;
-            map?.setFeatureState(
+            map.setFeatureState(
                 {
                     source: 'diagonal',
                     sourceLayer: layer,
@@ -292,22 +293,26 @@ export const OutlinerProvider = ({
             );
         });
         return () => {
-            highlightedFeatures.forEach((f) => {
-                if (!f) return;
-                const { feature, layer } = f;
-                map?.setFeatureState(
-                    {
-                        source: 'diagonal',
-                        sourceLayer: layer,
-                        id: feature.id,
-                    },
-                    {
-                        highlighted: false,
-                    }
-                );
-            });
+            try {
+                highlightedFeatures.forEach((f) => {
+                    if (!f || !map) return;
+                    const { feature, layer } = f;
+                    map.setFeatureState(
+                        {
+                            source: 'diagonal',
+                            sourceLayer: layer,
+                            id: feature.id,
+                        },
+                        {
+                            highlighted: false,
+                        }
+                    );
+                });
+            } catch (e) {
+                console.error(e);
+            }
         };
-    }, [outliner.data?.proto.highlighted]);
+    }, [outliner.data?.proto.highlighted, map]);
 
     return (
         <OutlinerContext.Provider

--- a/frontend/src/lib/context/outliner.tsx
+++ b/frontend/src/lib/context/outliner.tsx
@@ -93,10 +93,18 @@ export const OutlinerProvider = ({
     outliner: OutlinerStore;
 }) => {
     const { request } = outliner;
-    const { setApp, closeOutliner } = useAppContext();
+    const {
+        setApp,
+        closeOutliner,
+        app: { scenarios },
+    } = useAppContext();
     const viewState = useAtomValue(viewAtom);
     const { data } = useAtomValue(startupQueryAtom);
     const { [outliner.properties?.scenario || 'baseline']: map } = useMap();
+
+    const scenario = useMemo(() => {
+        return scenarios[outliner.properties?.scenario || 'baseline'];
+    }, [outliner.properties?.scenario, scenarios]);
 
     const close = useCallback(() => {
         closeOutliner(outliner.id);
@@ -111,7 +119,7 @@ export const OutlinerProvider = ({
             request?.expression,
             request?.eventType,
             request?.locked,
-            JSON.stringify(request?.node),
+            JSON.stringify(scenario?.featureId),
         ],
         queryFn: () => {
             if (!request) return Promise.reject('No request');
@@ -120,7 +128,7 @@ export const OutlinerProvider = ({
                 logEvent: request.eventType,
                 locked: request.locked,
                 node: request?.node,
-                root: request?.root,
+                root: scenario?.featureId,
                 logMapCenter: {
                     latE7: Math.round(viewState.latitude * 1e7),
                     lngE7: Math.round(viewState.longitude * 1e7),

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -348,11 +348,21 @@ export const ScenarioProvider = ({
 
     const getVisibleMarkers = useCallback(
         (map: MapRef) => {
+            console.log({ cenas: Object.values(scenarioOutliners) });
             const features = Object.values(scenarioOutliners)
+                .filter(
+                    (outliner) =>
+                        outliner.active || outliner.properties.transient
+                )
                 .flatMap((outliner) => outliner.data?.geoJSON || [])
+                .flatMap((f: $FixMe) => {
+                    if (f.type === 'FeatureCollection') return f.features;
+                    if (f.type === 'Feature') return [f];
+                    return [];
+                })
                 .flat()
                 .filter((f: $FixMe) => {
-                    f.geometry.type === 'Point' &&
+                    f.geometry?.type === 'Point' &&
                         map
                             ?.getBounds()
                             ?.contains(
@@ -360,6 +370,7 @@ export const ScenarioProvider = ({
                             );
                     return true;
                 });
+            console.log({ features });
             return features;
         },
         [scenarioOutliners]

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -348,7 +348,6 @@ export const ScenarioProvider = ({
 
     const getVisibleMarkers = useCallback(
         (map: MapRef) => {
-            console.log({ cenas: Object.values(scenarioOutliners) });
             const features = Object.values(scenarioOutliners)
                 .filter(
                     (outliner) =>
@@ -370,7 +369,6 @@ export const ScenarioProvider = ({
                             );
                     return true;
                 });
-            console.log({ features });
             return features;
         },
         [scenarioOutliners]

--- a/frontend/src/types/generated/api.ts
+++ b/frontend/src/types/generated/api.ts
@@ -69,60 +69,60 @@ export function featureTypeToJSON(object: FeatureType): string {
 }
 
 export interface TagProto {
-  key: string;
-  value: string;
+  key?: string | undefined;
+  value?: string | undefined;
 }
 
 export interface FeatureIDProto {
-  type: FeatureType;
-  namespace: string;
-  value: number;
+  type?: FeatureType | undefined;
+  namespace?: string | undefined;
+  value?: number | undefined;
 }
 
 export interface PointFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  point: PointProto | undefined;
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  point?: PointProto | undefined;
 }
 
 export interface PathFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  features: PointFeatureProto[];
-  lengthMeters: number;
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  features?: PointFeatureProto[] | undefined;
+  lengthMeters?: number | undefined;
 }
 
 export interface PathFeaturesProto {
-  paths: PathFeatureProto[];
+  paths?: PathFeatureProto[] | undefined;
 }
 
 export interface AreaFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  features: PathFeaturesProto[];
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  features?: PathFeaturesProto[] | undefined;
 }
 
 export interface RelationMemberProto {
-  id: FeatureIDProto | undefined;
-  role: string;
+  id?: FeatureIDProto | undefined;
+  role?: string | undefined;
 }
 
 export interface RelationFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  members: RelationMemberProto[];
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  members?: RelationMemberProto[] | undefined;
 }
 
 export interface CollectionFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  collection: CollectionProto | undefined;
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  collection?: CollectionProto | undefined;
 }
 
 export interface ExpressionFeatureProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
-  expression: NodeProto | undefined;
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
+  expression?: NodeProto | undefined;
 }
 
 export interface FeatureProto {
@@ -135,22 +135,22 @@ export interface FeatureProto {
 }
 
 export interface CollectionProto {
-  keys: LiteralNodeProto[];
-  values: LiteralNodeProto[];
+  keys?: LiteralNodeProto[] | undefined;
+  values?: LiteralNodeProto[] | undefined;
 }
 
 export interface PairProto {
-  first: LiteralNodeProto | undefined;
-  second: LiteralNodeProto | undefined;
+  first?: LiteralNodeProto | undefined;
+  second?: LiteralNodeProto | undefined;
 }
 
 export interface ModifiedFeaturesProto {
-  ids: FeatureIDProto[];
+  ids?: FeatureIDProto[] | undefined;
 }
 
 export interface AppliedChangeProto {
-  original: FeatureIDProto[];
-  modified: FeatureIDProto[];
+  original?: FeatureIDProto[] | undefined;
+  modified?: FeatureIDProto[] | undefined;
 }
 
 export interface NodeProto {
@@ -158,9 +158,9 @@ export interface NodeProto {
   literal?: LiteralNodeProto | undefined;
   call?: CallNodeProto | undefined;
   lambda?: LambdaNodeProto | undefined;
-  name: string;
-  begin: number;
-  end: number;
+  name?: string | undefined;
+  begin?: number | undefined;
+  end?: number | undefined;
 }
 
 export interface LiteralNodeProto {
@@ -187,32 +187,32 @@ export interface LiteralNodeProto {
 }
 
 export interface CallNodeProto {
-  function: NodeProto | undefined;
-  args: NodeProto[];
-  pipelined: boolean;
+  function?: NodeProto | undefined;
+  args?: NodeProto[] | undefined;
+  pipelined?: boolean | undefined;
 }
 
 export interface LambdaNodeProto {
-  args: string[];
-  node: NodeProto | undefined;
+  args?: string[] | undefined;
+  node?: NodeProto | undefined;
 }
 
 export interface KeyQueryProto {
-  key: string;
+  key?: string | undefined;
 }
 
 export interface KeyValueQueryProto {
-  key: string;
-  value: string;
+  key?: string | undefined;
+  value?: string | undefined;
 }
 
 export interface TypedQueryProto {
-  type: FeatureType;
-  query: QueryProto | undefined;
+  type?: FeatureType | undefined;
+  query?: QueryProto | undefined;
 }
 
 export interface QueriesProto {
-  queries: QueryProto[];
+  queries?: QueryProto[] | undefined;
 }
 
 export interface AllQueryProto {
@@ -222,12 +222,12 @@ export interface EmptyQueryProto {
 }
 
 export interface CapProto {
-  center: PointProto | undefined;
-  radiusMeters: number;
+  center?: PointProto | undefined;
+  radiusMeters?: number | undefined;
 }
 
 export interface S2CellIDsProto {
-  s2CellIDs: number[];
+  s2CellIDs?: number[] | undefined;
 }
 
 export interface QueryProto {
@@ -248,56 +248,56 @@ export interface QueryProto {
 }
 
 export interface StepProto {
-  destination: FeatureIDProto | undefined;
-  via: FeatureIDProto | undefined;
-  cost: number;
+  destination?: FeatureIDProto | undefined;
+  via?: FeatureIDProto | undefined;
+  cost?: number | undefined;
 }
 
 export interface RouteProto {
-  origin: FeatureIDProto | undefined;
-  steps: StepProto[];
+  origin?: FeatureIDProto | undefined;
+  steps?: StepProto[] | undefined;
 }
 
 export interface FindFeatureByIDRequestProto {
-  id: FeatureIDProto | undefined;
+  id?: FeatureIDProto | undefined;
 }
 
 export interface FindFeatureByIDResponseProto {
-  feature: FeatureProto | undefined;
+  feature?: FeatureProto | undefined;
 }
 
 export interface FindFeaturesRequestProto {
-  query: QueryProto | undefined;
+  query?: QueryProto | undefined;
 }
 
 export interface FindFeaturesResponseProto {
-  features: FeatureProto[];
+  features?: FeatureProto[] | undefined;
 }
 
 export interface ModifyTagsRequestProto {
-  id: FeatureIDProto | undefined;
-  tags: TagProto[];
+  id?: FeatureIDProto | undefined;
+  tags?: TagProto[] | undefined;
 }
 
 export interface ModifyTagsBatchRequestProto {
-  requests: ModifyTagsRequestProto[];
+  requests?: ModifyTagsRequestProto[] | undefined;
 }
 
 export interface ModifyTagsBatchResponseProto {
 }
 
 export interface EvaluateRequestProto {
-  request: NodeProto | undefined;
-  version: string;
-  root: FeatureIDProto | undefined;
+  request?: NodeProto | undefined;
+  version?: string | undefined;
+  root?: FeatureIDProto | undefined;
 }
 
 export interface EvaluateResponseProto {
-  result: NodeProto | undefined;
+  result?: NodeProto | undefined;
 }
 
 export interface DeleteWorldRequestProto {
-  id: FeatureIDProto | undefined;
+  id?: FeatureIDProto | undefined;
 }
 
 export interface DeleteWorldResponseProto {
@@ -307,7 +307,7 @@ export interface ListWorldsRequestProto {
 }
 
 export interface ListWorldsResponseProto {
-  ids: FeatureIDProto[];
+  ids?: FeatureIDProto[] | undefined;
 }
 
 function createBaseTagProto(): TagProto {
@@ -316,10 +316,10 @@ function createBaseTagProto(): TagProto {
 
 export const TagProto = {
   encode(message: TagProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -364,10 +364,10 @@ export const TagProto = {
 
   toJSON(message: TagProto): unknown {
     const obj: any = {};
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       obj.key = message.key;
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       obj.value = message.value;
     }
     return obj;
@@ -390,13 +390,13 @@ function createBaseFeatureIDProto(): FeatureIDProto {
 
 export const FeatureIDProto = {
   encode(message: FeatureIDProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.type !== 0) {
+    if (message.type !== undefined && message.type !== 0) {
       writer.uint32(8).int32(message.type);
     }
-    if (message.namespace !== "") {
+    if (message.namespace !== undefined && message.namespace !== "") {
       writer.uint32(18).string(message.namespace);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined && message.value !== 0) {
       writer.uint32(24).uint64(message.value);
     }
     return writer;
@@ -449,13 +449,13 @@ export const FeatureIDProto = {
 
   toJSON(message: FeatureIDProto): unknown {
     const obj: any = {};
-    if (message.type !== 0) {
+    if (message.type !== undefined && message.type !== 0) {
       obj.type = featureTypeToJSON(message.type);
     }
-    if (message.namespace !== "") {
+    if (message.namespace !== undefined && message.namespace !== "") {
       obj.namespace = message.namespace;
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined && message.value !== 0) {
       obj.value = Math.round(message.value);
     }
     return obj;
@@ -482,8 +482,10 @@ export const PointFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     if (message.point !== undefined) {
       PointProto.encode(message.point, writer.uint32(26).fork()).ldelim();
@@ -510,7 +512,7 @@ export const PointFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
@@ -573,13 +575,17 @@ export const PathFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
-    for (const v of message.features) {
-      PointFeatureProto.encode(v!, writer.uint32(26).fork()).ldelim();
+    if (message.features !== undefined && message.features.length !== 0) {
+      for (const v of message.features) {
+        PointFeatureProto.encode(v!, writer.uint32(26).fork()).ldelim();
+      }
     }
-    if (message.lengthMeters !== 0) {
+    if (message.lengthMeters !== undefined && message.lengthMeters !== 0) {
       writer.uint32(33).double(message.lengthMeters);
     }
     return writer;
@@ -604,14 +610,14 @@ export const PathFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
             break;
           }
 
-          message.features.push(PointFeatureProto.decode(reader, reader.uint32()));
+          message.features!.push(PointFeatureProto.decode(reader, reader.uint32()));
           continue;
         case 4:
           if (tag !== 33) {
@@ -651,7 +657,7 @@ export const PathFeatureProto = {
     if (message.features?.length) {
       obj.features = message.features.map((e) => PointFeatureProto.toJSON(e));
     }
-    if (message.lengthMeters !== 0) {
+    if (message.lengthMeters !== undefined && message.lengthMeters !== 0) {
       obj.lengthMeters = message.lengthMeters;
     }
     return obj;
@@ -676,8 +682,10 @@ function createBasePathFeaturesProto(): PathFeaturesProto {
 
 export const PathFeaturesProto = {
   encode(message: PathFeaturesProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.paths) {
-      PathFeatureProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.paths !== undefined && message.paths.length !== 0) {
+      for (const v of message.paths) {
+        PathFeatureProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -694,7 +702,7 @@ export const PathFeaturesProto = {
             break;
           }
 
-          message.paths.push(PathFeatureProto.decode(reader, reader.uint32()));
+          message.paths!.push(PathFeatureProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -738,11 +746,15 @@ export const AreaFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
-    for (const v of message.features) {
-      PathFeaturesProto.encode(v!, writer.uint32(26).fork()).ldelim();
+    if (message.features !== undefined && message.features.length !== 0) {
+      for (const v of message.features) {
+        PathFeaturesProto.encode(v!, writer.uint32(26).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -766,14 +778,14 @@ export const AreaFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
             break;
           }
 
-          message.features.push(PathFeaturesProto.decode(reader, reader.uint32()));
+          message.features!.push(PathFeaturesProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -829,7 +841,7 @@ export const RelationMemberProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    if (message.role !== "") {
+    if (message.role !== undefined && message.role !== "") {
       writer.uint32(26).string(message.role);
     }
     return writer;
@@ -877,7 +889,7 @@ export const RelationMemberProto = {
     if (message.id !== undefined) {
       obj.id = FeatureIDProto.toJSON(message.id);
     }
-    if (message.role !== "") {
+    if (message.role !== undefined && message.role !== "") {
       obj.role = message.role;
     }
     return obj;
@@ -903,11 +915,15 @@ export const RelationFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
-    for (const v of message.members) {
-      RelationMemberProto.encode(v!, writer.uint32(26).fork()).ldelim();
+    if (message.members !== undefined && message.members.length !== 0) {
+      for (const v of message.members) {
+        RelationMemberProto.encode(v!, writer.uint32(26).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -931,14 +947,14 @@ export const RelationFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
             break;
           }
 
-          message.members.push(RelationMemberProto.decode(reader, reader.uint32()));
+          message.members!.push(RelationMemberProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -994,8 +1010,10 @@ export const CollectionFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     if (message.collection !== undefined) {
       CollectionProto.encode(message.collection, writer.uint32(26).fork()).ldelim();
@@ -1022,7 +1040,7 @@ export const CollectionFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
@@ -1085,8 +1103,10 @@ export const ExpressionFeatureProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     if (message.expression !== undefined) {
       NodeProto.encode(message.expression, writer.uint32(26).fork()).ldelim();
@@ -1113,7 +1133,7 @@ export const ExpressionFeatureProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 26) {
@@ -1326,11 +1346,15 @@ function createBaseCollectionProto(): CollectionProto {
 
 export const CollectionProto = {
   encode(message: CollectionProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.keys) {
-      LiteralNodeProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.keys !== undefined && message.keys.length !== 0) {
+      for (const v of message.keys) {
+        LiteralNodeProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
-    for (const v of message.values) {
-      LiteralNodeProto.encode(v!, writer.uint32(34).fork()).ldelim();
+    if (message.values !== undefined && message.values.length !== 0) {
+      for (const v of message.values) {
+        LiteralNodeProto.encode(v!, writer.uint32(34).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -1347,14 +1371,14 @@ export const CollectionProto = {
             break;
           }
 
-          message.keys.push(LiteralNodeProto.decode(reader, reader.uint32()));
+          message.keys!.push(LiteralNodeProto.decode(reader, reader.uint32()));
           continue;
         case 4:
           if (tag !== 34) {
             break;
           }
 
-          message.values.push(LiteralNodeProto.decode(reader, reader.uint32()));
+          message.values!.push(LiteralNodeProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1480,8 +1504,10 @@ function createBaseModifiedFeaturesProto(): ModifiedFeaturesProto {
 
 export const ModifiedFeaturesProto = {
   encode(message: ModifiedFeaturesProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.ids) {
-      FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.ids !== undefined && message.ids.length !== 0) {
+      for (const v of message.ids) {
+        FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -1498,7 +1524,7 @@ export const ModifiedFeaturesProto = {
             break;
           }
 
-          message.ids.push(FeatureIDProto.decode(reader, reader.uint32()));
+          message.ids!.push(FeatureIDProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1537,11 +1563,15 @@ function createBaseAppliedChangeProto(): AppliedChangeProto {
 
 export const AppliedChangeProto = {
   encode(message: AppliedChangeProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.original) {
-      FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.original !== undefined && message.original.length !== 0) {
+      for (const v of message.original) {
+        FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
-    for (const v of message.modified) {
-      FeatureIDProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.modified !== undefined && message.modified.length !== 0) {
+      for (const v of message.modified) {
+        FeatureIDProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -1558,14 +1588,14 @@ export const AppliedChangeProto = {
             break;
           }
 
-          message.original.push(FeatureIDProto.decode(reader, reader.uint32()));
+          message.original!.push(FeatureIDProto.decode(reader, reader.uint32()));
           continue;
         case 2:
           if (tag !== 18) {
             break;
           }
 
-          message.modified.push(FeatureIDProto.decode(reader, reader.uint32()));
+          message.modified!.push(FeatureIDProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1627,13 +1657,13 @@ export const NodeProto = {
     if (message.lambda !== undefined) {
       LambdaNodeProto.encode(message.lambda, writer.uint32(34).fork()).ldelim();
     }
-    if (message.name !== "") {
+    if (message.name !== undefined && message.name !== "") {
       writer.uint32(42).string(message.name);
     }
-    if (message.begin !== 0) {
+    if (message.begin !== undefined && message.begin !== 0) {
       writer.uint32(48).int32(message.begin);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined && message.end !== 0) {
       writer.uint32(56).int32(message.end);
     }
     return writer;
@@ -1730,13 +1760,13 @@ export const NodeProto = {
     if (message.lambda !== undefined) {
       obj.lambda = LambdaNodeProto.toJSON(message.lambda);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined && message.name !== "") {
       obj.name = message.name;
     }
-    if (message.begin !== 0) {
+    if (message.begin !== undefined && message.begin !== 0) {
       obj.begin = Math.round(message.begin);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined && message.end !== 0) {
       obj.end = Math.round(message.end);
     }
     return obj;
@@ -2114,10 +2144,12 @@ export const CallNodeProto = {
     if (message.function !== undefined) {
       NodeProto.encode(message.function, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.args) {
-      NodeProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.args !== undefined && message.args.length !== 0) {
+      for (const v of message.args) {
+        NodeProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
-    if (message.pipelined !== false) {
+    if (message.pipelined !== undefined && message.pipelined !== false) {
       writer.uint32(24).bool(message.pipelined);
     }
     return writer;
@@ -2142,7 +2174,7 @@ export const CallNodeProto = {
             break;
           }
 
-          message.args.push(NodeProto.decode(reader, reader.uint32()));
+          message.args!.push(NodeProto.decode(reader, reader.uint32()));
           continue;
         case 3:
           if (tag !== 24) {
@@ -2176,7 +2208,7 @@ export const CallNodeProto = {
     if (message.args?.length) {
       obj.args = message.args.map((e) => NodeProto.toJSON(e));
     }
-    if (message.pipelined !== false) {
+    if (message.pipelined !== undefined && message.pipelined !== false) {
       obj.pipelined = message.pipelined;
     }
     return obj;
@@ -2202,8 +2234,10 @@ function createBaseLambdaNodeProto(): LambdaNodeProto {
 
 export const LambdaNodeProto = {
   encode(message: LambdaNodeProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.args) {
-      writer.uint32(10).string(v!);
+    if (message.args !== undefined && message.args.length !== 0) {
+      for (const v of message.args) {
+        writer.uint32(10).string(v!);
+      }
     }
     if (message.node !== undefined) {
       NodeProto.encode(message.node, writer.uint32(18).fork()).ldelim();
@@ -2223,7 +2257,7 @@ export const LambdaNodeProto = {
             break;
           }
 
-          message.args.push(reader.string());
+          message.args!.push(reader.string());
           continue;
         case 2:
           if (tag !== 18) {
@@ -2276,7 +2310,7 @@ function createBaseKeyQueryProto(): KeyQueryProto {
 
 export const KeyQueryProto = {
   encode(message: KeyQueryProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       writer.uint32(10).string(message.key);
     }
     return writer;
@@ -2311,7 +2345,7 @@ export const KeyQueryProto = {
 
   toJSON(message: KeyQueryProto): unknown {
     const obj: any = {};
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       obj.key = message.key;
     }
     return obj;
@@ -2333,10 +2367,10 @@ function createBaseKeyValueQueryProto(): KeyValueQueryProto {
 
 export const KeyValueQueryProto = {
   encode(message: KeyValueQueryProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -2381,10 +2415,10 @@ export const KeyValueQueryProto = {
 
   toJSON(message: KeyValueQueryProto): unknown {
     const obj: any = {};
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       obj.key = message.key;
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       obj.value = message.value;
     }
     return obj;
@@ -2407,7 +2441,7 @@ function createBaseTypedQueryProto(): TypedQueryProto {
 
 export const TypedQueryProto = {
   encode(message: TypedQueryProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.type !== 0) {
+    if (message.type !== undefined && message.type !== 0) {
       writer.uint32(8).int32(message.type);
     }
     if (message.query !== undefined) {
@@ -2455,7 +2489,7 @@ export const TypedQueryProto = {
 
   toJSON(message: TypedQueryProto): unknown {
     const obj: any = {};
-    if (message.type !== 0) {
+    if (message.type !== undefined && message.type !== 0) {
       obj.type = featureTypeToJSON(message.type);
     }
     if (message.query !== undefined) {
@@ -2483,8 +2517,10 @@ function createBaseQueriesProto(): QueriesProto {
 
 export const QueriesProto = {
   encode(message: QueriesProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.queries) {
-      QueryProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.queries !== undefined && message.queries.length !== 0) {
+      for (const v of message.queries) {
+        QueryProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -2501,7 +2537,7 @@ export const QueriesProto = {
             break;
           }
 
-          message.queries.push(QueryProto.decode(reader, reader.uint32()));
+          message.queries!.push(QueryProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2631,7 +2667,7 @@ export const CapProto = {
     if (message.center !== undefined) {
       PointProto.encode(message.center, writer.uint32(10).fork()).ldelim();
     }
-    if (message.radiusMeters !== 0) {
+    if (message.radiusMeters !== undefined && message.radiusMeters !== 0) {
       writer.uint32(17).double(message.radiusMeters);
     }
     return writer;
@@ -2679,7 +2715,7 @@ export const CapProto = {
     if (message.center !== undefined) {
       obj.center = PointProto.toJSON(message.center);
     }
-    if (message.radiusMeters !== 0) {
+    if (message.radiusMeters !== undefined && message.radiusMeters !== 0) {
       obj.radiusMeters = message.radiusMeters;
     }
     return obj;
@@ -2704,11 +2740,13 @@ function createBaseS2CellIDsProto(): S2CellIDsProto {
 
 export const S2CellIDsProto = {
   encode(message: S2CellIDsProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).fork();
-    for (const v of message.s2CellIDs) {
-      writer.uint64(v);
+    if (message.s2CellIDs !== undefined && message.s2CellIDs.length !== 0) {
+      writer.uint32(10).fork();
+      for (const v of message.s2CellIDs) {
+        writer.uint64(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
     return writer;
   },
 
@@ -2721,7 +2759,7 @@ export const S2CellIDsProto = {
       switch (tag >>> 3) {
         case 1:
           if (tag === 8) {
-            message.s2CellIDs.push(longToNumber(reader.uint64() as Long));
+            message.s2CellIDs!.push(longToNumber(reader.uint64() as Long));
 
             continue;
           }
@@ -2729,7 +2767,7 @@ export const S2CellIDsProto = {
           if (tag === 10) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.s2CellIDs.push(longToNumber(reader.uint64() as Long));
+              message.s2CellIDs!.push(longToNumber(reader.uint64() as Long));
             }
 
             continue;
@@ -3083,7 +3121,7 @@ export const StepProto = {
     if (message.via !== undefined) {
       FeatureIDProto.encode(message.via, writer.uint32(18).fork()).ldelim();
     }
-    if (message.cost !== 0) {
+    if (message.cost !== undefined && message.cost !== 0) {
       writer.uint32(25).double(message.cost);
     }
     return writer;
@@ -3142,7 +3180,7 @@ export const StepProto = {
     if (message.via !== undefined) {
       obj.via = FeatureIDProto.toJSON(message.via);
     }
-    if (message.cost !== 0) {
+    if (message.cost !== undefined && message.cost !== 0) {
       obj.cost = message.cost;
     }
     return obj;
@@ -3173,8 +3211,10 @@ export const RouteProto = {
     if (message.origin !== undefined) {
       FeatureIDProto.encode(message.origin, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.steps) {
-      StepProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.steps !== undefined && message.steps.length !== 0) {
+      for (const v of message.steps) {
+        StepProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3198,7 +3238,7 @@ export const RouteProto = {
             break;
           }
 
-          message.steps.push(StepProto.decode(reader, reader.uint32()));
+          message.steps!.push(StepProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3421,8 +3461,10 @@ function createBaseFindFeaturesResponseProto(): FindFeaturesResponseProto {
 
 export const FindFeaturesResponseProto = {
   encode(message: FindFeaturesResponseProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.features) {
-      FeatureProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.features !== undefined && message.features.length !== 0) {
+      for (const v of message.features) {
+        FeatureProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3439,7 +3481,7 @@ export const FindFeaturesResponseProto = {
             break;
           }
 
-          message.features.push(FeatureProto.decode(reader, reader.uint32()));
+          message.features!.push(FeatureProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3485,8 +3527,10 @@ export const ModifyTagsRequestProto = {
     if (message.id !== undefined) {
       FeatureIDProto.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.tags) {
-      TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3510,7 +3554,7 @@ export const ModifyTagsRequestProto = {
             break;
           }
 
-          message.tags.push(TagProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3556,8 +3600,10 @@ function createBaseModifyTagsBatchRequestProto(): ModifyTagsBatchRequestProto {
 
 export const ModifyTagsBatchRequestProto = {
   encode(message: ModifyTagsBatchRequestProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.requests) {
-      ModifyTagsRequestProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.requests !== undefined && message.requests.length !== 0) {
+      for (const v of message.requests) {
+        ModifyTagsRequestProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3574,7 +3620,7 @@ export const ModifyTagsBatchRequestProto = {
             break;
           }
 
-          message.requests.push(ModifyTagsRequestProto.decode(reader, reader.uint32()));
+          message.requests!.push(ModifyTagsRequestProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3663,7 +3709,7 @@ export const EvaluateRequestProto = {
     if (message.request !== undefined) {
       NodeProto.encode(message.request, writer.uint32(10).fork()).ldelim();
     }
-    if (message.version !== "") {
+    if (message.version !== undefined && message.version !== "") {
       writer.uint32(18).string(message.version);
     }
     if (message.root !== undefined) {
@@ -3722,7 +3768,7 @@ export const EvaluateRequestProto = {
     if (message.request !== undefined) {
       obj.request = NodeProto.toJSON(message.request);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined && message.version !== "") {
       obj.version = message.version;
     }
     if (message.root !== undefined) {
@@ -3955,8 +4001,10 @@ function createBaseListWorldsResponseProto(): ListWorldsResponseProto {
 
 export const ListWorldsResponseProto = {
   encode(message: ListWorldsResponseProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.ids) {
-      FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.ids !== undefined && message.ids.length !== 0) {
+      for (const v of message.ids) {
+        FeatureIDProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3973,7 +4021,7 @@ export const ListWorldsResponseProto = {
             break;
           }
 
-          message.ids.push(FeatureIDProto.decode(reader, reader.uint32()));
+          message.ids!.push(FeatureIDProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {

--- a/frontend/src/types/generated/geometry.ts
+++ b/frontend/src/types/generated/geometry.ts
@@ -4,12 +4,12 @@ import _m0 from "protobufjs/minimal";
 export const protobufPackage = "geometry";
 
 export interface PolylineProto {
-  points: PointProto[];
-  lengthMeters: number;
+  points?: PointProto[] | undefined;
+  lengthMeters?: number | undefined;
 }
 
 export interface MultiPolygonProto {
-  polygons: PolygonProto[];
+  polygons?: PolygonProto[] | undefined;
 }
 
 export interface PolygonProto {
@@ -17,16 +17,16 @@ export interface PolygonProto {
    * All loops are ordered counter-clockwise, and a point is defined to be
    * inside the polygon if it's enclosed by an odd number of loops.
    */
-  loops: LoopProto[];
+  loops?: LoopProto[] | undefined;
 }
 
 export interface LoopProto {
-  points: PointProto[];
+  points?: PointProto[] | undefined;
 }
 
 export interface PointProto {
-  latE7: number;
-  lngE7: number;
+  latE7?: number | undefined;
+  lngE7?: number | undefined;
 }
 
 function createBasePolylineProto(): PolylineProto {
@@ -35,10 +35,12 @@ function createBasePolylineProto(): PolylineProto {
 
 export const PolylineProto = {
   encode(message: PolylineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.points) {
-      PointProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.points !== undefined && message.points.length !== 0) {
+      for (const v of message.points) {
+        PointProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
-    if (message.lengthMeters !== 0) {
+    if (message.lengthMeters !== undefined && message.lengthMeters !== 0) {
       writer.uint32(17).double(message.lengthMeters);
     }
     return writer;
@@ -56,7 +58,7 @@ export const PolylineProto = {
             break;
           }
 
-          message.points.push(PointProto.decode(reader, reader.uint32()));
+          message.points!.push(PointProto.decode(reader, reader.uint32()));
           continue;
         case 2:
           if (tag !== 17) {
@@ -86,7 +88,7 @@ export const PolylineProto = {
     if (message.points?.length) {
       obj.points = message.points.map((e) => PointProto.toJSON(e));
     }
-    if (message.lengthMeters !== 0) {
+    if (message.lengthMeters !== undefined && message.lengthMeters !== 0) {
       obj.lengthMeters = message.lengthMeters;
     }
     return obj;
@@ -109,8 +111,10 @@ function createBaseMultiPolygonProto(): MultiPolygonProto {
 
 export const MultiPolygonProto = {
   encode(message: MultiPolygonProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.polygons) {
-      PolygonProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.polygons !== undefined && message.polygons.length !== 0) {
+      for (const v of message.polygons) {
+        PolygonProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -127,7 +131,7 @@ export const MultiPolygonProto = {
             break;
           }
 
-          message.polygons.push(PolygonProto.decode(reader, reader.uint32()));
+          message.polygons!.push(PolygonProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -170,8 +174,10 @@ function createBasePolygonProto(): PolygonProto {
 
 export const PolygonProto = {
   encode(message: PolygonProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.loops) {
-      LoopProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.loops !== undefined && message.loops.length !== 0) {
+      for (const v of message.loops) {
+        LoopProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -188,7 +194,7 @@ export const PolygonProto = {
             break;
           }
 
-          message.loops.push(LoopProto.decode(reader, reader.uint32()));
+          message.loops!.push(LoopProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -229,8 +235,10 @@ function createBaseLoopProto(): LoopProto {
 
 export const LoopProto = {
   encode(message: LoopProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.points) {
-      PointProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.points !== undefined && message.points.length !== 0) {
+      for (const v of message.points) {
+        PointProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -247,7 +255,7 @@ export const LoopProto = {
             break;
           }
 
-          message.points.push(PointProto.decode(reader, reader.uint32()));
+          message.points!.push(PointProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -288,10 +296,10 @@ function createBasePointProto(): PointProto {
 
 export const PointProto = {
   encode(message: PointProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.latE7 !== 0) {
+    if (message.latE7 !== undefined && message.latE7 !== 0) {
       writer.uint32(8).int32(message.latE7);
     }
-    if (message.lngE7 !== 0) {
+    if (message.lngE7 !== undefined && message.lngE7 !== 0) {
       writer.uint32(16).int32(message.lngE7);
     }
     return writer;
@@ -336,10 +344,10 @@ export const PointProto = {
 
   toJSON(message: PointProto): unknown {
     const obj: any = {};
-    if (message.latE7 !== 0) {
+    if (message.latE7 !== undefined && message.latE7 !== 0) {
       obj.latE7 = Math.round(message.latE7);
     }
-    if (message.lngE7 !== 0) {
+    if (message.lngE7 !== undefined && message.lngE7 !== 0) {
       obj.lngE7 = Math.round(message.lngE7);
     }
     return obj;

--- a/frontend/src/types/generated/ui.ts
+++ b/frontend/src/types/generated/ui.ts
@@ -46,48 +46,49 @@ export function mapLayerPositionToJSON(object: MapLayerPosition): string {
 }
 
 export interface UIRequestProto {
-  node: NodeProto | undefined;
-  expression: string;
-  root: FeatureIDProto | undefined;
-  locked: boolean;
-  logEvent: string;
-  logMapCenter: PointProto | undefined;
-  logMapZoom: number;
-  session: number;
+  node?: NodeProto | undefined;
+  expression?: string | undefined;
+  root?: FeatureIDProto | undefined;
+  locked?: boolean | undefined;
+  logEvent?: string | undefined;
+  logMapCenter?: PointProto | undefined;
+  logMapZoom?: number | undefined;
+  session?: number | undefined;
 }
 
 export interface UIResponseProto {
-  stack: StackProto | undefined;
-  node: NodeProto | undefined;
-  expression: string;
-  highlighted:
+  stack?: StackProto | undefined;
+  node?: NodeProto | undefined;
+  expression?: string | undefined;
+  highlighted?:
     | FeatureIDsProto
     | undefined;
   /** References geojson array in response */
-  geoJSON: GeoJSONProto[];
-  layers: MapLayerProto[];
-  mapCenter: PointProto | undefined;
-  locked: boolean;
-  chipValues: number[];
-  logDetail: string;
-  tilesChanged: boolean;
+  geoJSON?: GeoJSONProto[] | undefined;
+  layers?: MapLayerProto[] | undefined;
+  mapCenter?: PointProto | undefined;
+  locked?: boolean | undefined;
+  chipValues?: number[] | undefined;
+  logDetail?: string | undefined;
+  tilesChanged?: boolean | undefined;
 }
 
 export interface MapLayerProto {
-  path: string;
-  q: string;
-  v: string;
-  before: MapLayerPosition;
-  condition: ConditionProto | undefined;
+  path?: string | undefined;
+  q?: string | undefined;
+  v?: string | undefined;
+  before?: MapLayerPosition | undefined;
+  condition?: ConditionProto | undefined;
 }
 
 export interface StackProto {
-  substacks: SubstackProto[];
+  substacks?: SubstackProto[] | undefined;
+  id?: FeatureIDProto | undefined;
 }
 
 export interface SubstackProto {
-  lines: LineProto[];
-  collapsable: boolean;
+  lines?: LineProto[] | undefined;
+  collapsable?: boolean | undefined;
 }
 
 export interface LineProto {
@@ -106,84 +107,84 @@ export interface LineProto {
 }
 
 export interface ValueLineProto {
-  atom: AtomProto | undefined;
-  clickExpression: NodeProto | undefined;
+  atom?: AtomProto | undefined;
+  clickExpression?: NodeProto | undefined;
 }
 
 export interface LeftRightValueLineProto {
-  left: ClickableAtomProto[];
-  right: ClickableAtomProto | undefined;
+  left?: ClickableAtomProto[] | undefined;
+  right?: ClickableAtomProto | undefined;
 }
 
 export interface ClickableAtomProto {
-  atom: AtomProto | undefined;
-  clickExpression: NodeProto | undefined;
+  atom?: AtomProto | undefined;
+  clickExpression?: NodeProto | undefined;
 }
 
 export interface ExpressionLineProto {
-  expression: string;
+  expression?: string | undefined;
 }
 
 export interface TagsLineProto {
-  tags: TagAtomProto[];
+  tags?: TagAtomProto[] | undefined;
 }
 
 export interface TagAtomProto {
-  prefix: string;
-  key: string;
-  value: string;
-  clickExpression: NodeProto | undefined;
+  prefix?: string | undefined;
+  key?: string | undefined;
+  value?: string | undefined;
+  clickExpression?: NodeProto | undefined;
 }
 
 export interface HistogramBarLineProto {
-  range: AtomProto | undefined;
-  value: number;
-  total: number;
-  index: number;
+  range?: AtomProto | undefined;
+  value?: number | undefined;
+  total?: number | undefined;
+  index?: number | undefined;
 }
 
 export interface SwatchLineProto {
-  label: AtomProto | undefined;
-  index: number;
+  label?: AtomProto | undefined;
+  index?: number | undefined;
 }
 
 export interface ShellLineProto {
-  functions: string[];
+  functions?: string[] | undefined;
 }
 
 export interface ChoiceLineProto {
-  label: AtomProto | undefined;
-  chips: AtomProto[];
+  label?: AtomProto | undefined;
+  chips?: AtomProto[] | undefined;
 }
 
 export interface ChoiceProto {
-  chipValues: number[];
-  label: AtomProto | undefined;
+  chipValues?: number[] | undefined;
+  label?: AtomProto | undefined;
 }
 
 export interface HeaderLineProto {
-  title: AtomProto | undefined;
-  close: boolean;
-  share: boolean;
+  title?: AtomProto | undefined;
+  close?: boolean | undefined;
+  share?: boolean | undefined;
 }
 
 export interface ErrorLineProto {
-  error: string;
+  error?: string | undefined;
 }
 
 export interface ActionLineProto {
-  atom: AtomProto | undefined;
-  clickExpression: NodeProto | undefined;
-  inContext: boolean;
+  atom?: AtomProto | undefined;
+  clickExpression?: NodeProto | undefined;
+  inContext?: boolean | undefined;
 }
 
 export interface ComparisonHistogramProto {
-  bars: HistogramBarLineProto[];
+  bars?: HistogramBarLineProto[] | undefined;
 }
 
 export interface ComparisonLineProto {
-  baseline: ComparisonHistogramProto | undefined;
-  scenarios: ComparisonHistogramProto[];
+  baseline?: ComparisonHistogramProto | undefined;
+  scenarios?: ComparisonHistogramProto[] | undefined;
 }
 
 export interface AtomProto {
@@ -195,13 +196,13 @@ export interface AtomProto {
 }
 
 export interface LabelledIconProto {
-  icon: string;
-  label: string;
+  icon?: string | undefined;
+  label?: string | undefined;
 }
 
 export interface ChipProto {
-  index: number;
-  labels: string[];
+  index?: number | undefined;
+  labels?: string[] | undefined;
 }
 
 export interface ConditionProto {
@@ -209,40 +210,40 @@ export interface ConditionProto {
    * The value of the chips specified in indices need to match
    * the respective value for the element to be rendered.
    */
-  indices: number[];
-  values: number[];
+  indices?: number[] | undefined;
+  values?: number[] | undefined;
 }
 
 export interface ConditionalProto {
-  conditions: ConditionProto[];
-  atoms: AtomProto[];
+  conditions?: ConditionProto[] | undefined;
+  atoms?: AtomProto[] | undefined;
 }
 
 export interface GeoJSONProto {
-  condition: ConditionProto | undefined;
-  index: number;
+  condition?: ConditionProto | undefined;
+  index?: number | undefined;
 }
 
 export interface FeatureIDsProto {
-  namespaces: string[];
-  ids: IDsProto[];
+  namespaces?: string[] | undefined;
+  ids?: IDsProto[] | undefined;
 }
 
 export interface IDsProto {
-  ids: number[];
+  ids?: number[] | undefined;
 }
 
 export interface ComparisonRequestProto {
   /** The ID of the analysis to run in different worlds */
-  analysis:
+  analysis?:
     | FeatureIDProto
     | undefined;
   /** The ID of the baseline world in which to run the analysis */
-  baseline:
+  baseline?:
     | FeatureIDProto
     | undefined;
   /** The IDs of the scenario worlds in which to run the analysis */
-  scenarios: FeatureIDProto[];
+  scenarios?: FeatureIDProto[] | undefined;
 }
 
 function createBaseUIRequestProto(): UIRequestProto {
@@ -263,25 +264,25 @@ export const UIRequestProto = {
     if (message.node !== undefined) {
       NodeProto.encode(message.node, writer.uint32(10).fork()).ldelim();
     }
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       writer.uint32(18).string(message.expression);
     }
     if (message.root !== undefined) {
       FeatureIDProto.encode(message.root, writer.uint32(26).fork()).ldelim();
     }
-    if (message.locked !== false) {
+    if (message.locked !== undefined && message.locked !== false) {
       writer.uint32(32).bool(message.locked);
     }
-    if (message.logEvent !== "") {
+    if (message.logEvent !== undefined && message.logEvent !== "") {
       writer.uint32(42).string(message.logEvent);
     }
     if (message.logMapCenter !== undefined) {
       PointProto.encode(message.logMapCenter, writer.uint32(50).fork()).ldelim();
     }
-    if (message.logMapZoom !== 0) {
+    if (message.logMapZoom !== undefined && message.logMapZoom !== 0) {
       writer.uint32(61).float(message.logMapZoom);
     }
-    if (message.session !== 0) {
+    if (message.session !== undefined && message.session !== 0) {
       writer.uint32(64).uint64(message.session);
     }
     return writer;
@@ -377,25 +378,25 @@ export const UIRequestProto = {
     if (message.node !== undefined) {
       obj.node = NodeProto.toJSON(message.node);
     }
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       obj.expression = message.expression;
     }
     if (message.root !== undefined) {
       obj.root = FeatureIDProto.toJSON(message.root);
     }
-    if (message.locked !== false) {
+    if (message.locked !== undefined && message.locked !== false) {
       obj.locked = message.locked;
     }
-    if (message.logEvent !== "") {
+    if (message.logEvent !== undefined && message.logEvent !== "") {
       obj.logEvent = message.logEvent;
     }
     if (message.logMapCenter !== undefined) {
       obj.logMapCenter = PointProto.toJSON(message.logMapCenter);
     }
-    if (message.logMapZoom !== 0) {
+    if (message.logMapZoom !== undefined && message.logMapZoom !== 0) {
       obj.logMapZoom = message.logMapZoom;
     }
-    if (message.session !== 0) {
+    if (message.session !== undefined && message.session !== 0) {
       obj.session = Math.round(message.session);
     }
     return obj;
@@ -446,33 +447,39 @@ export const UIResponseProto = {
     if (message.node !== undefined) {
       NodeProto.encode(message.node, writer.uint32(18).fork()).ldelim();
     }
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       writer.uint32(26).string(message.expression);
     }
     if (message.highlighted !== undefined) {
       FeatureIDsProto.encode(message.highlighted, writer.uint32(34).fork()).ldelim();
     }
-    for (const v of message.geoJSON) {
-      GeoJSONProto.encode(v!, writer.uint32(42).fork()).ldelim();
+    if (message.geoJSON !== undefined && message.geoJSON.length !== 0) {
+      for (const v of message.geoJSON) {
+        GeoJSONProto.encode(v!, writer.uint32(42).fork()).ldelim();
+      }
     }
-    for (const v of message.layers) {
-      MapLayerProto.encode(v!, writer.uint32(58).fork()).ldelim();
+    if (message.layers !== undefined && message.layers.length !== 0) {
+      for (const v of message.layers) {
+        MapLayerProto.encode(v!, writer.uint32(58).fork()).ldelim();
+      }
     }
     if (message.mapCenter !== undefined) {
       PointProto.encode(message.mapCenter, writer.uint32(66).fork()).ldelim();
     }
-    if (message.locked !== false) {
+    if (message.locked !== undefined && message.locked !== false) {
       writer.uint32(72).bool(message.locked);
     }
-    writer.uint32(82).fork();
-    for (const v of message.chipValues) {
-      writer.int32(v);
+    if (message.chipValues !== undefined && message.chipValues.length !== 0) {
+      writer.uint32(82).fork();
+      for (const v of message.chipValues) {
+        writer.int32(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
-    if (message.logDetail !== "") {
+    if (message.logDetail !== undefined && message.logDetail !== "") {
       writer.uint32(90).string(message.logDetail);
     }
-    if (message.tilesChanged !== false) {
+    if (message.tilesChanged !== undefined && message.tilesChanged !== false) {
       writer.uint32(96).bool(message.tilesChanged);
     }
     return writer;
@@ -518,14 +525,14 @@ export const UIResponseProto = {
             break;
           }
 
-          message.geoJSON.push(GeoJSONProto.decode(reader, reader.uint32()));
+          message.geoJSON!.push(GeoJSONProto.decode(reader, reader.uint32()));
           continue;
         case 7:
           if (tag !== 58) {
             break;
           }
 
-          message.layers.push(MapLayerProto.decode(reader, reader.uint32()));
+          message.layers!.push(MapLayerProto.decode(reader, reader.uint32()));
           continue;
         case 8:
           if (tag !== 66) {
@@ -543,7 +550,7 @@ export const UIResponseProto = {
           continue;
         case 10:
           if (tag === 80) {
-            message.chipValues.push(reader.int32());
+            message.chipValues!.push(reader.int32());
 
             continue;
           }
@@ -551,7 +558,7 @@ export const UIResponseProto = {
           if (tag === 82) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.chipValues.push(reader.int32());
+              message.chipValues!.push(reader.int32());
             }
 
             continue;
@@ -609,7 +616,7 @@ export const UIResponseProto = {
     if (message.node !== undefined) {
       obj.node = NodeProto.toJSON(message.node);
     }
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       obj.expression = message.expression;
     }
     if (message.highlighted !== undefined) {
@@ -624,16 +631,16 @@ export const UIResponseProto = {
     if (message.mapCenter !== undefined) {
       obj.mapCenter = PointProto.toJSON(message.mapCenter);
     }
-    if (message.locked !== false) {
+    if (message.locked !== undefined && message.locked !== false) {
       obj.locked = message.locked;
     }
     if (message.chipValues?.length) {
       obj.chipValues = message.chipValues.map((e) => Math.round(e));
     }
-    if (message.logDetail !== "") {
+    if (message.logDetail !== undefined && message.logDetail !== "") {
       obj.logDetail = message.logDetail;
     }
-    if (message.tilesChanged !== false) {
+    if (message.tilesChanged !== undefined && message.tilesChanged !== false) {
       obj.tilesChanged = message.tilesChanged;
     }
     return obj;
@@ -671,16 +678,16 @@ function createBaseMapLayerProto(): MapLayerProto {
 
 export const MapLayerProto = {
   encode(message: MapLayerProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.path !== "") {
+    if (message.path !== undefined && message.path !== "") {
       writer.uint32(10).string(message.path);
     }
-    if (message.q !== "") {
+    if (message.q !== undefined && message.q !== "") {
       writer.uint32(18).string(message.q);
     }
-    if (message.v !== "") {
+    if (message.v !== undefined && message.v !== "") {
       writer.uint32(26).string(message.v);
     }
-    if (message.before !== 0) {
+    if (message.before !== undefined && message.before !== 0) {
       writer.uint32(32).int32(message.before);
     }
     if (message.condition !== undefined) {
@@ -752,16 +759,16 @@ export const MapLayerProto = {
 
   toJSON(message: MapLayerProto): unknown {
     const obj: any = {};
-    if (message.path !== "") {
+    if (message.path !== undefined && message.path !== "") {
       obj.path = message.path;
     }
-    if (message.q !== "") {
+    if (message.q !== undefined && message.q !== "") {
       obj.q = message.q;
     }
-    if (message.v !== "") {
+    if (message.v !== undefined && message.v !== "") {
       obj.v = message.v;
     }
-    if (message.before !== 0) {
+    if (message.before !== undefined && message.before !== 0) {
       obj.before = mapLayerPositionToJSON(message.before);
     }
     if (message.condition !== undefined) {
@@ -787,13 +794,18 @@ export const MapLayerProto = {
 };
 
 function createBaseStackProto(): StackProto {
-  return { substacks: [] };
+  return { substacks: [], id: undefined };
 }
 
 export const StackProto = {
   encode(message: StackProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.substacks) {
-      SubstackProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.substacks !== undefined && message.substacks.length !== 0) {
+      for (const v of message.substacks) {
+        SubstackProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
+    }
+    if (message.id !== undefined) {
+      FeatureIDProto.encode(message.id, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -810,7 +822,14 @@ export const StackProto = {
             break;
           }
 
-          message.substacks.push(SubstackProto.decode(reader, reader.uint32()));
+          message.substacks!.push(SubstackProto.decode(reader, reader.uint32()));
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.id = FeatureIDProto.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -826,6 +845,7 @@ export const StackProto = {
       substacks: globalThis.Array.isArray(object?.substacks)
         ? object.substacks.map((e: any) => SubstackProto.fromJSON(e))
         : [],
+      id: isSet(object.id) ? FeatureIDProto.fromJSON(object.id) : undefined,
     };
   },
 
@@ -833,6 +853,9 @@ export const StackProto = {
     const obj: any = {};
     if (message.substacks?.length) {
       obj.substacks = message.substacks.map((e) => SubstackProto.toJSON(e));
+    }
+    if (message.id !== undefined) {
+      obj.id = FeatureIDProto.toJSON(message.id);
     }
     return obj;
   },
@@ -843,6 +866,7 @@ export const StackProto = {
   fromPartial<I extends Exact<DeepPartial<StackProto>, I>>(object: I): StackProto {
     const message = createBaseStackProto();
     message.substacks = object.substacks?.map((e) => SubstackProto.fromPartial(e)) || [];
+    message.id = (object.id !== undefined && object.id !== null) ? FeatureIDProto.fromPartial(object.id) : undefined;
     return message;
   },
 };
@@ -853,10 +877,12 @@ function createBaseSubstackProto(): SubstackProto {
 
 export const SubstackProto = {
   encode(message: SubstackProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.lines) {
-      LineProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.lines !== undefined && message.lines.length !== 0) {
+      for (const v of message.lines) {
+        LineProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
-    if (message.collapsable !== false) {
+    if (message.collapsable !== undefined && message.collapsable !== false) {
       writer.uint32(16).bool(message.collapsable);
     }
     return writer;
@@ -874,7 +900,7 @@ export const SubstackProto = {
             break;
           }
 
-          message.lines.push(LineProto.decode(reader, reader.uint32()));
+          message.lines!.push(LineProto.decode(reader, reader.uint32()));
           continue;
         case 2:
           if (tag !== 16) {
@@ -904,7 +930,7 @@ export const SubstackProto = {
     if (message.lines?.length) {
       obj.lines = message.lines.map((e) => LineProto.toJSON(e));
     }
-    if (message.collapsable !== false) {
+    if (message.collapsable !== undefined && message.collapsable !== false) {
       obj.collapsable = message.collapsable;
     }
     return obj;
@@ -1266,8 +1292,10 @@ function createBaseLeftRightValueLineProto(): LeftRightValueLineProto {
 
 export const LeftRightValueLineProto = {
   encode(message: LeftRightValueLineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.left) {
-      ClickableAtomProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.left !== undefined && message.left.length !== 0) {
+      for (const v of message.left) {
+        ClickableAtomProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     if (message.right !== undefined) {
       ClickableAtomProto.encode(message.right, writer.uint32(18).fork()).ldelim();
@@ -1287,7 +1315,7 @@ export const LeftRightValueLineProto = {
             break;
           }
 
-          message.left.push(ClickableAtomProto.decode(reader, reader.uint32()));
+          message.left!.push(ClickableAtomProto.decode(reader, reader.uint32()));
           continue;
         case 2:
           if (tag !== 18) {
@@ -1418,7 +1446,7 @@ function createBaseExpressionLineProto(): ExpressionLineProto {
 
 export const ExpressionLineProto = {
   encode(message: ExpressionLineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       writer.uint32(10).string(message.expression);
     }
     return writer;
@@ -1453,7 +1481,7 @@ export const ExpressionLineProto = {
 
   toJSON(message: ExpressionLineProto): unknown {
     const obj: any = {};
-    if (message.expression !== "") {
+    if (message.expression !== undefined && message.expression !== "") {
       obj.expression = message.expression;
     }
     return obj;
@@ -1475,8 +1503,10 @@ function createBaseTagsLineProto(): TagsLineProto {
 
 export const TagsLineProto = {
   encode(message: TagsLineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.tags) {
-      TagAtomProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.tags !== undefined && message.tags.length !== 0) {
+      for (const v of message.tags) {
+        TagAtomProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -1493,7 +1523,7 @@ export const TagsLineProto = {
             break;
           }
 
-          message.tags.push(TagAtomProto.decode(reader, reader.uint32()));
+          message.tags!.push(TagAtomProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1534,13 +1564,13 @@ function createBaseTagAtomProto(): TagAtomProto {
 
 export const TagAtomProto = {
   encode(message: TagAtomProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.prefix !== "") {
+    if (message.prefix !== undefined && message.prefix !== "") {
       writer.uint32(10).string(message.prefix);
     }
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       writer.uint32(18).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       writer.uint32(26).string(message.value);
     }
     if (message.clickExpression !== undefined) {
@@ -1604,13 +1634,13 @@ export const TagAtomProto = {
 
   toJSON(message: TagAtomProto): unknown {
     const obj: any = {};
-    if (message.prefix !== "") {
+    if (message.prefix !== undefined && message.prefix !== "") {
       obj.prefix = message.prefix;
     }
-    if (message.key !== "") {
+    if (message.key !== undefined && message.key !== "") {
       obj.key = message.key;
     }
-    if (message.value !== "") {
+    if (message.value !== undefined && message.value !== "") {
       obj.value = message.value;
     }
     if (message.clickExpression !== undefined) {
@@ -1643,13 +1673,13 @@ export const HistogramBarLineProto = {
     if (message.range !== undefined) {
       AtomProto.encode(message.range, writer.uint32(10).fork()).ldelim();
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined && message.value !== 0) {
       writer.uint32(16).int32(message.value);
     }
-    if (message.total !== 0) {
+    if (message.total !== undefined && message.total !== 0) {
       writer.uint32(24).int32(message.total);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       writer.uint32(32).int32(message.index);
     }
     return writer;
@@ -1713,13 +1743,13 @@ export const HistogramBarLineProto = {
     if (message.range !== undefined) {
       obj.range = AtomProto.toJSON(message.range);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined && message.value !== 0) {
       obj.value = Math.round(message.value);
     }
-    if (message.total !== 0) {
+    if (message.total !== undefined && message.total !== 0) {
       obj.total = Math.round(message.total);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       obj.index = Math.round(message.index);
     }
     return obj;
@@ -1749,7 +1779,7 @@ export const SwatchLineProto = {
     if (message.label !== undefined) {
       AtomProto.encode(message.label, writer.uint32(10).fork()).ldelim();
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       writer.uint32(16).int32(message.index);
     }
     return writer;
@@ -1797,7 +1827,7 @@ export const SwatchLineProto = {
     if (message.label !== undefined) {
       obj.label = AtomProto.toJSON(message.label);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       obj.index = Math.round(message.index);
     }
     return obj;
@@ -1822,8 +1852,10 @@ function createBaseShellLineProto(): ShellLineProto {
 
 export const ShellLineProto = {
   encode(message: ShellLineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.functions) {
-      writer.uint32(10).string(v!);
+    if (message.functions !== undefined && message.functions.length !== 0) {
+      for (const v of message.functions) {
+        writer.uint32(10).string(v!);
+      }
     }
     return writer;
   },
@@ -1840,7 +1872,7 @@ export const ShellLineProto = {
             break;
           }
 
-          message.functions.push(reader.string());
+          message.functions!.push(reader.string());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1886,8 +1918,10 @@ export const ChoiceLineProto = {
     if (message.label !== undefined) {
       AtomProto.encode(message.label, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.chips) {
-      AtomProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.chips !== undefined && message.chips.length !== 0) {
+      for (const v of message.chips) {
+        AtomProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -1911,7 +1945,7 @@ export const ChoiceLineProto = {
             break;
           }
 
-          message.chips.push(AtomProto.decode(reader, reader.uint32()));
+          message.chips!.push(AtomProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -1959,11 +1993,13 @@ function createBaseChoiceProto(): ChoiceProto {
 
 export const ChoiceProto = {
   encode(message: ChoiceProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).fork();
-    for (const v of message.chipValues) {
-      writer.int32(v);
+    if (message.chipValues !== undefined && message.chipValues.length !== 0) {
+      writer.uint32(10).fork();
+      for (const v of message.chipValues) {
+        writer.int32(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
     if (message.label !== undefined) {
       AtomProto.encode(message.label, writer.uint32(18).fork()).ldelim();
     }
@@ -1979,7 +2015,7 @@ export const ChoiceProto = {
       switch (tag >>> 3) {
         case 1:
           if (tag === 8) {
-            message.chipValues.push(reader.int32());
+            message.chipValues!.push(reader.int32());
 
             continue;
           }
@@ -1987,7 +2023,7 @@ export const ChoiceProto = {
           if (tag === 10) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.chipValues.push(reader.int32());
+              message.chipValues!.push(reader.int32());
             }
 
             continue;
@@ -2052,10 +2088,10 @@ export const HeaderLineProto = {
     if (message.title !== undefined) {
       AtomProto.encode(message.title, writer.uint32(10).fork()).ldelim();
     }
-    if (message.close !== false) {
+    if (message.close !== undefined && message.close !== false) {
       writer.uint32(16).bool(message.close);
     }
-    if (message.share !== false) {
+    if (message.share !== undefined && message.share !== false) {
       writer.uint32(24).bool(message.share);
     }
     return writer;
@@ -2111,10 +2147,10 @@ export const HeaderLineProto = {
     if (message.title !== undefined) {
       obj.title = AtomProto.toJSON(message.title);
     }
-    if (message.close !== false) {
+    if (message.close !== undefined && message.close !== false) {
       obj.close = message.close;
     }
-    if (message.share !== false) {
+    if (message.share !== undefined && message.share !== false) {
       obj.share = message.share;
     }
     return obj;
@@ -2140,7 +2176,7 @@ function createBaseErrorLineProto(): ErrorLineProto {
 
 export const ErrorLineProto = {
   encode(message: ErrorLineProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.error !== "") {
+    if (message.error !== undefined && message.error !== "") {
       writer.uint32(10).string(message.error);
     }
     return writer;
@@ -2175,7 +2211,7 @@ export const ErrorLineProto = {
 
   toJSON(message: ErrorLineProto): unknown {
     const obj: any = {};
-    if (message.error !== "") {
+    if (message.error !== undefined && message.error !== "") {
       obj.error = message.error;
     }
     return obj;
@@ -2203,7 +2239,7 @@ export const ActionLineProto = {
     if (message.clickExpression !== undefined) {
       NodeProto.encode(message.clickExpression, writer.uint32(18).fork()).ldelim();
     }
-    if (message.inContext !== false) {
+    if (message.inContext !== undefined && message.inContext !== false) {
       writer.uint32(24).bool(message.inContext);
     }
     return writer;
@@ -2262,7 +2298,7 @@ export const ActionLineProto = {
     if (message.clickExpression !== undefined) {
       obj.clickExpression = NodeProto.toJSON(message.clickExpression);
     }
-    if (message.inContext !== false) {
+    if (message.inContext !== undefined && message.inContext !== false) {
       obj.inContext = message.inContext;
     }
     return obj;
@@ -2288,8 +2324,10 @@ function createBaseComparisonHistogramProto(): ComparisonHistogramProto {
 
 export const ComparisonHistogramProto = {
   encode(message: ComparisonHistogramProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.bars) {
-      HistogramBarLineProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.bars !== undefined && message.bars.length !== 0) {
+      for (const v of message.bars) {
+        HistogramBarLineProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -2306,7 +2344,7 @@ export const ComparisonHistogramProto = {
             break;
           }
 
-          message.bars.push(HistogramBarLineProto.decode(reader, reader.uint32()));
+          message.bars!.push(HistogramBarLineProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2352,8 +2390,10 @@ export const ComparisonLineProto = {
     if (message.baseline !== undefined) {
       ComparisonHistogramProto.encode(message.baseline, writer.uint32(10).fork()).ldelim();
     }
-    for (const v of message.scenarios) {
-      ComparisonHistogramProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.scenarios !== undefined && message.scenarios.length !== 0) {
+      for (const v of message.scenarios) {
+        ComparisonHistogramProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -2377,7 +2417,7 @@ export const ComparisonLineProto = {
             break;
           }
 
-          message.scenarios.push(ComparisonHistogramProto.decode(reader, reader.uint32()));
+          message.scenarios!.push(ComparisonHistogramProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2550,10 +2590,10 @@ function createBaseLabelledIconProto(): LabelledIconProto {
 
 export const LabelledIconProto = {
   encode(message: LabelledIconProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.icon !== "") {
+    if (message.icon !== undefined && message.icon !== "") {
       writer.uint32(10).string(message.icon);
     }
-    if (message.label !== "") {
+    if (message.label !== undefined && message.label !== "") {
       writer.uint32(18).string(message.label);
     }
     return writer;
@@ -2598,10 +2638,10 @@ export const LabelledIconProto = {
 
   toJSON(message: LabelledIconProto): unknown {
     const obj: any = {};
-    if (message.icon !== "") {
+    if (message.icon !== undefined && message.icon !== "") {
       obj.icon = message.icon;
     }
-    if (message.label !== "") {
+    if (message.label !== undefined && message.label !== "") {
       obj.label = message.label;
     }
     return obj;
@@ -2624,11 +2664,13 @@ function createBaseChipProto(): ChipProto {
 
 export const ChipProto = {
   encode(message: ChipProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       writer.uint32(8).int32(message.index);
     }
-    for (const v of message.labels) {
-      writer.uint32(18).string(v!);
+    if (message.labels !== undefined && message.labels.length !== 0) {
+      for (const v of message.labels) {
+        writer.uint32(18).string(v!);
+      }
     }
     return writer;
   },
@@ -2652,7 +2694,7 @@ export const ChipProto = {
             break;
           }
 
-          message.labels.push(reader.string());
+          message.labels!.push(reader.string());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2672,7 +2714,7 @@ export const ChipProto = {
 
   toJSON(message: ChipProto): unknown {
     const obj: any = {};
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       obj.index = Math.round(message.index);
     }
     if (message.labels?.length) {
@@ -2698,16 +2740,20 @@ function createBaseConditionProto(): ConditionProto {
 
 export const ConditionProto = {
   encode(message: ConditionProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).fork();
-    for (const v of message.indices) {
-      writer.int32(v);
+    if (message.indices !== undefined && message.indices.length !== 0) {
+      writer.uint32(10).fork();
+      for (const v of message.indices) {
+        writer.int32(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
-    writer.uint32(18).fork();
-    for (const v of message.values) {
-      writer.int32(v);
+    if (message.values !== undefined && message.values.length !== 0) {
+      writer.uint32(18).fork();
+      for (const v of message.values) {
+        writer.int32(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
     return writer;
   },
 
@@ -2720,7 +2766,7 @@ export const ConditionProto = {
       switch (tag >>> 3) {
         case 1:
           if (tag === 8) {
-            message.indices.push(reader.int32());
+            message.indices!.push(reader.int32());
 
             continue;
           }
@@ -2728,7 +2774,7 @@ export const ConditionProto = {
           if (tag === 10) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.indices.push(reader.int32());
+              message.indices!.push(reader.int32());
             }
 
             continue;
@@ -2737,7 +2783,7 @@ export const ConditionProto = {
           break;
         case 2:
           if (tag === 16) {
-            message.values.push(reader.int32());
+            message.values!.push(reader.int32());
 
             continue;
           }
@@ -2745,7 +2791,7 @@ export const ConditionProto = {
           if (tag === 18) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.values.push(reader.int32());
+              message.values!.push(reader.int32());
             }
 
             continue;
@@ -2796,11 +2842,15 @@ function createBaseConditionalProto(): ConditionalProto {
 
 export const ConditionalProto = {
   encode(message: ConditionalProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.conditions) {
-      ConditionProto.encode(v!, writer.uint32(10).fork()).ldelim();
+    if (message.conditions !== undefined && message.conditions.length !== 0) {
+      for (const v of message.conditions) {
+        ConditionProto.encode(v!, writer.uint32(10).fork()).ldelim();
+      }
     }
-    for (const v of message.atoms) {
-      AtomProto.encode(v!, writer.uint32(18).fork()).ldelim();
+    if (message.atoms !== undefined && message.atoms.length !== 0) {
+      for (const v of message.atoms) {
+        AtomProto.encode(v!, writer.uint32(18).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -2817,14 +2867,14 @@ export const ConditionalProto = {
             break;
           }
 
-          message.conditions.push(ConditionProto.decode(reader, reader.uint32()));
+          message.conditions!.push(ConditionProto.decode(reader, reader.uint32()));
           continue;
         case 2:
           if (tag !== 18) {
             break;
           }
 
-          message.atoms.push(AtomProto.decode(reader, reader.uint32()));
+          message.atoms!.push(AtomProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -2875,7 +2925,7 @@ export const GeoJSONProto = {
     if (message.condition !== undefined) {
       ConditionProto.encode(message.condition, writer.uint32(10).fork()).ldelim();
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       writer.uint32(16).int32(message.index);
     }
     return writer;
@@ -2923,7 +2973,7 @@ export const GeoJSONProto = {
     if (message.condition !== undefined) {
       obj.condition = ConditionProto.toJSON(message.condition);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined && message.index !== 0) {
       obj.index = Math.round(message.index);
     }
     return obj;
@@ -2948,11 +2998,15 @@ function createBaseFeatureIDsProto(): FeatureIDsProto {
 
 export const FeatureIDsProto = {
   encode(message: FeatureIDsProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    for (const v of message.namespaces) {
-      writer.uint32(26).string(v!);
+    if (message.namespaces !== undefined && message.namespaces.length !== 0) {
+      for (const v of message.namespaces) {
+        writer.uint32(26).string(v!);
+      }
     }
-    for (const v of message.ids) {
-      IDsProto.encode(v!, writer.uint32(34).fork()).ldelim();
+    if (message.ids !== undefined && message.ids.length !== 0) {
+      for (const v of message.ids) {
+        IDsProto.encode(v!, writer.uint32(34).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -2969,14 +3023,14 @@ export const FeatureIDsProto = {
             break;
           }
 
-          message.namespaces.push(reader.string());
+          message.namespaces!.push(reader.string());
           continue;
         case 4:
           if (tag !== 34) {
             break;
           }
 
-          message.ids.push(IDsProto.decode(reader, reader.uint32()));
+          message.ids!.push(IDsProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -3024,11 +3078,13 @@ function createBaseIDsProto(): IDsProto {
 
 export const IDsProto = {
   encode(message: IDsProto, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    writer.uint32(10).fork();
-    for (const v of message.ids) {
-      writer.uint64(v);
+    if (message.ids !== undefined && message.ids.length !== 0) {
+      writer.uint32(10).fork();
+      for (const v of message.ids) {
+        writer.uint64(v);
+      }
+      writer.ldelim();
     }
-    writer.ldelim();
     return writer;
   },
 
@@ -3041,7 +3097,7 @@ export const IDsProto = {
       switch (tag >>> 3) {
         case 1:
           if (tag === 8) {
-            message.ids.push(longToNumber(reader.uint64() as Long));
+            message.ids!.push(longToNumber(reader.uint64() as Long));
 
             continue;
           }
@@ -3049,7 +3105,7 @@ export const IDsProto = {
           if (tag === 10) {
             const end2 = reader.uint32() + reader.pos;
             while (reader.pos < end2) {
-              message.ids.push(longToNumber(reader.uint64() as Long));
+              message.ids!.push(longToNumber(reader.uint64() as Long));
             }
 
             continue;
@@ -3099,8 +3155,10 @@ export const ComparisonRequestProto = {
     if (message.baseline !== undefined) {
       FeatureIDProto.encode(message.baseline, writer.uint32(18).fork()).ldelim();
     }
-    for (const v of message.scenarios) {
-      FeatureIDProto.encode(v!, writer.uint32(26).fork()).ldelim();
+    if (message.scenarios !== undefined && message.scenarios.length !== 0) {
+      for (const v of message.scenarios) {
+        FeatureIDProto.encode(v!, writer.uint32(26).fork()).ldelim();
+      }
     }
     return writer;
   },
@@ -3131,7 +3189,7 @@ export const ComparisonRequestProto = {
             break;
           }
 
-          message.scenarios.push(FeatureIDProto.decode(reader, reader.uint32()));
+          message.scenarios!.push(FeatureIDProto.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {

--- a/frontend/src/types/startup.ts
+++ b/frontend/src/types/startup.ts
@@ -6,12 +6,14 @@ export type LatLng = {
     lngE7: number;
 };
 
+export type Docked = {
+    geoJSON: FeatureCollection[];
+    proto: UIResponseProto;
+};
+
 export type StartupResponse = {
     version?: string;
-    docked?: {
-        geoJSON: FeatureCollection[];
-        proto: UIResponseProto;
-    }[];
+    docked?: Docked[];
     openDockIndex?: number;
     mapCenter?: LatLng;
     mapZoom?: number;


### PR DESCRIPTION

Fetch comparison for an analysis form `/evaluate` endpoint and use the result to display data in the comparison panel.
Additionally, display amenity icons when relevant.


