### PR TITLE
Require explicit feature flags

### DIFF
--- a/frontend/src/hooks/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag.ts
@@ -10,8 +10,8 @@ const useFeatureFlag = (flagName: string): boolean => {
         const envVariableName = `VITE_FEATURES_${flagName.toUpperCase()}`;
         const flag = import.meta.env[envVariableName as $IntentionalAny];
 
-        // If the flag is not explicitly set to false, we consider it to be true
-        if (flag === 'true' || isUndefined(flag)) {
+        // If the flag is not explicitly set to true, we consider it to be false
+        if (flag === 'true') {
             setFlagValue(true);
         }
     }, [flagName]);


### PR DESCRIPTION
@gacafe This change will mean that, by default, the nightly, and other builds, do _not_ include any feature-flagged behaviour (namely, at present, scenarios).

In the future, it will mean that if any of these are required, they will need to be enabled specifically, in the appropriate place, via the appropriate vite flag; something like:


```shell
VITE_FEATURES_SCENARIOS=true pnpm build ...
```

> [!Caution]  
> This is, of course, a breaking change. The "scenarios" tab will be disabled, on _all builds_, unless explicitly enabled.


**Trivia**:
You can see how to use these flags at _JavaScript build time_ over in the [add-nix](https://github.com/diagonalworks/diagonal-b6/pull/295) branch in [this recent commit](https://github.com/diagonalworks/diagonal-b6/pull/295/commits/ee246e847c92e8c6b8ce16ce6634543852643cfa#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R92).