### PR TITLE
feat: don't encode url search params

### DIFF
--- a/frontend/src/hooks/usePersistURL.ts
+++ b/frontend/src/hooks/usePersistURL.ts
@@ -79,8 +79,13 @@ export const usePersistURL = <T>(
                 searchParams.set(key, value);
             }
         });
-
-        url.search = new URLSearchParams(searchParams).toString();
+        const newParams = new URLSearchParams(searchParams).toString();
+        /**
+         * we don't encode the URL params because:
+         * 1. We want to keep the URL human-readable and editable
+         * 2. We want to avoid double encoding issues
+         */
+        url.search = decodeURIComponent(newParams);
         window.history.pushState({}, '', url.toString());
     }, debounceWait);
 


### PR DESCRIPTION
### Goal

This PR removes the encoding of the URL search parameters.

### Description 

We choose to no longer encode the URL params for two reasons:
- We want to keep the URL human-readable and editable
- On the production environment, we noticed flaky behavior of URL encoding/decoding. In this approach we want to avoid any possible double encoding happening.
