### PR TITLE
feat: add copy to clipboard to outliners

### DIFF
--- a/frontend/src/components/Outliner.tsx
+++ b/frontend/src/components/Outliner.tsx
@@ -105,6 +105,7 @@ function Outliner({
                                 collapsible={firstSubstack.collapsable}
                                 close={!outliner.properties.docked}
                                 show={!outliner.properties.docked}
+                                copy
                             />
                         </Stack.Trigger>
                     )}

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -1,6 +1,7 @@
 import {
     ComponentInstanceIcon,
     ComponentNoneIcon,
+    CopyIcon,
     Cross1Icon,
 } from '@radix-ui/react-icons';
 import React from 'react';
@@ -24,6 +25,7 @@ export const LineAdapter = ({
     actions?: {
         show?: boolean;
         close?: boolean;
+        copy?: boolean;
     };
 }) => {
     const clickable =
@@ -98,40 +100,59 @@ export const LineAdapter = ({
                         </span>
                     )}
                     {line.tags && <Tags tagLine={line.tags} />}
-                    {actions && (actions.show || actions.close) && (
-                        <div className="flex gap-1">
-                            {actions.show && (
-                                <Tooltip content={'Toggle visiblity'}>
+                    {actions &&
+                        (actions.show || actions.close || actions.copy) && (
+                            <div className="flex gap-1">
+                                {actions.copy && (
+                                    <Tooltip content={'Copy to clipboard'}>
+                                        <IconButton
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                navigator.clipboard.writeText(
+                                                    line.value?.atom?.value ??
+                                                        outliner?.request
+                                                            ?.expression ??
+                                                        ''
+                                                );
+                                            }}
+                                        >
+                                            <CopyIcon />
+                                        </IconButton>
+                                    </Tooltip>
+                                )}
+                                {actions.show && (
+                                    <Tooltip content={'Toggle visiblity'}>
+                                        <IconButton
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                e.preventDefault();
+                                                toggleVisibility();
+                                            }}
+                                        >
+                                            {outliner &&
+                                            outliner.properties.show ? (
+                                                <ComponentInstanceIcon />
+                                            ) : (
+                                                <ComponentNoneIcon />
+                                            )}
+                                        </IconButton>
+                                    </Tooltip>
+                                )}
+                                {actions.close && (
                                     <IconButton
                                         onClick={(e) => {
-                                            e.stopPropagation();
                                             e.preventDefault();
-                                            toggleVisibility();
+                                            e.stopPropagation();
+                                            closeFn();
                                         }}
+                                        className="close"
                                     >
-                                        {outliner &&
-                                        outliner.properties.show ? (
-                                            <ComponentInstanceIcon />
-                                        ) : (
-                                            <ComponentNoneIcon />
-                                        )}
+                                        <Cross1Icon />
                                     </IconButton>
-                                </Tooltip>
-                            )}
-                            {actions.close && (
-                                <IconButton
-                                    onClick={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        closeFn();
-                                    }}
-                                    className="close"
-                                >
-                                    <Cross1Icon />
-                                </IconButton>
-                            )}
-                        </div>
-                    )}
+                                )}
+                            </div>
+                        )}
                 </Wrapper>
             </Line>
         </LineContextProvider>

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -13,12 +13,14 @@ export const SubstackAdapter = ({
     collapsible = false,
     close,
     show,
+    copy,
     analysisTitle,
 }: {
     substack: SubstackProto;
     collapsible?: boolean;
     close?: boolean;
     show?: boolean;
+    copy?: boolean;
     analysisTitle?: string; // @TODO: remove this, it's a hack to get the analysis title
 }) => {
     const [open, setOpen] = useState(collapsible ? false : true);
@@ -100,6 +102,7 @@ export const SubstackAdapter = ({
                                 actions={{
                                     close: close && i === 0,
                                     show: show && i === 0,
+                                    copy: copy && i === 0,
                                 }}
                             />
                         );


### PR DESCRIPTION
### Goal 

This feature will enable users to copy the value or expression of an outliner to the clipboard.

### Description

We are introducing a new line action type called 'copy'. When enabled, it will display an icon button for the copy action. The copy action function will copy either the value if the line is an atomic value or the expression of the respective outliner. This copy action will be added only to the first line of an outliner, similar to the close and toggle visibility actions.