### PR TITLE
up backend version

### DIFF
--- a/src/diagonal.works/b6/ingest/compact/encoding.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding.go
@@ -22,7 +22,7 @@ import (
 
 // A semver 2.0.0 compliant version for the index format. Indicies generated
 // with a different major version will fail to load.
-const Version = "4.0.0"
+const Version = "5.0.0"
 
 func init() {
 	if l := encoding.MarshalledSize(Header{}); l != HeaderLength {


### PR DESCRIPTION
compacts no longer compatible after tag value is expression + no longer un/marsh via string changes

https://github.com/diagonalworks/diagonal-b6/commit/26ecf70f97f4c5f318508bdc2b8a331f3a261bb6
https://github.com/diagonalworks/diagonal-b6/commit/51bcb67c88e29cf1ea761dbb805fd732a2c86657