### PR TITLE
Support writing output from b6-ingest-gdal to cloud.

### DIFF
--- a/src/diagonal.works/b6/cmd/b6-ingest-osm/b6-ingest-osm.go
+++ b/src/diagonal.works/b6/cmd/b6-ingest-osm/b6-ingest-osm.go
@@ -21,7 +21,7 @@ func main() {
 	output := flag.String("output", "tmp/out", "Output filename")
 	cores := flag.Int("cores", runtime.NumCPU(), "Available cores")
 	memory := flag.Bool("memory", true, "Use memory for intermediate data")
-	scratch := flag.String("scratch", ".", "Directory for temporary files, for --memory=false")
+	scratch := flag.String("scratch", ".", "Directory for temporary files, for --memory=false  or writing to cloud")
 	flag.Parse()
 
 	var err error

--- a/src/diagonal.works/b6/ingest/gdal/source.go
+++ b/src/diagonal.works/b6/ingest/gdal/source.go
@@ -45,6 +45,10 @@ var (
 		return b6.FeatureIDFromUKONSCode(value, 2011, t), nil
 	}
 
+	UKONS2021IDStrategy IDStrategy = func(value string, i int, t b6.FeatureType, ns b6.Namespace) (b6.FeatureID, error) {
+		return b6.FeatureIDFromUKONSCode(value, 2021, t), nil
+	}
+
 	UKONS2022IDStrategy IDStrategy = func(value string, i int, t b6.FeatureType, ns b6.Namespace) (b6.FeatureID, error) {
 		return b6.FeatureIDFromUKONSCode(value, 2022, t), nil
 	}


### PR DESCRIPTION
Also add an ID strategy for ONS 2021 boundaries.