### PR TITLE
Use aarch64 runners; publish images with this info

### DIFF
--- a/.github/workflows/build-latest-image.yaml
+++ b/.github/workflows/build-latest-image.yaml
@@ -12,11 +12,13 @@ permissions:
 jobs:
   release-artifacts:
     name: "Build and publish b6 docker image"
-    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         image-name: ["b6", "b6-minimal"]
+        os: [ "aarch64", "ubuntu-latest" ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -37,6 +39,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: "Build and publish docker image"
+      env:
+        IMAGE_NAME: ${{ matrix.os == 'ubuntu-latest' && matrix.image-name || format('{0}-{1}', matrix.image-name, matrix.os) }}
       run: |
         nix build .#${{ matrix.image-name }}-image
         ./result | docker load
@@ -44,5 +48,5 @@ jobs:
         export TARBALL_TAG="$(nix eval --raw .#${{ matrix.image-name }}-image.imageName):$(nix eval --raw .#${{ matrix.image-name }}-image.imageTag)"
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
-        docker tag "$TARBALL_TAG" ghcr.io/diagonalworks/diagonal-${{ matrix.image-name }}:latest
-        docker push ghcr.io/diagonalworks/diagonal-${{ matrix.image-name }}:latest
+        docker tag "$TARBALL_TAG" ghcr.io/diagonalworks/diagonal-$IMAGE_NAME:latest
+        docker push ghcr.io/diagonalworks/diagonal-$IMAGE_NAME:latest

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -15,11 +15,13 @@ permissions:
 jobs:
   release-artifacts:
     name: "Build and publish b6 docker image"
-    runs-on: ubuntu-latest
 
     strategy:
       matrix:
         image-name: ["b6", "b6-minimal"]
+        os: [ "aarch64", "ubuntu-latest" ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -44,6 +46,7 @@ jobs:
     - name: "Build and publish docker image"
       env:
         RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.release_tag }}
+        IMAGE_NAME: ${{ matrix.os == 'ubuntu-latest' && matrix.image-name || format('{0}-{1}', matrix.image-name, matrix.os) }}
       run: |
         nix build .#${{ matrix.image-name }}-image
         ./result | docker load
@@ -51,5 +54,5 @@ jobs:
         export TARBALL_TAG="$(nix eval --raw .#${{ matrix.image-name }}-image.imageName):$(nix eval --raw .#${{ matrix.image-name }}-image.imageTag)"
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
-        docker tag "$TARBALL_TAG" ghcr.io/diagonalworks/diagonal-${{ matrix.image-name }}:$RELEASE_TAG
-        docker push ghcr.io/diagonalworks/diagonal-${{ matrix.image-name }}:$RELEASE_TAG
+        docker tag "$TARBALL_TAG" ghcr.io/diagonalworks/diagonal-$IMAGE_NAME:$RELEASE_TAG
+        docker push ghcr.io/diagonalworks/diagonal-$IMAGE_NAME:$RELEASE_TAG


### PR DESCRIPTION
This publishes two new images:

- b6-aarch64
- b6-minimal-aarch64

built on the corresponding runner.