### PR TITLE
fix interaction issues related with multi tabs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -193,6 +193,7 @@ const TabButton = ({
     );
 
     const handleClick = () => {
+        console.log('click');
         setActiveScenario(scenario.id);
     };
 
@@ -215,12 +216,16 @@ const TabButton = ({
             onClick={handleClick}
         >
             <ReaderIcon />
-            <input
-                onChange={handleInputChange}
-                disabled={!editable || !active}
-                className="bg-transparent border-none text-sm focus:outline-none focus:text-graphite-80 transition-colors  caret-rose-60 "
-                value={scenario.name}
-            />
+            {editable && active ? (
+                <input
+                    onChange={handleInputChange}
+                    disabled={!editable || !active}
+                    className="bg-transparent border-none text-sm focus:outline-none focus:text-graphite-80 transition-colors  caret-rose-60 "
+                    value={scenario.name}
+                />
+            ) : (
+                <span className=" cursor-pointer">{scenario.name}</span>
+            )}
 
             {scenario.id !== 'baseline' && (
                 <div className="w-4 flex">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -193,7 +193,6 @@ const TabButton = ({
     );
 
     const handleClick = () => {
-        console.log('click');
         setActiveScenario(scenario.id);
     };
 

--- a/frontend/src/atoms/app.tsx
+++ b/frontend/src/atoms/app.tsx
@@ -32,6 +32,7 @@ export type Scenario = ScenarioSpec & {
     change?: Change;
     featureId?: FeatureIDProto;
     worldCreated?: boolean;
+    tabIndex: number;
 };
 
 export type Scenarios = Record<string, Scenario>;
@@ -60,6 +61,7 @@ export const initialAppStore: AppStore = {
     comparators: {},
     scenarios: {
         baseline: {
+            tabIndex: 0,
             id: 'baseline',
             name: 'Baseline',
         },

--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -63,10 +63,10 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
 
     const queryLayersGL = useMemo(() => {
         if (!map) return null;
-        return queryLayers.map((ql) => {
+        return queryLayers.flatMap((ql) => {
             const histogram = ql.histogram;
 
-            if (!histogram || !ql.show) return null;
+            if (!histogram || !ql.show) return [];
             return new MVTLayer({
                 data: [
                     `${b6Path}tiles/${ql.layer.path}/{z}/{x}/{y}.mvt?q=${

--- a/frontend/src/components/ScenarioTab.tsx
+++ b/frontend/src/components/ScenarioTab.tsx
@@ -52,8 +52,6 @@ export const ScenarioTab = ({
     const [showWorldShell, setShowWorldShell] = useState(false);
     const { comparisonOutliners } = useScenarioContext();
 
-    console.log({ comparisonOutliners });
-
     useHotkeys('shift+meta+b, `', () => {
         setShowWorldShell((prev) => !prev);
     });

--- a/frontend/src/components/ScenarioTab.tsx
+++ b/frontend/src/components/ScenarioTab.tsx
@@ -52,6 +52,8 @@ export const ScenarioTab = ({
     const [showWorldShell, setShowWorldShell] = useState(false);
     const { comparisonOutliners } = useScenarioContext();
 
+    console.log({ comparisonOutliners });
+
     useHotkeys('shift+meta+b, `', () => {
         setShowWorldShell((prev) => !prev);
     });

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -46,7 +46,6 @@ export const StackAdapter = () => {
 
     const handleOpenChange = (open: boolean) => {
         setActiveOutliner(outliner.id, open);
-
         setOpen(open);
     };
 

--- a/frontend/src/lib/context/app.tsx
+++ b/frontend/src/lib/context/app.tsx
@@ -261,15 +261,19 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     );
 
     const changedWorldScenarios = useMemo(() => {
-        return Object.values(app.scenarios).filter((o) => o.id !== 'baseline');
+        return Object.values(app.scenarios)
+            .filter((o) => o.id !== 'baseline')
+            .sort((a, b) => a.tabIndex - b.tabIndex);
     }, [app.scenarios]);
 
     const addScenario = useCallback(() => {
         const id = uniqueId(random(0, 1000).toString());
         setApp((draft) => {
+            const tabIndex = Object.keys(draft.scenarios).length;
             draft.scenarios[id] = {
                 id: id,
                 name: 'Untitled Scenario',
+                tabIndex,
             };
             draft.tabs.right = id;
         });

--- a/frontend/src/lib/context/comparator.tsx
+++ b/frontend/src/lib/context/comparator.tsx
@@ -83,7 +83,7 @@ export const ComparatorProvider = ({
             createOutliner({
                 id: `${comparator.id}-baseline`,
                 properties: {
-                    comparison: true,
+                    comparison: comparator.id,
                     scenario: comparator?.baseline as $FixMe,
                     docked: false,
                     transient: false,
@@ -118,7 +118,7 @@ export const ComparatorProvider = ({
                 createOutliner({
                     id: `${comparator.id}-scenario-${i}`,
                     properties: {
-                        comparison: true,
+                        comparison: comparator.id,
                         origin: `${comparator.id}-baseline`,
                         scenario: scenarioId as $FixMe,
                         docked: false,

--- a/frontend/src/lib/context/outliner.tsx
+++ b/frontend/src/lib/context/outliner.tsx
@@ -32,7 +32,7 @@ export type OutlinerSpec = {
         coordinates: { x: number; y: number };
         scenario?: string;
         changeable?: boolean;
-        comparison?: boolean;
+        comparison?: string;
         origin?: string;
     };
     request?: {

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -28,7 +28,7 @@ import { $FixMe } from '@/utils/defs';
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { GeoJsonObject } from 'geojson';
 import { useAtomValue } from 'jotai';
-import { isEqual, pickBy } from 'lodash';
+import { isEqual, isUndefined, pickBy } from 'lodash';
 import { MapRef } from 'react-map-gl/maplibre';
 import { b6, b6Path } from '../b6';
 import { changeMapStyleSource } from '../map';
@@ -338,12 +338,11 @@ export const ScenarioProvider = ({
     }, [scenarioOutliners]);
 
     const comparisonOutliners = useMemo(() => {
-        console.log({ scenarioOutliners });
         return Object.values(scenarioOutliners).filter(
             (outliner) =>
                 outliner.properties.comparison === activeComparator?.id
         );
-    }, [scenarioOutliners]);
+    }, [scenarioOutliners, activeComparator?.id]);
 
     const draggableOutliners = useMemo(() => {
         return Object.values(scenarioOutliners).filter(
@@ -359,14 +358,19 @@ export const ScenarioProvider = ({
     }, [scenarioOutliners]);
 
     const queryLayers = useMemo(() => {
+        const activeLayer = Object.values(scenarioOutliners).find(
+            (outliner) => outliner.active
+        );
         return Object.values(scenarioOutliners).flatMap((outliner) => {
             return (outliner.data?.proto.layers?.map((l) => ({
                 layer: l,
                 histogram: outliner.histogram,
-                show: outliner.active || outliner.properties.comparison,
+                show: !isUndefined(activeLayer)
+                    ? outliner.active
+                    : outliner.properties.comparison === activeComparator?.id,
             })) || []) as QueryLayer[];
         });
-    }, [scenarioOutliners]);
+    }, [scenarioOutliners, activeComparator?.id]);
 
     const highlightedFeatures = useMemo(() => {
         const featureIds = Object.values(scenarioOutliners)

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -102,6 +102,7 @@ export const ScenarioProvider = ({
         createOutliner,
         addComparator,
         setApp,
+        activeComparator,
     } = useAppContext();
     const startupQuery = useAtomValue(startupQueryAtom);
     const collection = useAtomValue(collectionAtom);
@@ -337,8 +338,10 @@ export const ScenarioProvider = ({
     }, [scenarioOutliners]);
 
     const comparisonOutliners = useMemo(() => {
+        console.log({ scenarioOutliners });
         return Object.values(scenarioOutliners).filter(
-            (outliner) => outliner.properties.comparison
+            (outliner) =>
+                outliner.properties.comparison === activeComparator?.id
         );
     }, [scenarioOutliners]);
 

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -367,10 +367,11 @@ export const ScenarioProvider = ({
                 histogram: outliner.histogram,
                 show: !isUndefined(activeLayer)
                     ? outliner.active
-                    : outliner.properties.comparison === activeComparator?.id,
+                    : activeComparator &&
+                      outliner.properties.comparison === activeComparator.id,
             })) || []) as QueryLayer[];
         });
-    }, [scenarioOutliners, activeComparator?.id]);
+    }, [scenarioOutliners, activeComparator]);
 
     const highlightedFeatures = useMemo(() => {
         const featureIds = Object.values(scenarioOutliners)


### PR DESCRIPTION
### Goal

Fix a few interaction issues related to the multi-tab behavior, namely:

- [x] When more than one scenario tab existed, multiple comparison outlines would show for the baseline tab.
- [x] Defined behavior for when a new outliner with query layers becomes active in a comparison setting: 
             Previously, this would cause an overlap of histograms which led to an incorrect state. We now prioritize an active query layer, and only if none exists, show the comparison layers.
- [x] Click on the scenario's name on its tab did not change to the respective tab.