### PR TITLE
Bump version so we can use minor versions

### DIFF
--- a/src/diagonal.works/b6/version.go
+++ b/src/diagonal.works/b6/version.go
@@ -16,7 +16,7 @@ import (
 // indicators of a, b or rc, since that's all Python allows.
 // For consistency, we tie the version of a backend and client library build
 // to this version, using AdvanceVersionFromGit.
-const ApiVersion = "0.0.4"
+const ApiVersion = "0.1.0"
 
 // BackendVersion is a semver 2.0.0 compliant version for the backend binary,
 // generated at build time by AdvanceVersionFromGit, and stamped into the


### PR DESCRIPTION
Presently it's hard to indicate minor changes in the vesion as the repo uses the most minor version possible to start with. This changes it to v0.1.0, from which one can start incrementing minor versions if ones wishes!