### PR TITLE
Add shell history

### DIFF
--- a/frontend/src/components/adapters/ShellAdapter.tsx
+++ b/frontend/src/components/adapters/ShellAdapter.tsx
@@ -3,13 +3,19 @@ import { useMemo } from 'react';
 import { Shell } from '@/components/system/Shell';
 import { useMap } from '@/hooks/useMap';
 import { useStackContext } from '@/lib/context/stack';
+import { useOutlinersStore } from '@/stores/outliners';
+import { useWorldStore } from '@/stores/worlds';
 import { ShellLineProto } from '@/types/generated/ui';
 
 export const ShellAdapter = ({ shell }: { shell?: ShellLineProto }) => {
-    const { evaluateExpressionInOutliner } = useStackContext();
+    const { evaluateExpressionInOutliner, outliner } = useStackContext();
+    const { addToShellHistory } = useOutlinersStore((state) => state.actions);
 
     const handleSubmit = (e: string) => {
         evaluateExpressionInOutliner(e);
+        if (outliner) {
+            addToShellHistory(outliner.id, e);
+        }
     };
 
     const functions = useMemo(() => {
@@ -23,15 +29,30 @@ export const ShellAdapter = ({ shell }: { shell?: ShellLineProto }) => {
         );
     }, [shell?.functions]);
 
-    return <Shell functions={functions} onSubmit={handleSubmit} />;
+    return (
+        <Shell
+            functions={functions}
+            onSubmit={handleSubmit}
+            history={outliner?.properties.shellHistory}
+        />
+    );
 };
 
 export const WorldShellAdapter = ({ mapId }: { mapId: string }) => {
     const [{ evaluateExpression }] = useMap({ id: mapId });
+    const world = useWorldStore((state) => state.worlds[mapId]);
+    const { addToShellHistory } = useWorldStore((state) => state.actions);
 
     const handleSubmit = (e: string) => {
         evaluateExpression(e);
+        addToShellHistory(mapId, e);
     };
 
-    return <Shell functions={[]} onSubmit={handleSubmit} />;
+    return (
+        <Shell
+            functions={[]}
+            onSubmit={handleSubmit}
+            history={world.shellHistory}
+        />
+    );
 };

--- a/frontend/src/components/system/Shell.tsx
+++ b/frontend/src/components/system/Shell.tsx
@@ -24,6 +24,7 @@ export function Shell({
     functions,
     className,
     placeholder,
+    history,
 }: {
     /** The list of functions that can be executed. */
     functions: FunctionB6[];
@@ -31,8 +32,10 @@ export function Shell({
     onSubmit?: (expression: string) => void;
     className?: string;
     placeholder?: string;
+    history?: string[];
 }) {
     const inputRef = useRef<HTMLInputElement>(null);
+    const [historyIndex, setHistoryIndex] = useState(0);
     const keywordsRef = useRef<HTMLDivElement>(null);
     const [currentWord, setCurrentWord] = useState<{
         word: string;
@@ -103,6 +106,27 @@ export function Shell({
                             'input caret-ultramarine-60 bg-transparent text-transparent focus:outline-none'
                         )}
                         onKeyDown={(evt) => {
+                            if (evt.key === 'ArrowUp') {
+                                if (history && historyIndex < history.length) {
+                                    setInput(
+                                        history![
+                                            history.length - 1 - historyIndex
+                                        ]
+                                    );
+                                    setHistoryIndex(historyIndex + 1);
+                                }
+                            }
+                            if (evt.key === 'ArrowDown') {
+                                if (history && historyIndex > 0) {
+                                    setInput(
+                                        history![history.length - historyIndex]
+                                    );
+                                    setHistoryIndex(historyIndex - 1);
+                                }
+                                if (historyIndex === 0) {
+                                    setInput('');
+                                }
+                            }
                             if (
                                 evt.key === 'Enter' &&
                                 functionResults.length === 0 &&

--- a/frontend/src/stores/outliners.ts
+++ b/frontend/src/stores/outliners.ts
@@ -22,6 +22,7 @@ export interface OutlinerSpec {
             x: number;
             y: number;
         };
+        shellHistory?: string[];
     };
     // The request to fetch data for the outliner
     request?: UIRequestProto;
@@ -86,6 +87,14 @@ interface OutlinersStore {
          * @returns An array of outliner specs
          */
         getByWorld: (world: World['id']) => OutlinerSpec[];
+
+        /**
+         * Add a shell command to the history of an outliner
+         * @param id
+         * @param shell
+         * @returns
+         */
+        addToShellHistory: (id: string, shell: string) => void;
     };
 }
 
@@ -146,6 +155,14 @@ export const createOutlinersStore: ImmerStateCreator<
         setRequest: (id, request) => {
             set((state) => {
                 state.outliners[id].request = request;
+            });
+        },
+        addToShellHistory: (id, shell) => {
+            set((state) => {
+                state.outliners[id].properties.shellHistory = [
+                    ...(state.outliners[id].properties.shellHistory ?? []),
+                    shell,
+                ];
             });
         },
     },

--- a/frontend/src/stores/worlds.ts
+++ b/frontend/src/stores/worlds.ts
@@ -16,6 +16,7 @@ export interface World {
     id: string;
     featureId: FeatureIDProto;
     tiles: string;
+    shellHistory?: string[];
 }
 
 export interface WorldsStore {
@@ -47,6 +48,13 @@ export interface WorldsStore {
          * @returns void
          */
         setTiles: (worldId: string, tiles: string) => void;
+        /**
+         * Add a shell command to the history of a world
+         * @param worldId - The id of the world to add the command to
+         * @param shell - The shell command to add
+         * @returns void
+         */
+        addToShellHistory: (worldId: string, shell: string) => void;
     };
 }
 
@@ -73,6 +81,14 @@ export const createWorldStore: ImmerStateCreator<WorldsStore, WorldsStore> = (
         setTiles: (worldId, tiles) => {
             set((state) => {
                 state.worlds[worldId].tiles = tiles;
+            });
+        },
+        addToShellHistory: (worldId, shell) => {
+            set((state) => {
+                state.worlds[worldId].shellHistory = [
+                    ...(state.worlds[worldId].shellHistory ?? []),
+                    shell,
+                ];
             });
         },
     },


### PR DESCRIPTION
### Goal

The goal is to enable the use of arrow keys to navigate the previous shell commands by adding history to the shell.

### Description

History is added to the shell and is scoped to separate histories for individual outliner shells and global history for the world shell. The command history is stored in the corresponding outliner store for outliner shells and in the world store for global shells. This history is then passed on to the `<Shell>` component as a prop.