### PR TITLE
Add feature flag for scenarios

### DIFF
--- a/frontend/src/components/Workspace.tsx
+++ b/frontend/src/components/Workspace.tsx
@@ -9,6 +9,7 @@ import ComparisonCard from '@/features/scenarios/components/ComparisonCard';
 import { Tabs } from '@/features/scenarios/components/Tabs';
 import { useComparisonsStore } from '@/features/scenarios/stores/comparisons';
 import { useTabsStore } from '@/features/scenarios/stores/tabs';
+import useFeatureFlag from '@/hooks/useFeatureFlag';
 import { useViewStore, useViewURLStorage } from '@/stores/view';
 import { useWorkspaceURLStorage } from '@/stores/workspace';
 
@@ -29,6 +30,8 @@ export default function Workspace() {
         state.actions.setView,
         state.view,
     ]);
+
+    const isScenariosEnabled = useFeatureFlag('scenarios');
 
     const startup = useStartup();
 
@@ -106,7 +109,11 @@ export default function Workspace() {
                             onValueChange={tabActions.rename}
                         />
                     ))}
-                    {rightTabs.length === 0 && (
+                    {/**
+                     * Only show the add scenario button if there are no right tabs and scenarios are enabled.
+                     * This is the entrypoint for the scenarios feature, we hide it if the feature is disabled.
+                     */}
+                    {rightTabs.length === 0 && isScenariosEnabled && (
                         <button
                             onClick={() => {
                                 handleAddScenario();

--- a/frontend/src/hooks/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,22 @@
+import { isUndefined } from 'lodash';
+import { useEffect, useState } from 'react';
+
+import { $IntentionalAny } from '@/utils/defs';
+
+const useFeatureFlag = (flagName: string): boolean => {
+    const [flagValue, setFlagValue] = useState<boolean>(false);
+
+    useEffect(() => {
+        const envVariableName = `VITE_FEATURES_${flagName.toUpperCase()}`;
+        const flag = import.meta.env[envVariableName as $IntentionalAny];
+
+        // If the flag is not explicitly set to false, we consider it to be true
+        if (flag === 'true' || isUndefined(flag)) {
+            setFlagValue(true);
+        }
+    }, [flagName]);
+
+    return flagValue;
+};
+
+export default useFeatureFlag;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_FEATURES_SCENARIOS: boolean;
+    // more env variables...
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### Goal

Add logic for feature flags, and add a flag for the scenarios feature.
This is a first step, meaning we're temporarily relying on environment variables, and these flags only apply to the front end.

### Description

We are currently using environment variables to decide whether to enable or disable features. These variables should be prefixed "VITE_" to [make them accessible to the frontend code](https://vitejs.dev/guide/env-and-mode).

Preferably, we should not rely on environment variables. Instead, this information should be sent from the backend during startup.

```
export type StartupResponse = {
    version?: string;
    ...
    features: {
       scenarios: boolean
    }   
};
```
And the feature flags could be passed as a [UI option](https://github.com/diagonalworks/diagonal-b6/blob/931bff9931972b1124372f8c6ac4cdf51e04ad72/src/diagonal.works/b6/ui/ui.go#L36) when launching b6.

```
$ bin/darwin/arm64/b6  [...] --enable-scenarios
```
