### PR TITLE
Include a compact encoding version in index filenames.

### DIFF
--- a/docker/Dockerfile.b6.inc
+++ b/docker/Dockerfile.b6.inc
@@ -15,8 +15,8 @@ RUN TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH make -C /build
 RUN TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH make -C /build test
 RUN TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH make -C /build python-test
 RUN cd /build/python; python3 -m build
-RUN /build/bin/$TARGETOS/$TARGETARCH/b6-ingest-osm --input=/build/data/tests/camden.osm.pbf --output=/build/data/camden.index
-RUN /build/bin/$TARGETOS/$TARGETARCH/b6-connect --input=/build/data/camden.index --output=/build/data/camden.connected.index
+RUN /build/bin/$TARGETOS/$TARGETARCH/b6-ingest-osm --input=/build/data/tests/camden.osm.pbf --output=/build/data/camden.VERSION.index
+RUN /build/bin/$TARGETOS/$TARGETARCH/b6-connect --input=/build/data/camden.VERSION.index --output=/build/data/camden.connected.VERSION.index
 FROM ubuntu:mantic
 ARG TARGETOS
 ARG TARGETARCH

--- a/src/diagonal.works/b6/ingest/compact/build.go
+++ b/src/diagonal.works/b6/ingest/compact/build.go
@@ -53,37 +53,37 @@ type Output interface {
 type FileOutput string
 
 func (f FileOutput) Read() (ReadCloserAt, error) {
-	r, err := mmap.Open(string(f))
+	r, err := mmap.Open(includeVersion(string(f)))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to mmap %s: %w", f, err)
+		return nil, fmt.Errorf("failed to mmap %s: %w", f, err)
 
 	}
 	return r, nil
 }
 
 func (f FileOutput) Write() (WriteCloserAt, error) {
-	w, err := os.OpenFile(string(f), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	w, err := os.OpenFile(includeVersion(string(f)), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open %s for write: %w", f, err)
+		return nil, fmt.Errorf("failed to open %s for write: %w", f, err)
 	}
 	return w, nil
 }
 
 func (f FileOutput) ReadWrite() (ReadWriteCloserAt, error) {
-	w, err := os.OpenFile(string(f), os.O_RDWR, 0644)
+	w, err := os.OpenFile(includeVersion(string(f)), os.O_RDWR, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open %s for write: %w", f, err)
+		return nil, fmt.Errorf("failed to open %s for write: %w", f, err)
 	}
 	return w, nil
 }
 
 func (f FileOutput) Bytes() ([]byte, io.Closer, error) {
-	m, err := encoding.Mmap(string(f))
+	m, err := encoding.Mmap(includeVersion(string(f)))
 	return m.Data, m, err
 }
 
 func (f FileOutput) Len() (int64, error) {
-	info, err := os.Stat(string(f))
+	info, err := os.Stat(includeVersion(string(f)))
 	if err != nil {
 		return -1, err
 	}
@@ -1121,7 +1121,7 @@ func isCloudFilename(filename string) bool {
 
 func MaybeWriteToCloud(options *Options) (func() error, error) {
 	if isCloudFilename(options.OutputFilename) {
-		originalOutputFilename := options.OutputFilename
+		originalOutputFilename := includeVersion(options.OutputFilename)
 		if options.ScratchDirectory == "" {
 			return nil, errors.New("need scratch directory")
 		}

--- a/src/diagonal.works/b6/ingest/compact/encoding.go
+++ b/src/diagonal.works/b6/ingest/compact/encoding.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -16,6 +17,7 @@ import (
 	pb "diagonal.works/b6/proto"
 	"diagonal.works/b6/search"
 	"github.com/golang/geo/s2"
+	"golang.org/x/mod/semver"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -23,6 +25,16 @@ import (
 // A semver 2.0.0 compliant version for the index format. Indicies generated
 // with a different major version will fail to load.
 const Version = "5.0.0"
+
+const FilenameVersionPattern = "VERSION"
+
+func includeVersion(f string) string {
+	major := semver.Major("v" + Version)
+	if major == "" {
+		major = "v0"
+	}
+	return strings.ReplaceAll(f, FilenameVersionPattern, major)
+}
 
 func init() {
 	if l := encoding.MarshalledSize(Header{}); l != HeaderLength {

--- a/src/diagonal.works/b6/ingest/compact/read.go
+++ b/src/diagonal.works/b6/ingest/compact/read.go
@@ -99,6 +99,7 @@ func ReadWorld(input string, o *ingest.BuildOptions) (b6.World, error) {
 	toClose := make([]io.Closer, len(sources))
 
 	for i, s := range sources {
+		s = includeVersion(s)
 		var hasCompactPrefix, hasOSMPRefix bool
 		if hasCompactPrefix = strings.HasPrefix(s, "compact:"); hasCompactPrefix {
 			s = strings.TrimPrefix(s, "compact:")
@@ -111,7 +112,7 @@ func ReadWorld(input string, o *ingest.BuildOptions) (b6.World, error) {
 		}
 		toClose[i] = fs
 		var children []string
-		if strings.Index(s, "*") >= 0 {
+		if strings.Contains(s, "*") {
 			children, err = fs.List(ctx, s)
 		} else {
 			children, err = fs.List(ctx, s+"/*")


### PR DESCRIPTION
Include a compact encoding version in index filenames, by replacing VERSION in filenames with the major component of the semver (eg v5).