### PR TITLE
Enable PyPI workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -16,7 +16,6 @@ jobs:
     name: "Upload release to PyPI"
     runs-on: ubuntu-latest
     environment:
-      name: pypi
       url: https://pypi.org/p/diagonal-b6
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/src/diagonal.works/b6/version.go
+++ b/src/diagonal.works/b6/version.go
@@ -16,7 +16,7 @@ import (
 // indicators of a, b or rc, since that's all Python allows.
 // For consistency, we tie the version of a backend and client library build
 // to this version, using AdvanceVersionFromGit.
-const ApiVersion = "0.2.2"
+const ApiVersion = "0.2.3"
 
 // BackendVersion is a semver 2.0.0 compliant version for the backend binary,
 // generated at build time by AdvanceVersionFromGit, and stamped into the


### PR DESCRIPTION
- Bump a minor version so we can do a release
- Enable the PyPI trusted publishing workflow!