### PR TITLE
Update `colour -> b6:colour` and some other small fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,11 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.tsx]
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/frontend/src/assets/map/diagonal-map-style-rose.json
+++ b/frontend/src/assets/map/diagonal-map-style-rose.json
@@ -50,8 +50,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#F5DED4"]
                 ]
             }
@@ -73,8 +73,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#F5DED4"]
                 ]
             }
@@ -97,8 +97,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#F5DED4"]
                 ]
             }
@@ -117,8 +117,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#F5DED4"]
                 ]
             }
@@ -290,8 +290,8 @@
                     "#914331",
                     [
                         "case",
-                        ["has", "colour"],
-                        ["get", "colour"],
+                        ["has", "b6:colour"],
+                        ["get", "b6:colour"],
                         ["literal", "#FFD9C4"]
                     ]
                 ]
@@ -320,8 +320,8 @@
                     "#ffae8d",
                     [
                         "case",
-                        ["has", "colour"],
-                        ["get", "colour"],
+                        ["has", "b6:colour"],
+                        ["get", "b6:colour"],
                         ["literal", "rgba(255, 255, 255)"]
                     ]
                 ]

--- a/frontend/src/assets/map/diagonal-map-style.json
+++ b/frontend/src/assets/map/diagonal-map-style.json
@@ -50,8 +50,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#dbdeeb"]
                 ]
             }
@@ -73,8 +73,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#c5cadd"]
                 ]
             }
@@ -97,8 +97,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#e1e1ee"]
                 ]
             }
@@ -117,8 +117,8 @@
             "paint": {
                 "fill-color": [
                     "case",
-                    ["has", "colour"],
-                    ["get", "colour"],
+                    ["has", "b6:colour"],
+                    ["get", "b6:colour"],
                     ["literal", "#c5cadd"]
                 ]
             }
@@ -290,8 +290,8 @@
                     "#37589f",
                     [
                         "case",
-                        ["has", "colour"],
-                        ["get", "colour"],
+                        ["has", "b6:colour"],
+                        ["get", "b6:colour"],
                         ["literal", "#e1e1ee"]
                     ]
                 ]
@@ -320,8 +320,8 @@
                     "#b1c5fd",
                     [
                         "case",
-                        ["has", "colour"],
-                        ["get", "colour"],
+                        ["has", "b6:colour"],
+                        ["get", "b6:colour"],
                         ["literal", "rgba(255, 255, 255)"]
                     ]
                 ]

--- a/frontend/src/components/adapters/LineAdapter.tsx
+++ b/frontend/src/components/adapters/LineAdapter.tsx
@@ -77,7 +77,7 @@ export const LineAdapter = ({
                                     ({ atom, clickExpression }, i) => {
                                         if (!atom) return null;
                                         return (
-                                            <ClickableAtom atom={atom} clickExpression={clickExpression} key={i}/>
+                                            <ClickableAtom atom={atom} clickExpression={clickExpression} key={i} key_={i}/>
                                         )
                                     }
                                 )}

--- a/frontend/src/components/system/ClickableAtom.tsx
+++ b/frontend/src/components/system/ClickableAtom.tsx
@@ -11,11 +11,11 @@ import { AtomProto } from '@/types/generated/ui';
 export const ClickableAtom = ({
     atom,
     clickExpression,
-    key,
+    key_,
 }: {
     atom: AtomProto;
     clickExpression: NodeProto | undefined;
-    key?: number;
+    key_?: number;
 }) => {
     const { evaluateNode } = useStackContext();
 
@@ -31,7 +31,7 @@ export const ClickableAtom = ({
                 },
             })}
         >
-            <AtomAdapter key={key} atom={atom} />
+            <AtomAdapter key={key_} atom={atom} />
         </Wrapper>
     );
 };


### PR DESCRIPTION
The "colour" word in the map styles should be "b6:colour".

Also, there were a couple of JS warnings/errors that were solved by:

- ~Fixing the button-in-button to be a [button-in-div](https://github.com/diagonalworks/diagonal-b6/pull/321/files#diff-7f002c927558376676c0b0becd6e59a947fcb3d100b638b1942e4853a018caa2)~ Edit: Apparently not; with this change typescript is unhappy; so we will live with the browser being upset.
- Using "key_" instead of "key" ( https://react.dev/warnings/special-props )
- ~Installing `gl-matrix` ( https://stackoverflow.com/a/69456837 )~ Edit: No; this one we will leave as well, as it has an error during the offline pnpm build.