### PR TITLE
Add additional worlds on the b6 cmdline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.go]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ result*
 
 # Data
 data/*.index
+data/*.yaml

--- a/src/diagonal.works/b6/elevation.go
+++ b/src/diagonal.works/b6/elevation.go
@@ -1,4 +1,4 @@
-package b6 
+package b6
 
 import (
 	"sort"

--- a/src/diagonal.works/b6/merged.go
+++ b/src/diagonal.works/b6/merged.go
@@ -1,4 +1,4 @@
-package b6 
+package b6
 
 import (
 	"container/heap"


### PR DESCRIPTION
This adds a new `b6` command line option to add additional (mutable) worlds.

Note that this only is in effect when the world is **not** read-only. Hopefully the name is suggestive enough of that fact.

Example of usage:

```shell
nix run .#b6 -- \
  -static-v2=$(nix build .#frontend --print-out-paths) \
  -enable-v2-ui \
  -world data/camden.index \
  -add-world "/collection/diagonal.works/demo/example/0 data/some-yaml.yaml"
```

where `some-yaml.yaml` contains some information; perhaps like:

```yaml
collection:
- - centroid
  - id: /path/openstreetmap.org/way/15703989
id: /collection/diagonal.works/demo/example/0
```

I.e. you just give a FeatureID and "normal string" that you would pass to `-world` and it'll load that world at that point.

Also added is an editorconfig to help enforce the coding style, and a few other changes that came about when running `go fmt`.