### PR TITLE
Don't use V1 by default; simpler run-b6 script

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -65,6 +65,7 @@ jobs:
 
     - name: "Test a few common entrypoints"
       run: |
+        nix run .#run-b6 -- --help
         nix run .#b6 -- --help
         nix run .#b6-ingest-osm -- --help
         nix run .#b6-connect -- --help

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run \
   -p 8001:8001 \
   -p 8002:8002 \
   -v ./data:/data \
-  -e FRONTEND_CONFIGURATION="frontend-with-scenarios=false,shell=true" \
+  -e FRONTEND_CONFIGURATION="frontend-dev" \
   ghcr.io/diagonalworks/diagonal-b6:latest \
   --world /data/tests/camden.osm.pbf
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ docker run \
 > We provide a specific environment variable, `FRONTEND_CONFIGURATION`, to
 > select the features we want to enable; in this case we want the _shell_
 > feature to be on, but the _scenarios_ feature off. You can read more above
-> these in the <./nix/js.nix> file and <./nix/docker.nix>.
+> these in the [/nix/js.nix](./nix/js.nix) file and
+> [/nix/docker.nix](./nix/docker.nix).
 
 This starts an instance of b6, with a web interface on port 8001, and
 a gRPC interface for analysis from Python on port 8002, hosting a small amount
@@ -60,7 +61,7 @@ of data from OpenStreetMap for the area of London around
 You can also run b6 directly via Nix:
 
 ```sh
-nix run github:diagonalworks/diagonal-b6#b6 \
+nix run github:diagonalworks/diagonal-b6#run-b6 \
   -- \
   --world data/tests/camden.osm.pbf
 ```
@@ -164,7 +165,9 @@ docker run \
   --input data/tests/granary-square.osm.pbf --output data/granary-square.index
 
 # Nix
-nix run .#b6-ingest-osm -- --input data/tests/granary-square.osm.pbf --output granary-square.index
+nix run .#b6-ingest-osm -- \
+      --input data/tests/granary-square.osm.pbf \
+      --output granary-square.index
 ```
 
 To ingest a shapefile via GDAL, use something like:
@@ -175,8 +178,8 @@ b6-ingest-gdal \
     --output data/region/scottish-borders/data-zones-2011.index \
     --namespace maps.scot.gov/data-zone-2011 \
     --id DataZone \
-    --id-strategy strip
-    --add-tags "#boundary=datazone"
+    --id-strategy strip \
+    --add-tags "#boundary=datazone" \
     --copy-tags "name=Name,code=DataZone,population:2011=TotPop2011"
 ```
 
@@ -225,6 +228,11 @@ nix run .#b6 -- --help
 nix run .#b6-ingest-gdal -- --help
 ```
 
+> [!note]
+> We provide a helpful nix package, `nix run .#run-b6` that pre-defines a few
+> of a common command-line options so you don't need to set them explicitly.
+> See the [flake.nix](./flake.nix) for more information.
+
 The go application is built with
 [gomod2nix](https://github.com/nix-community/gomod2nix/).
 
@@ -253,7 +261,7 @@ environment with `nix develop .#python`.
 
 > [!Important]
 > The version of Python you use must match when you bring in the library; i.e.
-> if you python312 you need to use the `.#python312` derivation.
+> if you python312 you need to use the `python312` package.
 
 #### Running with Nix
 

--- a/flake.nix
+++ b/flake.nix
@@ -213,7 +213,6 @@
           # `nix build` and look in `./result/bin`.
           default = (b6-go-packages ourGdal).everything;
 
-
           # We define a wrapped version of the b6 executable, using a particular
           # build of the frontend, for easy invocation, such as:
           #
@@ -223,7 +222,7 @@
                 -http=0.0.0.0:8001 \
                 -grpc=0.0.0.0:8002 \
                 -enable-v2-ui \
-                -static-v2=${packages."frontend".outPath} \
+                -static-v2=${packages.frontend-dev.outPath} \
                 "$@"
               '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,20 @@
           # `nix build` and look in `./result/bin`.
           default = (b6-go-packages ourGdal).everything;
 
+
+          # We define a wrapped version of the b6 executable, using a particular
+          # build of the frontend, for easy invocation, such as:
+          #
+          # > nix run .#run-b6 -- -world data
+          run-b6 = pkgs.writeShellScriptBin "run-b6" ''
+              ${packages.b6}/bin/b6 \
+                -http=0.0.0.0:8001 \
+                -grpc=0.0.0.0:8002 \
+                -enable-v2-ui \
+                -static-v2=${packages."frontend".outPath} \
+                "$@"
+              '';
+
           # Add an explicit 'go' entrypoint for the full go build+test.
           go = (b6-go-packages ourGdal).everything;
 
@@ -260,9 +274,9 @@
         #
         # Examples:
         #
-        #   nix build .#b6-js
         #   nix build .#frontend-with-scenarios=false,shell=true
         #   nix build .#frontend-with-scenarios=true,shell=false
+        #   nix build .#b6-js # Old v1 UI
         #
         // b6-js-packages
         ;

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -27,6 +27,8 @@ let
             STATIC_ARG=${b6-js-packages."frontend-with-scenarios=false,shell=true".outPath} ;;
           "frontend-with-scenarios=false,shell=false")
             STATIC_ARG=${b6-js-packages."frontend-with-scenarios=false,shell=false".outPath} ;;
