### PR TITLE
feat: highlight and select improvements on comparison histogram

### DIFF
--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -41,6 +41,7 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
         queryLayers,
         geoJSON,
         scenario: { id, featureId, worldCreated },
+        highlightedFeatures,
         mapStyle,
         tab,
     } = useScenarioContext();
@@ -135,6 +136,15 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
                     return 0;
                 },
                 getLineColor: (f: Feature) => {
+                    const isHighlighted = highlightedFeatures?.find(
+                        (hf) =>
+                            hf.value &&
+                            hf.value.toString() ===
+                                parseInt(f.properties.id, 16).toString()
+                    );
+                    if (isHighlighted) {
+                        return [0, 0, 0, 255];
+                    }
                     if (f.properties?.layerName === ql.layer.path) {
                         const c = histogram?.colorScale?.(f.properties?.bucket);
                         if (!c) {
@@ -157,13 +167,21 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
                     return [0, 0, 0, 0];
                 },
                 updateTriggers: {
-                    getLineColor: [histogram.colorScale, histogram.selected],
-                    getFillColor: [histogram.colorScale, histogram.selected],
+                    getLineColor: [
+                        histogram.colorScale,
+                        histogram.selected,
+                        highlightedFeatures,
+                    ],
+                    getFillColor: [
+                        histogram.colorScale,
+                        histogram.selected,
+                        highlightedFeatures,
+                    ],
                     getLineWidth: [histogram.selected],
                 },
             });
         });
-    }, [queryLayers]);
+    }, [queryLayers, highlightedFeatures]);
 
     const Markers = useMemo(() => {
         if (!map) return null;

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -17,7 +17,7 @@ export const StackAdapter = () => {
     } = useAppContext();
     const { outliner } = useOutlinerContext();
     const {
-        scenario: { change, worldCreated },
+        scenario: { worldCreated, change },
         addFeatureToChange,
         removeFeatureFromChange,
     } = useScenarioContext();
@@ -61,9 +61,8 @@ export const StackAdapter = () => {
     const featureId = outliner.data?.proto?.stack?.id;
 
     const isInChange = change?.features?.find((f) => isEqual(f.id, featureId));
-    const outlierFeatureId = outliner.data.proto.stack?.id;
     const showChangeElements =
-        outlierFeatureId && !worldCreated && outliner.properties.changeable;
+        featureId && !worldCreated && outliner.properties.changeable;
 
     const labelledIcon =
         outliner.data.proto.stack?.substacks?.[1]?.lines?.flatMap((l) =>
@@ -76,21 +75,19 @@ export const StackAdapter = () => {
                 <div className="flex justify-start">
                     <button
                         onClick={() => {
-                            const node = outliner.data?.proto.node;
                             const expression =
                                 outliner.request?.expression ?? '';
-                            if (!node) return;
 
                             if (isInChange) {
                                 removeFeatureFromChange({
                                     expression,
-                                    id: outlierFeatureId,
+                                    id: featureId,
                                     label: labelledIcon,
                                 });
                             }
                             addFeatureToChange({
                                 expression,
-                                id: outlierFeatureId,
+                                id: featureId,
                                 label: labelledIcon,
                             });
                         }}

--- a/frontend/src/lib/context/comparator.tsx
+++ b/frontend/src/lib/context/comparator.tsx
@@ -92,6 +92,7 @@ export const ComparatorProvider = ({
                 data: {
                     geoJSON: [],
                     proto: {
+                        layers: analysis ? analysis.proto.layers : [],
                         stack: {
                             substacks: [
                                 {


### PR DESCRIPTION
Make it visible when a building in a histogram bucket is also highlighted. 
Fixes the issue with the comparison histograms not allowing selection.