### PR TITLE
Fix evaluateNode from docked outliner

### DIFF
--- a/frontend/src/components/Outliner.tsx
+++ b/frontend/src/components/Outliner.tsx
@@ -161,7 +161,7 @@ function Outliner({
                                 collapsible={firstSubstack.collapsable}
                                 close={!outliner.properties.docked}
                                 show={!outliner.properties.docked}
-                                copy
+                                copy={!outliner.properties.docked}
                             />
                         </Stack.Trigger>
                     )}

--- a/frontend/src/components/OutlinersLayer.tsx
+++ b/frontend/src/components/OutlinersLayer.tsx
@@ -22,6 +22,11 @@ import { popOpen } from '@/utils/animations';
 
 import Outliner from './Outliner';
 
+export const OUTLINER_SPAWN_ORIGIN = {
+    x: 8,
+    y: 480,
+};
+
 const useOutlinerSensors = () => {
     const pointerSensor = useSensor(PointerSensor, {
         activationConstraint: {
@@ -155,8 +160,8 @@ const DraggableOutliner = ({
                           left: outliner.properties.coordinates.x + 4,
                       }
                     : {
-                          top: 280,
-                          left: 8,
+                          top: OUTLINER_SPAWN_ORIGIN.y,
+                          left: OUTLINER_SPAWN_ORIGIN.x,
                       }),
                 position: 'absolute',
             }}

--- a/frontend/src/components/adapters/SubstackAdapter.tsx
+++ b/frontend/src/components/adapters/SubstackAdapter.tsx
@@ -82,10 +82,7 @@ export const SubstackAdapter = ({
                         open ? 'border-b-0' : ''
                     )}
                 >
-                    <LineAdapter
-                        line={substack.lines[0]}
-                        //changeable={changeable}
-                    />
+                    <LineAdapter line={substack.lines[0]} />
                 </Stack.Trigger>
             )}
 

--- a/frontend/src/components/system/Line.tsx
+++ b/frontend/src/components/system/Line.tsx
@@ -22,7 +22,7 @@ const Value = React.forwardRef<
             <span
                 {...props}
                 className={twMerge(
-                    'text-graphite-100 text-base text-right',
+                    'text-graphite-100 text-base text-left',
                     className
                 )}
                 ref={forwardedRef}

--- a/frontend/src/lib/context/stack.tsx
+++ b/frontend/src/lib/context/stack.tsx
@@ -8,6 +8,7 @@ import {
 
 import { useStack } from '@/api/stack';
 import { OutlinerSpec, useOutlinersStore } from '@/stores/outliners';
+import { useWorldStore } from '@/stores/worlds';
 import { Event } from '@/types/events';
 import { NodeProto } from '@/types/generated/api';
 import { UIResponseProto } from '@/types/generated/ui';
@@ -63,6 +64,7 @@ export const StackContextProvider = ({
     origin,
 }: { outliner: OutlinerSpec; origin?: OutlinerSpec } & PropsWithChildren) => {
     const actions = useOutlinersStore((state) => state.actions);
+    const world = useWorldStore((state) => state.worlds[outliner.world]);
 
     const data = useStack(outliner.world, outliner.request, outliner.data);
 
@@ -91,8 +93,8 @@ export const StackContextProvider = ({
 
     const evaluateNode = useCallback(
         (node: NodeProto) => {
-            if (!outliner.request) return;
             const event: Event = 'oc';
+            const root = outliner.request?.root ?? world.featureId;
 
             actions.add({
                 id: `${outliner.id}-${event}-${JSON.stringify(node)}`,
@@ -105,12 +107,12 @@ export const StackContextProvider = ({
                     show: true,
                 },
                 request: {
-                    root: outliner.request.root,
+                    root,
                     node,
                     locked: true,
                     logEvent: event,
-                    logMapCenter: outliner.request.logMapCenter,
-                    logMapZoom: outliner.request.logMapZoom,
+                    logMapCenter: outliner.request?.logMapCenter,
+                    logMapZoom: outliner.request?.logMapZoom,
                     expression: '',
                 },
             });

--- a/frontend/src/stores/outliners.ts
+++ b/frontend/src/stores/outliners.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
+import { OUTLINER_SPAWN_ORIGIN } from '@/components/OutlinersLayer';
 import { ImmerStateCreator } from '@/lib/zustand';
 import { World } from '@/stores/worlds';
 import { UIRequestProto } from '@/types/generated/ui';
@@ -125,10 +126,11 @@ export const createOutlinersStore: ImmerStateCreator<
         move: (id, dx, dy) => {
             set((state) => {
                 const { coordinates } = state.outliners[id].properties;
-                if (!coordinates) return;
+                console.log(coordinates);
+
                 state.outliners[id].properties.coordinates = {
-                    x: coordinates.x + dx,
-                    y: coordinates.y + dy,
+                    x: (coordinates?.x ?? OUTLINER_SPAWN_ORIGIN.x) + dx,
+                    y: (coordinates?.y ?? OUTLINER_SPAWN_ORIGIN.y) + dy,
                 };
             });
         },


### PR DESCRIPTION
### Goal

Fixes issue where `evaluateNode` would not run from an outliner without a set request, as is the case with docked outliners.

### Description

If the outliner doesn't have a request set, it defaults to the current world root.
Additionally, some tweaks in the rendering outliners.