+          "frontend-dev")
+            STATIC_ARG=${b6-js-packages.frontend-dev.outPath} ;;
           *)
             STATIC_ARG=${b6-js-packages.frontend.outPath} ;;
         esac

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -40,7 +40,6 @@ let
         ${b6-drv}/bin/b6 \
           -http=0.0.0.0:8001 \
           -grpc=0.0.0.0:8002 \
-          -js=${b6-js-packages.b6-js.outPath} \
           -enable-v2-ui \
           -static-v2=''$STATIC_ARG \
           "$@" &

--- a/nix/js.nix
+++ b/nix/js.nix
@@ -106,10 +106,17 @@ let
     VITE_FEATURES_SCENARIOS = false;
     VITE_FEATURES_SHELL = false;
   };
+
+  # A frontend for development; shell is on, scenarios are off.
+  frontend-dev = make-frontend {
+    VITE_FEATURES_SCENARIOS = false;
+    VITE_FEATURES_SHELL = "true";
+  };
 in
 {
   inherit
     b6-js
     frontend
+    frontend-dev
     ;
 } // frontend-feature-matrix

--- a/nix/templates/python-client/flake.nix
+++ b/nix/templates/python-client/flake.nix
@@ -32,27 +32,6 @@
         # Note: Here is where you would add extra Python libraries
         # ex: numpy
       ]);
-
-
-      # b6 executable
-      #
-      # Note: We define a wrapped version of the b6 executable, using a
-      # particular build of the frontend, for easy invocation, such as:
-      #
-      # > b6 -world data
-      #
-      b6-wrapped =
-        let b6 = diagonal-b6.packages.${system};
-        in
-        pkgs.writeShellScriptBin "b6" ''
-          ${b6.b6}/bin/b6 \
-            -http=0.0.0.0:8001 \
-            -grpc=0.0.0.0:8002 \
-            -js=${b6.b6-js.outPath} \
-            -enable-v2-ui \
-            -static-v2=${b6."frontend".outPath} \
-            "$@"
-        '';
     in
     {
       # Development shell
@@ -64,10 +43,10 @@
       devShells.default = pkgs.mkShell {
         packages = with pkgs; [
           py-env
-          b6-wrapped
+          diagonal-b6.packages.${system}.run-b6
           # We'll also take a whole bunch of b6-ingest-* executables, in case
           # we would like to run any ad-hoc data ingestions.
-          diagonal-b6.packages."${system}".go
+          diagonal-b6.packages.${system}.go
         ];
       };
     });


### PR DESCRIPTION
This PR just removes the b6 js v1 UI from the build steps, as it isn't used presently.

It also formalises adding a `run-b6` entrypoint that wraps up the common arguments (and in particular the v2-ui path) so as to make working with it a bit easier.