### PR TITLE
Add visibility toggle on outliners

### DIFF
--- a/frontend/src/components/Comparator.tsx
+++ b/frontend/src/components/Comparator.tsx
@@ -16,7 +16,7 @@ export function Comparator() {
         <div>
             <div className="border-t border-x border-graphite-30">
                 {analysisTitle && (
-                    <Line className="border-b-0">
+                    <Line className="border-b-0 w-80">
                         <HeaderAdapter header={analysisTitle} />
                     </Line>
                 )}

--- a/frontend/src/components/ScenarioMap.tsx
+++ b/frontend/src/components/ScenarioMap.tsx
@@ -242,11 +242,12 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
                 </Marker>
             );
         });
-    }, [map, getVisibleMarkers]);
+    }, [map, getVisibleMarkers, queryLayers]);
 
     const handleMapClick = useCallback(
         (e: MapLayerMouseEvent) => {
             const outlinerProperties = {
+                show: true,
                 scenario: id,
                 docked: false,
                 transient: true,
@@ -324,7 +325,10 @@ export const ScenarioMap = ({ children }: PropsWithChildren) => {
             boxZoom={false} // https://github.com/mapbox/mapbox-gl-js/issues/6971s
         >
             <DeckGLOverlay
-                layers={[queryLayersGL, geoJsonLayerGL]}
+                layers={[
+                    ...(queryLayersGL ? queryLayersGL : []),
+                    geoJsonLayerGL,
+                ]}
                 interleaved
             />
 

--- a/frontend/src/components/ScenarioTab.tsx
+++ b/frontend/src/components/ScenarioTab.tsx
@@ -173,7 +173,7 @@ const ChangePanel = () => {
                                 change.features.map((feature, i) => (
                                     <Line
                                         className={twMerge(
-                                            'text-sm py-1 flex gap-2 items-center justify-between',
+                                            'text-sm py-1  w-80 flex gap-2 items-center justify-between',
                                             worldCreated &&
                                                 'bg-rose-10 hover:bg-rose-10 italic'
                                         )}

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -101,30 +101,32 @@ export const LineAdapter = ({
                     )}
                     {line.tags && <Tags tagLine={line.tags} />}
                 </Wrapper>
-                <div className="flex gap-1">
-                    {show && (
-                        <Tooltip content={'Toggle visiblity'}>
-                            <IconButton
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    e.preventDefault();
-                                    setVisible(!outliner.properties.show);
-                                }}
-                            >
-                                {outliner.properties.show ? (
-                                    <ComponentInstanceIcon />
-                                ) : (
-                                    <ComponentNoneIcon />
-                                )}
+                {(show || close) && (
+                    <div className="flex gap-1">
+                        {show && (
+                            <Tooltip content={'Toggle visiblity'}>
+                                <IconButton
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        e.preventDefault();
+                                        setVisible(!outliner.properties.show);
+                                    }}
+                                >
+                                    {outliner.properties.show ? (
+                                        <ComponentInstanceIcon />
+                                    ) : (
+                                        <ComponentNoneIcon />
+                                    )}
+                                </IconButton>
+                            </Tooltip>
+                        )}
+                        {close && (
+                            <IconButton onClick={closeFn} className="close">
+                                <Cross1Icon />
                             </IconButton>
-                        </Tooltip>
-                    )}
-                    {close && (
-                        <IconButton onClick={closeFn} className="close">
-                            <Cross1Icon />
-                        </IconButton>
-                    )}
-                </div>
+                        )}
+                    </div>
+                )}
             </Line>
         </LineContextProvider>
     );

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -3,10 +3,14 @@ import { LineContextProvider } from '@/lib/context/line';
 import { useOutlinerContext } from '@/lib/context/outliner';
 import { useScenarioContext } from '@/lib/context/scenario';
 import { LineProto, TagsLineProto } from '@/types/generated/ui';
-import { Cross1Icon } from '@radix-ui/react-icons';
+import {
+    ComponentInstanceIcon,
+    ComponentNoneIcon,
+    Cross1Icon,
+} from '@radix-ui/react-icons';
 import React from 'react';
 import { IconButton } from '../system/IconButton';
-import { TooltipOverflow } from '../system/Tooltip';
+import { Tooltip, TooltipOverflow } from '../system/Tooltip';
 import { AtomAdapter } from './AtomAdapter';
 import { ChoiceAdapter } from './ChoiceAdapter';
 import { HeaderAdapter } from './HeaderAdapter';
@@ -14,15 +18,19 @@ import { ShellAdapter } from './ShellAdapter';
 
 export const LineAdapter = ({
     line,
-    close,
+    actions: { close, show },
 }: {
     line: LineProto;
-    close?: boolean;
+    actions: {
+        close: boolean;
+        show: boolean;
+    };
 }) => {
     const clickable =
         line.value?.clickExpression ?? line.action?.clickExpression;
     const Wrapper = clickable ? Line.Button : React.Fragment;
-    const { outliner, close: closeFn } = useOutlinerContext();
+
+    const { outliner, close: closeFn, setVisible } = useOutlinerContext();
     const { createOutlinerInScenario } = useScenarioContext();
 
     const handleLineClick = () => {
@@ -35,6 +43,7 @@ export const LineAdapter = ({
                 scenario: outliner.properties.scenario,
                 transient: outliner.properties.transient,
                 docked: outliner.properties.docked,
+                show: true,
             },
             request: {
                 expression: '',
@@ -92,11 +101,30 @@ export const LineAdapter = ({
                     )}
                     {line.tags && <Tags tagLine={line.tags} />}
                 </Wrapper>
-                {close && (
-                    <IconButton onClick={closeFn} className="close">
-                        <Cross1Icon />
-                    </IconButton>
-                )}
+                <div className="flex gap-1">
+                    {show && (
+                        <Tooltip content={'Toggle visiblity'}>
+                            <IconButton
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    e.preventDefault();
+                                    setVisible(!outliner.properties.show);
+                                }}
+                            >
+                                {outliner.properties.show ? (
+                                    <ComponentInstanceIcon />
+                                ) : (
+                                    <ComponentNoneIcon />
+                                )}
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                    {close && (
+                        <IconButton onClick={closeFn} className="close">
+                            <Cross1Icon />
+                        </IconButton>
+                    )}
+                </div>
             </Line>
         </LineContextProvider>
     );

--- a/frontend/src/components/adapters/ShellAdapter.tsx
+++ b/frontend/src/components/adapters/ShellAdapter.tsx
@@ -42,6 +42,7 @@ export const WorldShellAdapter = ({ mapId }: { mapId: string }) => {
         createOutlinerInScenario({
             id: `stack_shell_${e}`,
             properties: {
+                show: true,
                 scenario: mapId,
                 docked: false,
                 transient: true,

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -20,9 +20,8 @@ const getFirstWord = (s?: string) => {
 export const StackAdapter = () => {
     const {
         app: { outliners },
-        setActiveOutliner,
     } = useAppContext();
-    const { outliner } = useOutlinerContext();
+    const { outliner, setVisible } = useOutlinerContext();
     const {
         scenario: { worldCreated, change },
         addFeatureToChange,
@@ -45,7 +44,7 @@ export const StackAdapter = () => {
     // hack stop
 
     const handleOpenChange = (open: boolean) => {
-        setActiveOutliner(outliner.id, open);
+        setVisible(open);
         setOpen(open);
     };
 
@@ -95,6 +94,10 @@ export const StackAdapter = () => {
         ? getFirstWord(headerTitleString)
         : analysisTitle;
     // hack stop
+
+    const queryLayers = outliner.query?.data?.proto.layers;
+    const geoJsons =
+        outliner.query?.data?.geoJSON || outliner.query?.data?.proto.geoJSON;
 
     return (
         <>
@@ -152,6 +155,10 @@ export const StackAdapter = () => {
                                 substack={firstSubstack}
                                 collapsible={firstSubstack.collapsable}
                                 close={!outliner.properties.docked}
+                                show={
+                                    !outliner.properties.docked &&
+                                    (!!queryLayers || !!geoJsons)
+                                }
                                 origin={originFirstSubstack}
                                 analysisTitle={analysisTitle}
                             />

--- a/frontend/src/components/adapters/StackAdapter.tsx
+++ b/frontend/src/components/adapters/StackAdapter.tsx
@@ -56,7 +56,7 @@ export const StackAdapter = () => {
         return (
             <Stack>
                 <Stack.Trigger>
-                    <Line className="flex flex-nowrap ">
+                    <Line className="flex flex-nowrap w-80 ">
                         <div className="loader shrink-0" />
                         <div className="text-graphite-60 italic text-nowrap overflow-hidden overflow-ellipsis">
                             {outliner.request?.expression}
@@ -150,7 +150,7 @@ export const StackAdapter = () => {
                     )}
                 >
                     {firstSubstack && (
-                        <Stack.Trigger>
+                        <Stack.Trigger className="w-full">
                             <SubstackAdapter
                                 substack={firstSubstack}
                                 collapsible={firstSubstack.collapsable}
@@ -165,7 +165,7 @@ export const StackAdapter = () => {
                         </Stack.Trigger>
                     )}
                     {otherSubstacks && (
-                        <Stack.Content>
+                        <Stack.Content className="w-full">
                             {otherSubstacks.map((substack, i) => {
                                 return (
                                     <SubstackAdapter

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -9,12 +9,14 @@ export const SubstackAdapter = ({
     substack,
     collapsible = false,
     close,
+    show,
     origin,
     analysisTitle,
 }: {
     substack: SubstackProto;
     collapsible?: boolean;
     close?: boolean;
+    show?: boolean;
     origin?: SubstackProto;
     analysisTitle?: string; // @TODO: remove this, it's a hack to get the analysis title
 }) => {
@@ -72,6 +74,10 @@ export const SubstackAdapter = ({
                 >
                     <LineAdapter
                         line={substack.lines[0]}
+                        actions={{
+                            close: false,
+                            show: false,
+                        }}
                         //changeable={changeable}
                     />
                 </Stack.Trigger>
@@ -84,7 +90,10 @@ export const SubstackAdapter = ({
                             <LineAdapter
                                 key={i}
                                 line={l}
-                                close={close && i === 0}
+                                actions={{
+                                    close: !!close && i === 0,
+                                    show: !!show && i === 0,
+                                }}
                             />
                         );
                     })}

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -64,11 +64,16 @@ export const SubstackAdapter = ({
     if (!substack.lines) return null;
 
     return (
-        <Stack collapsible={collapsible} open={open} onOpenChange={setOpen}>
+        <Stack
+            collapsible={collapsible}
+            open={open}
+            onOpenChange={setOpen}
+            className="w-full"
+        >
             {(header || collapsible) && (
                 <Stack.Trigger
                     className={twMerge(
-                        'border-b border-graphite-30 cursor-pointer',
+                        'w-full border-b border-graphite-30 cursor-pointer',
                         open ? 'border-b-0' : ''
                     )}
                 >
@@ -83,7 +88,10 @@ export const SubstackAdapter = ({
                 </Stack.Trigger>
             )}
 
-            <Stack.Content className="text-sm max-h-80 " header={!!header}>
+            <Stack.Content
+                className="text-sm max-h-80 w-full "
+                header={!!header}
+            >
                 {!isHistogram &&
                     contentLines.map((l, i) => {
                         return (

--- a/frontend/src/components/system/Line.stories.tsx
+++ b/frontend/src/components/system/Line.stories.tsx
@@ -56,7 +56,7 @@ export const Line: Story = {
         <div className="flex flex-col gap-8">
             <div>
                 <h3 className="mb-2">Empty Line</h3>
-                <LineComponent>
+                <LineComponent className="w-80">
                     <div className="text-sm text-graphite-40">
                         {'< line contents >'}
                     </div>
@@ -65,7 +65,7 @@ export const Line: Story = {
             <div>
                 <h3 className="mb-2">Lines with Atoms</h3>
                 <div className="flex flex-col gap-2">
-                    <LineComponent>
+                    <LineComponent className="w-80">
                         <LabelledIcon>
                             <LabelledIcon.Icon>
                                 <Shop />
@@ -73,7 +73,7 @@ export const Line: Story = {
                             <LabelledIcon.Label>Collection</LabelledIcon.Label>
                         </LabelledIcon>
                     </LineComponent>
-                    <LineComponent className="justify-between">
+                    <LineComponent className="justify-between w-80">
                         <LabelledIcon>
                             <LabelledIcon.Icon>
                                 <School />
@@ -82,7 +82,7 @@ export const Line: Story = {
                         </LabelledIcon>
                         <LineComponent.Value>3</LineComponent.Value>
                     </LineComponent>
-                    <LineComponent>
+                    <LineComponent className="w-80">
                         <LabelledIcon>
                             <LabelledIcon.Icon>
                                 <Grocery />
@@ -94,7 +94,7 @@ export const Line: Story = {
                             <SelectForStory type="grocery" />
                         </div>
                     </LineComponent>
-                    <LineComponent>
+                    <LineComponent className="w-80">
                         <LabelledIcon>
                             <LabelledIcon.Icon>
                                 <Grocery />
@@ -108,13 +108,13 @@ export const Line: Story = {
                             <SelectForStory type="grocery" />
                         </div>
                     </LineComponent>
-                    <LineComponent>
+                    <LineComponent className="w-80">
                         <Header>
                             <Header.Label>Header</Header.Label>
                             <Header.Actions close share />
                         </Header>
                     </LineComponent>
-                    <LineComponent>
+                    <LineComponent className="w-80">
                         <LineComponent.Button icon={<PlusIcon />}>
                             <LabelledIcon>
                                 <LabelledIcon.Icon>

--- a/frontend/src/components/system/Line.tsx
+++ b/frontend/src/components/system/Line.tsx
@@ -64,7 +64,7 @@ const Root = React.forwardRef<HTMLDivElement, LineProps>(
             <div
                 {...props}
                 className={twMerge(
-                    'line hover:has-[.tag]:bg-white has-[.expression]:bg-graphite-10 has-[.shell]:p-0 p-3 border-b flex items-center gap-1 w-80 min-h-11 box-border border-graphite-30 bg-white hover:bg-graphite-10 focus:bg-graphite-10 cursor-default has-[.line-button]:cursor-pointer has-[.line-button]:p-0',
+                    'line hover:has-[.tag]:bg-white has-[.expression]:bg-graphite-10 has-[.shell]:p-0 p-3 border-b flex items-center gap-1  w-full min-h-11 box-border border-graphite-30 bg-white hover:bg-graphite-10 focus:bg-graphite-10 cursor-default has-[.line-button]:cursor-pointer has-[.line-button]:p-0 ',
                     className
                 )}
                 ref={forwardedRef}

--- a/frontend/src/components/system/Stack.tsx
+++ b/frontend/src/components/system/Stack.tsx
@@ -27,10 +27,10 @@ const Root = React.forwardRef<
                 {...omit(props, 'collapsible')}
                 ref={forwardedRef}
                 className={twMerge(
-                    'border box-border border-graphite-30',
+                    'border box-border border-graphite-30  w-80',
                     props.open &&
                         props.collapsible &&
-                        'border border-graphite-50 transition-colors w-fit  ',
+                        'border border-graphite-50 transition-colors  ',
                     'stack ',
                     '[&_.line]:border-t-0 [&_.stack]:border-0',
                     className
@@ -60,7 +60,7 @@ const Trigger = React.forwardRef<
             ref={forwardedRef}
             className={twMerge(
                 collapsible &&
-                    'cursor-pointer select-none [&_.line]:data-[state=closed]:border-b-0',
+                    'cursor-pointer overflow-hidden select-none [&_.line]:data-[state=closed]:border-b-0',
                 className
             )}
         >

--- a/frontend/src/lib/context/app.tsx
+++ b/frontend/src/lib/context/app.tsx
@@ -44,6 +44,7 @@ export const AppContext = createContext<{
     addScenario: () => void;
     removeScenario: (id: string) => void;
     setActiveScenario: (id: string) => void;
+    setVisibleOutliner: (id: string, value: boolean) => void;
     addComparator: ({
         baseline,
         scenarios,
@@ -60,6 +61,7 @@ export const AppContext = createContext<{
     setApp: () => {},
     setFixedOutliner: () => {},
     setActiveOutliner: () => {},
+    setVisibleOutliner: () => {},
     createOutliner: () => {},
     moveOutliner: () => {},
     closeOutliner: () => {},
@@ -214,6 +216,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
                 draft.outliners[`docked-${i}`] = {
                     id: `docked-${i}`,
                     properties: {
+                        show: false,
                         scenario: 'baseline',
                         docked: true,
                         transient: false,
@@ -255,6 +258,18 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
         ) => {
             setApp((draft) => {
                 draft.outliners[id].active = value;
+            });
+        },
+        [setApp]
+    );
+
+    const setVisibleOutliner = useCallback(
+        (
+            id: keyof AppStore['outliners'],
+            value: AppStore['outliners'][string]['properties']['show']
+        ) => {
+            setApp((draft) => {
+                draft.outliners[id].properties.show = value;
             });
         },
         [setApp]
@@ -305,6 +320,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
         app,
         setApp,
         setActiveOutliner,
+        setVisibleOutliner,
         setFixedOutliner,
         moveOutliner,
         closeOutliner,

--- a/frontend/src/lib/context/comparator.tsx
+++ b/frontend/src/lib/context/comparator.tsx
@@ -83,6 +83,7 @@ export const ComparatorProvider = ({
             createOutliner({
                 id: `${comparator.id}-baseline`,
                 properties: {
+                    show: false,
                     comparison: comparator.id,
                     scenario: comparator?.baseline as $FixMe,
                     docked: false,
@@ -118,6 +119,7 @@ export const ComparatorProvider = ({
                 createOutliner({
                     id: `${comparator.id}-scenario-${i}`,
                     properties: {
+                        show: false,
                         comparison: comparator.id,
                         origin: `${comparator.id}-baseline`,
                         scenario: scenarioId as $FixMe,

--- a/frontend/src/lib/context/outliner.tsx
+++ b/frontend/src/lib/context/outliner.tsx
@@ -27,6 +27,7 @@ export type OutlinerSpec = {
     id: string;
     active?: boolean;
     properties: {
+        show: boolean;
         docked: boolean;
         transient: boolean;
         coordinates: { x: number; y: number };
@@ -66,6 +67,7 @@ const OutlinerContext = createContext<{
     choiceChips: Record<number, Chip>;
     setChoiceChipValue: (index: number, value: number) => void;
     close: () => void;
+    setVisible: (show: boolean) => void;
 }>({
     outliner: {} as OutlinerStore,
     setProperty: () => {},
@@ -76,6 +78,7 @@ const OutlinerContext = createContext<{
     choiceChips: {},
     setChoiceChipValue: () => {},
     close: () => {},
+    setVisible: () => {},
 });
 
 /**
@@ -109,6 +112,12 @@ export const OutlinerProvider = ({
     const close = useCallback(() => {
         closeOutliner(outliner.id);
     }, [closeOutliner, outliner.id]);
+
+    const setVisible = (show: boolean) => {
+        setApp((draft) => {
+            draft.outliners[outliner.id].properties.show = show;
+        });
+    };
 
     const [choiceChips, setChoiceChips] = useImmer<Record<number, Chip>>({});
 
@@ -357,6 +366,7 @@ export const OutlinerProvider = ({
                 choiceChips,
                 setChoiceChipValue,
                 close,
+                setVisible,
             }}
         >
             {children}

--- a/frontend/src/lib/context/scenario.tsx
+++ b/frontend/src/lib/context/scenario.tsx
@@ -353,20 +353,21 @@ export const ScenarioProvider = ({
 
     const geoJSON = useMemo(() => {
         return Object.values(scenarioOutliners)
+            .filter((outliner) => outliner.properties.show)
             .flatMap((outliner) => outliner.data?.geoJSON || [])
             .flat();
     }, [scenarioOutliners]);
 
     const queryLayers = useMemo(() => {
         const activeLayer = Object.values(scenarioOutliners).find(
-            (outliner) => outliner.active
+            (outliner) => outliner.properties.show
         );
         return Object.values(scenarioOutliners).flatMap((outliner) => {
             return (outliner.data?.proto.layers?.map((l) => ({
                 layer: l,
                 histogram: outliner.histogram,
                 show: !isUndefined(activeLayer)
-                    ? outliner.active
+                    ? outliner.properties.show
                     : activeComparator &&
                       outliner.properties.comparison === activeComparator.id,
             })) || []) as QueryLayer[];
@@ -402,8 +403,8 @@ export const ScenarioProvider = ({
         (map: MapRef) => {
             const features = Object.values(scenarioOutliners)
                 .filter(
-                    (outliner) =>
-                        outliner.active || outliner.properties.transient
+                    (outliner) => outliner.properties.show
+                    //outliner.active || outliner.properties.transient
                 )
                 .flatMap((outliner) => outliner.data?.geoJSON || [])
                 .flatMap((f: $FixMe) => {


### PR DESCRIPTION
### Goal

The goal is to add a visibility toggle to outlines. This toggle allows users to turn the respective outliner's map layers/markers on or off.

### Description

When there are multiple outlines in the view, each with a corresponding histogram or other geographical layers, we need a way to control what is displayed on the map. For example, displaying all the histograms at once could lead to overlap issues.
Previously, visibility was determined by whether an outlier was active, which overlapped with the drag behavior. So, we are adding a new "show" property to manage visibility, which the user can control via the toggle.


https://github.com/diagonalworks/diagonal-b6/assets/23224854/94b1c5a5-c278-4d82-b290-2f83adfa01d5

